### PR TITLE
Add multi-collections support

### DIFF
--- a/collectibles.go
+++ b/collectibles.go
@@ -17,7 +17,10 @@ type Collection struct {
 type CollectionPage []Collection
 
 type Collectible struct {
-	TokenID         string `json:"token_id"`
+	CollectionID     string `json:"collection_id"`
+	TokenID          string `json:"token_id"`
+	CategoryContract string `json:"category_contract"`
+	// Deprecated: for support old client, ContractAddress eq CollectionID
 	ContractAddress string `json:"contract_address"`
 	Category        string `json:"category"`
 	ImageUrl        string `json:"image_url"`

--- a/platform/ethereum/api.go
+++ b/platform/ethereum/api.go
@@ -239,9 +239,9 @@ func NormalizeCollectiblePage(c *Collection, srcPage []Collectible, coinIndex ui
 func NormalizeCollectible(c *Collection, a Collectible, coinIndex uint) blockatlas.Collectible {
 	return blockatlas.Collectible{
 		TokenID:         a.TokenId,
-		ContractAddress: c.Contracts[0].Address,
+		ContractAddress: c.Contracts[0].Address, ///a.AssetContract.Address
 		Name:            a.Name,
-		Category:        c.Name,
+		Category:        c.Name, //a.AssetContract.Category
 		ImageUrl:        a.ImagePreviewUrl,
 		ExternalLink:    a.ExternalLink,
 		Type:            "ERC721",

--- a/platform/ethereum/api.go
+++ b/platform/ethereum/api.go
@@ -196,11 +196,11 @@ func (p *Platform) GetCollections(owner string) (blockatlas.CollectionPage, erro
 }
 
 func (p *Platform) GetCollectibles(owner string, collectibleID string) (blockatlas.CollectiblePage, error) {
-	items, err := p.collectionsClient.GetCollectibles(owner, collectibleID)
+	collection, items, err := p.collectionsClient.GetCollectibles(owner, collectibleID)
 	if err != nil {
 		return nil, err
 	}
-	page := NormalizeCollectiblePage(items, p.CoinIndex)
+	page := NormalizeCollectiblePage(collection, items, p.CoinIndex)
 	return page, nil
 }
 
@@ -228,20 +228,20 @@ func NormalizeCollection(c Collection, coinIndex uint, owner string) blockatlas.
 	}
 }
 
-func NormalizeCollectiblePage(srcPage []Collectible, coinIndex uint) (page blockatlas.CollectiblePage) {
+func NormalizeCollectiblePage(c *Collection, srcPage []Collectible, coinIndex uint) (page blockatlas.CollectiblePage) {
 	for _, src := range srcPage {
-		item := NormalizeCollectible(src, coinIndex)
+		item := NormalizeCollectible(c, src, coinIndex)
 		page = append(page, item)
 	}
 	return
 }
 
-func NormalizeCollectible(a Collectible, coinIndex uint) blockatlas.Collectible {
+func NormalizeCollectible(c *Collection, a Collectible, coinIndex uint) blockatlas.Collectible {
 	return blockatlas.Collectible{
 		TokenID:         a.TokenId,
-		ContractAddress: a.AssetContract.Address,
+		ContractAddress: c.Contracts[0].Address,
 		Name:            a.Name,
-		Category:        a.AssetContract.Category,
+		Category:        c.Name,
 		ImageUrl:        a.ImagePreviewUrl,
 		ExternalLink:    a.ExternalLink,
 		Type:            "ERC721",

--- a/platform/ethereum/api.go
+++ b/platform/ethereum/api.go
@@ -245,7 +245,7 @@ func NormalizeCollectible(c *Collection, a Collectible, coinIndex uint) blockatl
 		Name:             a.Name,
 		Category:         c.Name,
 		ImageUrl:         a.ImagePreviewUrl,
-		ProviderLink:    a.Permalink,
+		ProviderLink:     a.Permalink,
 		ExternalLink:     a.ExternalLink,
 		Type:             "ERC721",
 		Description:      a.Description,

--- a/platform/ethereum/api.go
+++ b/platform/ethereum/api.go
@@ -238,14 +238,16 @@ func NormalizeCollectiblePage(c *Collection, srcPage []Collectible, coinIndex ui
 
 func NormalizeCollectible(c *Collection, a Collectible, coinIndex uint) blockatlas.Collectible {
 	return blockatlas.Collectible{
-		TokenID:         a.TokenId,
-		ContractAddress: c.Contracts[0].Address, ///a.AssetContract.Address
-		Name:            a.Name,
-		Category:        c.Name, //a.AssetContract.Category
-		ImageUrl:        a.ImagePreviewUrl,
-		ExternalLink:    a.ExternalLink,
-		Type:            "ERC721",
-		Description:     a.Description,
-		Coin:            coinIndex,
+		CollectionID:     c.Contracts[0].Address,
+		ContractAddress:  c.Contracts[0].Address,
+		TokenID:          a.TokenId,
+		CategoryContract: a.AssetContract.Address,
+		Name:             a.Name,
+		Category:         c.Name,
+		ImageUrl:         a.ImagePreviewUrl,
+		ExternalLink:     a.ExternalLink,
+		Type:             "ERC721",
+		Description:      a.Description,
+		Coin:             coinIndex,
 	}
 }

--- a/platform/ethereum/api.go
+++ b/platform/ethereum/api.go
@@ -206,17 +206,8 @@ func (p *Platform) GetCollectibles(owner string, collectibleID string) (blockatl
 
 func NormalizeCollectionPage(collections []Collection, coinIndex uint, owner string) (page blockatlas.CollectionPage) {
 	for _, collection := range collections {
-		l := len(collection.Contracts)
-		switch {
-		case l == 1:
-			item := NormalizeCollection(collection, coinIndex, owner)
-			page = append(page, item)
-		case l > 1:
-			for _, col := range collection.Contracts {
-				item := NormalizeMultiCollection(col, coinIndex, owner)
-				page = append(page, item)
-			}
-		}
+		item := NormalizeCollection(collection, coinIndex, owner)
+		page = append(page, item)
 	}
 	return
 }
@@ -234,27 +225,6 @@ func NormalizeCollection(c Collection, coinIndex uint, owner string) blockatlas.
 		Version:         c.Contracts[0].NftVersion,
 		Coin:            coinIndex,
 		Type:            c.Contracts[0].Type,
-	}
-}
-
-func NormalizeMultiCollection(c PrimaryAssetContract, coinIndex uint, owner string) blockatlas.Collection {
-	var imageUrl string
-	if len(c.Data.Images) > 0 {
-		imageUrl = c.Data.Images[0]
-	}
-
-	return blockatlas.Collection{
-		Name:            c.Name,
-		Symbol:          c.Symbol,
-		ImageUrl:        imageUrl,
-		Description:     c.Description,
-		ExternalLink:    c.Url,
-		Total:           1,
-		CategoryAddress: c.Address,
-		Address:         owner,
-		Version:         c.NftVersion,
-		Coin:            coinIndex,
-		Type:            c.Type,
 	}
 }
 

--- a/platform/ethereum/api.go
+++ b/platform/ethereum/api.go
@@ -206,18 +206,16 @@ func (p *Platform) GetCollectibles(owner string, collectibleID string) (blockatl
 
 func NormalizeCollectionPage(collections []Collection, coinIndex uint, owner string) (page blockatlas.CollectionPage) {
 	for _, collection := range collections {
-		if len(collection.Contracts) == 1 {
+		l := len(collection.Contracts)
+		switch {
+		case l == 1:
 			item := NormalizeCollection(collection, coinIndex, owner)
 			page = append(page, item)
-			continue
-		}
-
-		if len(collection.Contracts) > 1 {
+		case l > 1:
 			for _, col := range collection.Contracts {
 				item := NormalizeMultiCollection(col, coinIndex, owner)
 				page = append(page, item)
 			}
-			continue
 		}
 	}
 	return

--- a/platform/ethereum/collections_client.go
+++ b/platform/ethereum/collections_client.go
@@ -37,14 +37,14 @@ func (c CollectionsClient) GetCollections(owner string) ([]Collection, error) {
 	return page, err
 }
 
-func (c CollectionsClient) GetCollectibles(owner string, collectibleID string) ([]Collectible, error) {
+func (c CollectionsClient) GetCollectibles(owner string, collectibleID string) (*Collection, []Collectible, error) {
 	collections, err := c.GetCollections(owner)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	collection := searchCollection(&collections, collectibleID)
 	if collection == nil {
-		return nil, errors.New(fmt.Sprintf("%s not found", collectibleID))
+		return nil, nil, errors.New(fmt.Sprintf("%s not found", collectibleID))
 	}
 
 	uriValues := url.Values{
@@ -62,13 +62,13 @@ func (c CollectionsClient) GetCollectibles(owner string, collectibleID string) (
 	req.Header.Set("X-API-KEY", c.CollectionsApiKey)
 	res, err := c.HTTPClient.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	defer res.Body.Close()
 
 	var page CollectiblePage
 	err = json.NewDecoder(res.Body).Decode(&page)
-	return page.Collectibles, err
+	return collection, page.Collectibles, err
 }
 
 func searchCollection(collections *[]Collection, collectibleID string) *Collection {

--- a/platform/ethereum/model.go
+++ b/platform/ethereum/model.go
@@ -50,15 +50,22 @@ type Collection struct {
 	ImageUrl    string                 `json:"image_url"`
 	ExternalUrl string                 `json:"external_url"`
 	Total       int                    `json:"owned_asset_count"`
-	Contract    []PrimaryAssetContract `json:"primary_asset_contracts"`
+	Contracts   []PrimaryAssetContract `json:"primary_asset_contracts"`
 }
 
 type PrimaryAssetContract struct {
-	Address     string `json:"address"`
-	NftVersion  string `json:"nft_version"`
-	Symbol      string `json:"symbol"`
-	Description string `json:"description"`
-	Type        string `json:"schema_name"`
+	Name        string 		`json:"name"`
+	Address     string 		`json:"address"`
+	NftVersion  string      `json:"nft_version"`
+	Symbol      string      `json:"symbol"`
+	Description string      `json:"description"`
+	Type        string      `json:"schema_name"`
+	Data        DisplayData `json:"display_data"`
+	Url         string      `json:"external_link"`
+}
+
+type DisplayData struct {
+	Images []string `json:"images"`
 }
 
 type CollectiblePage struct {


### PR DESCRIPTION
Previously we  assumed `primary_asset_contracts` would have items belongs to same contract address. In new API OpenSea introduced new concept where one category can have multiple contracts. For example:  overall, 19 items spread over many different contracts, all in the Ether Legends collection.

https://api.opensea.io/api/v1/collections/?asset_owner=0x5e81e58deddba4bc2ab5213ba30e5ad75be42467&limit=1000

https://api.opensea.io/api/v1/assets/?asset_contract_address=0x6c0db75e2b5756081e93e1bcebb1a7560cbbb6d1&owner=0x5e81e58deddba4bc2ab5213ba30e5ad75be42467

Current PR add support for `multi-collections`

Introduced new property:
`provider_link` - represents the link to collectible on OpenSea website instead of dynamically create url on a client.

{
            "token_id": "1106318",
            "contract_address": "0x06012c8cf97bead5deae237070f9587f8e7a266d",
            "category": "CryptoKitties",
            "image_url": "https://storage.opensea.io/0x06012c8cf97bead5deae237070f9587f8e7a266d-preview/1106318-1551280260.png",
            "external_link": "https://www.cryptokitties.co/kitty/1106318",
            **"provider_link": "https://opensea.io/assets/0x06012c8cf97bead5deae237070f9587f8e7a266d/1106318",
            "type": "ERC721"**,
            "description": "Yo yo yo. My name is Tama Waddleki, and before you ask, no, it's not short for anything. I want our friendship to be like the one between Carrie Bradshaw and Zack Morris. I can tell you like to get into trouble.",
            "coin": 60,
            "name": "Tama Waddleki"
        }
