### PR TITLE
Return empty page instead of 204

### DIFF
--- a/cmd/api/generic.go
+++ b/cmd/api/generic.go
@@ -19,7 +19,7 @@ func makeTxRoute(router gin.IRouter, api blockatlas.Platform) {
 	router.GET("/:address", func(c *gin.Context) {
 		address := c.Param("address")
 		if address == "" {
-			c.String(http.StatusNoContent, "no content")
+			emptyPage(c)
 			return
 		}
 		token := c.Query("token")
@@ -32,7 +32,7 @@ func makeTxRoute(router gin.IRouter, api blockatlas.Platform) {
 		case token != "" && tokenTxAPI != nil:
 			page, err = tokenTxAPI.GetTokenTxsByAddress(address, token)
 		default:
-			c.String(http.StatusNoContent, "no content")
+			emptyPage(c)
 			return
 		}
 
@@ -54,4 +54,8 @@ func makeTxRoute(router gin.IRouter, api blockatlas.Platform) {
 		page.Sort()
 		c.JSON(http.StatusOK, &page)
 	})
+}
+
+func emptyPage(c *gin.Context) {
+	c.JSON(http.StatusOK, blockatlas.TxPage(nil))
 }

--- a/platform/tron/api.go
+++ b/platform/tron/api.go
@@ -39,11 +39,6 @@ func (p *Platform) GetTxsByAddress(address string) (blockatlas.TxPage, error) {
 	return txs, nil
 }
 
-func (p *Platform) GetTokenTxsByAddress(address string, _ string) (blockatlas.TxPage, error) {
-	// TODO: Filter by tokens
-	return p.GetTxsByAddress(address)
-}
-
 /// Normalize converts a Tron transaction into the generic model
 func Normalize(srcTx *Tx) (tx blockatlas.Tx, ok bool) {
 	if len(srcTx.Data.Contracts) < 1 {

--- a/platform/tron/api.go
+++ b/platform/tron/api.go
@@ -39,6 +39,11 @@ func (p *Platform) GetTxsByAddress(address string) (blockatlas.TxPage, error) {
 	return txs, nil
 }
 
+func (p *Platform) GetTokenTxsByAddress(address string, _ string) (blockatlas.TxPage, error) {
+	// TODO: Filter by tokens
+	return p.GetTxsByAddress(address)
+}
+
 /// Normalize converts a Tron transaction into the generic model
 func Normalize(srcTx *Tx) (tx blockatlas.Tx, ok bool) {
 	if len(srcTx.Data.Contracts) < 1 {


### PR DESCRIPTION
~Re-enables transaction API under Tron after a bug in #135 to fix faulty client behavior
(Allows API calls with `?token=` parameters)~

Return an empty page instead of `204 No Content` if the token parameter is present but not supported.