### PR TITLE
Observer concurrency

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -40,6 +40,7 @@ func loadDefaults() {
 	viper.SetDefault("observer.redis", "redis://localhost:6379")
 	viper.SetDefault("observer.min_poll", 250 * time.Millisecond)
 	viper.SetDefault("observer.backlog", 3 * time.Hour)
+	viper.SetDefault("observer.stream_conns", 16)
 
 	// All platforms with public RPC endpoints
 	viper.SetDefault("binance.api", "https://explorer.binance.org/api/v1")

--- a/config.yml
+++ b/config.yml
@@ -18,6 +18,8 @@ observer:
   min_poll: 250ms
   # Don't request blocks older than this
   backlog: 3h
+  # Max connections to open to API
+  stream_conns: 16
 
 # [BNB] Binance DEX: https://wallet.binance.org
 #       Binance Chain: https://explorer.binance.org

--- a/platform/vechain/client.go
+++ b/platform/vechain/client.go
@@ -1,11 +1,11 @@
 package vechain
 
-import(
-	"github.com/sirupsen/logrus"
-	"net/http"
-	"io/ioutil"
-	"fmt"
+import (
 	"encoding/json"
+	"fmt"
+	"github.com/sirupsen/logrus"
+	"io/ioutil"
+	"net/http"
 )
 
 type Client struct {
@@ -65,7 +65,7 @@ func (c *Client) GetTokenTransferTransactions(address string) (TokenTransferTxs,
 	return transfers, nil
 }
 
-func (c *Client) GetTransacionReceipt(cn chan <- TransferReceipt, id string) {
+func (c *Client) GetTransactionReceipt(cn chan <- TransferReceipt, id string) {
 	defer wg.Done()
 
 	url := fmt.Sprintf("%s/transactions/%s", c.URL, id)

--- a/util/semaphore.go
+++ b/util/semaphore.go
@@ -1,0 +1,17 @@
+package util
+
+type Semaphore struct {
+	c chan bool
+}
+
+func NewSemaphore(n int) *Semaphore {
+	return &Semaphore{ make(chan bool, n) }
+}
+
+func (s *Semaphore) Acquire() {
+	s.c <- true
+}
+
+func (s *Semaphore) Release() {
+	<-s.c
+}


### PR DESCRIPTION
 - Add `util.Semaphore` helper
 - Parallel `observer.Stream` requests for faster block syncing
 - Fix: Limit connections opened by `platform/vechain` to 16