### PR TITLE
observer: Limit number of blocks to request at once

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -49,6 +49,7 @@ func loadDefaults() {
 	viper.SetDefault("observer.redis", "redis://localhost:6379")
 	viper.SetDefault("observer.min_poll", 250 * time.Millisecond)
 	viper.SetDefault("observer.backlog", 3 * time.Hour)
+	viper.SetDefault("observer.backlog_max_blocks", 200)
 	viper.SetDefault("observer.stream_conns", 16)
 
 	// All platforms with public RPC endpoints

--- a/config.yml
+++ b/config.yml
@@ -18,6 +18,8 @@ observer:
   min_poll: 250ms
   # Don't request blocks older than this
   backlog: 3h
+  # Don't request more than N blocks at once
+  backlog_max_blocks: 200
   # Max connections to open to API
   stream_conns: 16
 

--- a/observer/stream.go
+++ b/observer/stream.go
@@ -68,6 +68,10 @@ func (s *Stream) load(c chan<- *blockatlas.Block) {
 	if height - lastHeight > int64(s.BacklogCount) {
 		lastHeight = height - int64(s.BacklogCount)
 	}
+	backLogMax := viper.GetInt64("observer.backlog_max_blocks")
+	if height - lastHeight > backLogMax {
+		lastHeight = height - backLogMax
+	}
 
 	atomic.StoreInt64(&s.blockNumber, lastHeight)
 	for i := lastHeight + 1; i <= height; i++ {


### PR DESCRIPTION
Avoid spamming block requests by limiting the backlog height.