### PR TITLE
Simplify observer API

### DIFF
--- a/cmd/api/observer.go
+++ b/cmd/api/observer.go
@@ -7,11 +7,13 @@ import (
 	"github.com/trustwallet/blockatlas/observer"
 	observerStorage "github.com/trustwallet/blockatlas/observer/storage"
 	"net/http"
+	"strconv"
 )
 
 func setupObserverAPI(router gin.IRouter) {
 	router.Use(requireAuth)
-	router.POST("/", addObserver)
+	router.POST("/", addCall)
+	router.DELETE("/", deleteCall)
 }
 
 func requireAuth(c *gin.Context) {
@@ -23,9 +25,9 @@ func requireAuth(c *gin.Context) {
 	}
 }
 
-func addObserver(c *gin.Context) {
+func addCall(c *gin.Context) {
 	var req struct {
-		Subscriptions map[uint][]string `json:"subscriptions"`
+		Subscriptions map[string][]string `json:"subscriptions"`
 		Webhook string `json:"webhook"`
 	}
 	if c.BindJSON(&req) != nil {
@@ -38,7 +40,11 @@ func addObserver(c *gin.Context) {
 	}
 
 	var subs []observer.Subscription
-	for coin, perCoin := range req.Subscriptions {
+	for coinStr, perCoin := range req.Subscriptions {
+		coin, _ := strconv.Atoi(coinStr)
+		if coin == 0 {
+			continue
+		}
 		for _, addr := range perCoin {
 			subs = append(subs, observer.Subscription{
 				Coin:    uint(coin),
@@ -55,4 +61,38 @@ func addObserver(c *gin.Context) {
 	}
 
 	c.String(http.StatusOK, "Added")
+}
+
+func deleteCall(c *gin.Context) {
+	var req map[string][]string
+	if c.BindJSON(&req) != nil {
+		return
+	}
+
+	if len(req) == 0 {
+		c.String(http.StatusOK, "Deleted")
+		return
+	}
+
+	var subs []observer.Subscription
+	for coinStr, perCoin := range req {
+		coin, _ := strconv.Atoi(coinStr)
+		if coin == 0 {
+			continue
+		}
+		for _, addr := range perCoin {
+			subs = append(subs, observer.Subscription{
+				Coin:    uint(coin),
+				Address: addr,
+			})
+		}
+	}
+
+	err := observerStorage.App.Delete(subs)
+	if err != nil {
+		_ = c.Error(err)
+		return
+	}
+
+	c.String(http.StatusOK, "Deleted")
 }

--- a/observer/entries.go
+++ b/observer/entries.go
@@ -14,7 +14,5 @@ type Tracker interface {
 type Storage interface {
 	Tracker
 	Lookup(coin uint, addresses ...string) ([]Subscription, error)
-	Add(Subscription) error
-	Remove(coin uint, address string) error
-	Contains(coin uint, address string) (bool, error)
+	Add([]Subscription) error
 }

--- a/observer/entries.go
+++ b/observer/entries.go
@@ -15,4 +15,5 @@ type Storage interface {
 	Tracker
 	Lookup(coin uint, addresses ...string) ([]Subscription, error)
 	Add([]Subscription) error
+	Delete([]Subscription) error
 }

--- a/observer/storage/memory/storage.go
+++ b/observer/storage/memory/storage.go
@@ -32,8 +32,10 @@ func (s *Storage) Contains(coin uint, address string) (bool, error) {
 	return ok, nil
 }
 
-func (s *Storage) Add(o observer.Subscription) error {
-	s.observers[key(o.Coin, o.Address)] = o
+func (s *Storage) Add(subs []observer.Subscription) error {
+	for _, sub := range subs {
+		s.observers[key(sub.Coin, sub.Address)] = sub
+	}
 	return nil
 }
 

--- a/observer/storage/memory/storage.go
+++ b/observer/storage/memory/storage.go
@@ -39,17 +39,19 @@ func (s *Storage) Add(subs []observer.Subscription) error {
 	return nil
 }
 
+func (s *Storage) Delete(subs []observer.Subscription) error {
+	for _, sub := range subs {
+		delete(s.observers, key(sub.Coin, sub.Address))
+	}
+	return nil
+}
+
 func (s *Storage) List() []observer.Subscription {
 	var values []observer.Subscription
 	for _, value := range s.observers {
 		values = append(values, value)
 	}
 	return values
-}
-
-func (s *Storage) Remove(coin uint, address string) error {
-	delete(s.observers, key(coin, address))
-	return nil
 }
 
 func (s *Storage) GetBlockNumber(coin uint) (int64, error) {

--- a/observer/storage/memory/storage_test.go
+++ b/observer/storage/memory/storage_test.go
@@ -20,11 +20,11 @@ func TestMemoryStorage_Add(t *testing.T) {
 		observers: observerMap,
 	}
 
-	_ = storage.Add(observer.Subscription{
+	_ = storage.Add([]observer.Subscription{{
 		Coin: ethCoin,
 		Address: addr1,
 		Webhook: webhook1,
-	})
+	}})
 
 	if len(observerMap) != 1 {
 		t.Error("observer not added")
@@ -105,7 +105,7 @@ func TestMemoryStorage_Get(t *testing.T) {
 
 func TestMemoryStorage_Contains(t *testing.T) {
 	var observerMap = make(map[string]observer.Subscription)
-	var storage observer.Storage = &Storage{
+	var storage = &Storage{
 		observers: observerMap,
 	}
 	obs1 := observer.Subscription{

--- a/observer/storage/memory/storage_test.go
+++ b/observer/storage/memory/storage_test.go
@@ -69,7 +69,7 @@ func TestMemoryStorage_Remove(t *testing.T) {
 	}
 	observerMap[key(ethCoin, addr1)] = obs
 
-	storage.Remove(ethCoin, addr1)
+	_ = storage.Delete([]observer.Subscription{ obs })
 
 	if len(storage.List()) != 0 {
 		t.Error("observer not removed")

--- a/observer/storage/redis/storage.go
+++ b/observer/storage/redis/storage.go
@@ -61,6 +61,15 @@ func (s *Storage) Add(subs []observer.Subscription) error {
 	return cmd.Err()
 }
 
+func (s *Storage) Delete(subs []observer.Subscription) error {
+	fields := make([]string, len(subs))
+	for i, sub := range subs {
+		fields[i] = key(sub.Coin, sub.Address)
+	}
+	cmd := s.client.HDel(keyObservers, fields...)
+	return cmd.Err()
+}
+
 func (s *Storage) GetBlockNumber(coin uint) (int64, error) {
 	key := fmt.Sprintf(keyBlockNumber, coin)
 	cmd := s.client.Get(key)

--- a/observer/storage/redis/storage.go
+++ b/observer/storage/redis/storage.go
@@ -52,17 +52,12 @@ func (s *Storage) Lookup(coin uint, addresses ...string) (observers []observer.S
 	return
 }
 
-func (s *Storage) Contains(coin uint, address string) (bool, error) {
-	return s.client.HExists(keyObservers, key(coin, address)).Result()
-}
-
-func (s *Storage) Add(o observer.Subscription) error {
-	cmd := s.client.HSet(keyObservers, key(o.Coin, o.Address), o.Webhook)
-	return cmd.Err()
-}
-
-func (s *Storage) Remove(coin uint, address string) error {
-	cmd := s.client.HDel(keyObservers, key(coin, address))
+func (s *Storage) Add(subs []observer.Subscription) error {
+	fields := make(map[string]interface{})
+	for _, sub := range subs {
+		fields[key(sub.Coin, sub.Address)] = sub.Webhook
+	}
+	cmd := s.client.HMSet(keyObservers, fields)
 	return cmd.Err()
 }
 


### PR DESCRIPTION
 - Only bulk add call for now
 - No remove / contains API for simplicity
 - Deletes best done with regular database resets / GC

Sample request:

```sh
export TOKEN=abcdef

curl -X POST -H "Content-Type: application/json" \
  -H "Authorization: $TOKEN"
  -d '{"subscriptions":{242: ["addr1","addr2"], 30: []}, "webhook": "https://example.org"}' \
  blockatlas.local/observer/v1/$COIN
```

Add request object

```json
{
  "subscriptions": {
    "242": ["addr1, "addr2"],
    "30": ...
  },
  "webhook": "https://example.org"
}
```

Delete request object (use DELETE HTTP method)

```json
{
  "242": ["addr1, "addr2"],
  "30": ...
}
```

If an event fires, the webhook is called by POST request with a `blockatlas.Tx` as JSON body.

Closes #128