### PR TITLE
API interface for list all tokens from an address and coin

### DIFF
--- a/api.go
+++ b/api.go
@@ -28,6 +28,12 @@ type TokenTxAPI interface {
 	GetTokenTxsByAddress(address string, token string) (TxPage, error)
 }
 
+// TokenAPI provides token lookups
+type TokenAPI interface {
+	Platform
+	GetTokenListByAddress(address string) (TokenPage, error)
+}
+
 // BlockAPI provides block information and lookups
 type BlockAPI interface {
 	Platform

--- a/cmd/api/generic.go
+++ b/cmd/api/generic.go
@@ -114,6 +114,31 @@ func makeCollectionRoute(router gin.IRouter, api blockatlas.Platform) {
 	})
 }
 
+func makeTokenRoute(router gin.IRouter, api blockatlas.Platform) {
+	var tokenAPI blockatlas.TokenAPI
+	tokenAPI, _ = api.(blockatlas.TokenAPI)
+
+	if tokenAPI == nil {
+		return
+	}
+
+	router.GET("/tokens/:address", func(c *gin.Context) {
+		address := c.Param("address")
+		if address == "" {
+			emptyPage(c)
+			return
+		}
+
+		tl, err := tokenAPI.GetTokenListByAddress(address)
+		if err != nil {
+			c.JSON(http.StatusServiceUnavailable, err)
+			return
+		}
+
+		c.JSON(http.StatusOK, blockatlas.DocsResponse{Docs: tl})
+	})
+}
+
 func emptyPage(c *gin.Context) {
 	var page blockatlas.TxPage
 	c.JSON(http.StatusOK, &page)

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -21,6 +21,11 @@ func loadPlatforms(root gin.IRouter) {
 		makeTxRouteV2(routerV2, txAPI)
 	}
 
+	for _, tokenAPI := range platform.Platforms {
+		router := getRouter(v2, tokenAPI.Coin().Handle)
+		makeTokenRoute(router, tokenAPI)
+	}
+
 	for _, stakeAPI := range platform.Platforms {
 		router := getRouter(v2, stakeAPI.Coin().Handle)
 		makeStakingRoute(router, stakeAPI)

--- a/config.yml
+++ b/config.yml
@@ -27,6 +27,7 @@ observer:
 #       Binance Chain: https://explorer.binance.org
 binance:
   api: https://explorer.binance.org/api/v1
+  dex: https://dex.binance.org/api
 
 # [NIM] Nimiq: https://nimiq.com
 #nimiq:

--- a/platform/binance/api.go
+++ b/platform/binance/api.go
@@ -17,6 +17,7 @@ type Platform struct {
 
 func (p *Platform) Init() error {
 	p.client.BaseURL = viper.GetString("binance.api")
+	p.client.BaseDexURL = viper.GetString("binance.dex")
 	p.client.HTTPClient = http.DefaultClient
 	return nil
 }

--- a/platform/binance/api.go
+++ b/platform/binance/api.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/trustwallet/blockatlas"
 	"net/http"
+	"strings"
 
 	"github.com/spf13/viper"
 	"github.com/trustwallet/blockatlas/coin"
@@ -115,4 +116,55 @@ func NormalizeTxs(srcTxs []Tx, token string) (txs []blockatlas.Tx) {
 		txs = append(txs, tx)
 	}
 	return
+}
+
+func (p *Platform) GetTokenListByAddress(address string) (blockatlas.TokenPage, error) {
+	account, err := p.client.GetAccountMetadata(address)
+	if err != nil {
+		return nil, err
+	}
+	tokens, err := p.client.GetTokens()
+	if err != nil {
+		return nil, err
+	}
+	return NormalizeTokens(account.Balances, tokens), nil
+}
+
+// NormalizeToken converts a Binance token into the generic model
+func NormalizeToken(srcToken *Balance, tokens *TokenPage) (t blockatlas.Token, ok bool) {
+	tk := tokens.findToken(srcToken.Symbol)
+	if tk == nil {
+		return blockatlas.Token{}, false
+	}
+
+	t = blockatlas.Token{
+		Name:     tk.Name,
+		Symbol:   tk.OriginalSymbol,
+		TokenId:  tk.Symbol,
+		Coin:     coin.BNB,
+		Decimals: uint(decimalPlaces(tk.TotalSupply)),
+	}
+
+	return t, true
+}
+
+// NormalizeTxs converts multiple Binance tokens
+func NormalizeTokens(srcBalance []Balance, tokens *TokenPage) (tokenPage []blockatlas.Token) {
+	for _, srcToken := range srcBalance {
+		token, ok := NormalizeToken(&srcToken, tokens)
+		if !ok {
+			continue
+		}
+		tokenPage = append(tokenPage, token)
+	}
+	return
+}
+
+// decimalPlaces count the decimals places.
+func decimalPlaces(v string) int {
+	s := strings.Split(v, ".")
+	if len(s) < 2 {
+		return 0
+	}
+	return len(s[1])
 }

--- a/platform/binance/api_test.go
+++ b/platform/binance/api_test.go
@@ -205,12 +205,12 @@ func testNormalizeToken(t *testing.T, _test *testToken) {
 		return
 	}
 
-	tx, ok := NormalizeToken(&srcToken, &srcTokens)
+	tk, ok := NormalizeToken(&srcToken, &srcTokens)
 	if !ok {
-		t.Errorf("transfer: tx could not be normalized")
+		t.Errorf("token: token could not be normalized")
 	}
 
-	resJSON, err := json.Marshal(&tx)
+	resJSON, err := json.Marshal(&tk)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -223,7 +223,7 @@ func testNormalizeToken(t *testing.T, _test *testToken) {
 	if !bytes.Equal(resJSON, dstJSON) {
 		println(string(resJSON))
 		println(string(dstJSON))
-		t.Error("transfer: tx don't equal")
+		t.Error("token: token don't equal")
 	}
 }
 

--- a/platform/binance/client.go
+++ b/platform/binance/client.go
@@ -90,7 +90,7 @@ func (c *Client) GetTxsOfAddress(address string, token string) (*TxPage, error) 
 }
 
 func (c *Client) GetAccountMetadata(address string) (*Account, error) {
-	uri := fmt.Sprintf("%s/account/%s", c.BaseDexURL, address)
+	uri := fmt.Sprintf("%s/v1/account/%s", c.BaseDexURL, address)
 
 	res, err := c.HTTPClient.Get(uri)
 	if err != nil {
@@ -108,7 +108,7 @@ func (c *Client) GetAccountMetadata(address string) (*Account, error) {
 }
 
 func (c *Client) GetTokens() (*TokenPage, error) {
-	uri := fmt.Sprintf("%s/tokens?%s",
+	uri := fmt.Sprintf("%s/v1/tokens?%s",
 		c.BaseDexURL,
 		url.Values{
 			"limits": {"1000"},

--- a/platform/binance/model.go
+++ b/platform/binance/model.go
@@ -15,9 +15,9 @@ type Account struct {
 
 type Balance struct {
 	Symbol string `json:"symbol"`
-	Free   uint64 `json:"free"`
-	Locked uint64 `json:"locked"`
-	Frozen uint64 `json:"frozen"`
+	Free   string `json:"free"`
+	Locked string `json:"locked"`
+	Frozen string `json:"frozen"`
 }
 
 type Error struct {
@@ -57,6 +57,27 @@ type Tx struct {
 type TxPage struct {
 	Nums int  `json:"txNums"`
 	Txs  []Tx `json:"txArray"`
+}
+
+type Token struct {
+	Mintable       bool   `json:"mintable"`
+	Name           string `json:"name"`
+	OriginalSymbol string `json:"original_symbol"`
+	Owner          string `json:"owner"`
+	Symbol         string `json:"symbol"`
+	TotalSupply    string `json:"total_supply"`
+}
+
+type TokenPage []Token
+
+// findToken find a token into a token list
+func (a TokenPage) findToken(symbol string) *Token {
+	for _, t := range a {
+		if t.Symbol == symbol {
+			return &t
+		}
+	}
+	return nil
 }
 
 func (e *Error) Error() string {

--- a/platform/ethereum/api.go
+++ b/platform/ethereum/api.go
@@ -252,3 +252,36 @@ func NormalizeCollectible(c *Collection, a Collectible, coinIndex uint) blockatl
 		Coin:             coinIndex,
 	}
 }
+
+func (p *Platform) GetTokenListByAddress(address string) (blockatlas.TokenPage, error) {
+	account, err := p.client.GetTokens(address)
+	if err != nil {
+		return nil, err
+	}
+	return NormalizeTokens(account.Docs), nil
+}
+
+// NormalizeToken converts a Ethereum token into the generic model
+func NormalizeToken(srcToken *Token) (t blockatlas.Token, ok bool) {
+	t = blockatlas.Token{
+		Name:     srcToken.Contract.Name,
+		Symbol:   srcToken.Contract.Symbol,
+		TokenId:  srcToken.Contract.Contract,
+		Coin:     coin.ETH,
+		Decimals: srcToken.Contract.Decimals,
+	}
+
+	return t, true
+}
+
+// NormalizeTxs converts multiple Ethereum tokens
+func NormalizeTokens(srcTokens []Token) (tokenPage []blockatlas.Token) {
+	for _, srcToken := range srcTokens {
+		token, ok := NormalizeToken(&srcToken)
+		if !ok {
+			continue
+		}
+		tokenPage = append(tokenPage, token)
+	}
+	return
+}

--- a/platform/ethereum/api_test.go
+++ b/platform/ethereum/api_test.go
@@ -292,12 +292,12 @@ func testNormalizeToken(t *testing.T, _test *testToken) {
 		t.Error(err)
 		return
 	}
-	tx, ok := NormalizeToken(&token)
+	tk, ok := NormalizeToken(&token)
 	if !ok {
-		t.Errorf("transfer: tx could not be normalized")
+		t.Errorf("token: token could not be normalized")
 	}
 
-	resJSON, err := json.Marshal(&tx)
+	resJSON, err := json.Marshal(&tk)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -310,6 +310,6 @@ func testNormalizeToken(t *testing.T, _test *testToken) {
 	if !bytes.Equal(resJSON, dstJSON) {
 		println(string(resJSON))
 		println(string(dstJSON))
-		t.Error("transfer: tx don't equal")
+		t.Error("token: token don't equal")
 	}
 }

--- a/platform/ethereum/api_test.go
+++ b/platform/ethereum/api_test.go
@@ -248,3 +248,68 @@ func testNormalize(t *testing.T, _test *test) {
 		t.Error(_test.name + ": tx don't equal")
 	}
 }
+
+
+const tokenSrc = `
+{
+	"balance": "0",
+	"contract": {
+		"contract": "0xa14839c9837657efcde754ebeaf5cbecdd801b2a",
+		"address": "0xa14839c9837657efcde754ebeaf5cbecdd801b2a",
+		"name": "FusChain",
+		"decimals": 18,
+		"symbol": "FUS"
+	}
+}`
+
+var tokenDst = blockatlas.Token{
+	Name:     "FusChain",
+	Symbol:   "FUS",
+	Decimals: 18,
+	TokenId:  "0xa14839c9837657efcde754ebeaf5cbecdd801b2a",
+	Coin:     coin.ETH,
+}
+
+type testToken struct {
+	name        string
+	apiResponse string
+	expected    *blockatlas.Token
+	token       bool
+}
+
+func TestNormalizeToken(t *testing.T) {
+	testNormalizeToken(t, &testToken{
+		name:        "token",
+		apiResponse: tokenSrc,
+		expected:    &tokenDst,
+	})
+}
+
+func testNormalizeToken(t *testing.T, _test *testToken) {
+	var token Token
+	err := json.Unmarshal([]byte(_test.apiResponse), &token)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	tx, ok := NormalizeToken(&token)
+	if !ok {
+		t.Errorf("transfer: tx could not be normalized")
+	}
+
+	resJSON, err := json.Marshal(&tx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dstJSON, err := json.Marshal(_test.expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(resJSON, dstJSON) {
+		println(string(resJSON))
+		println(string(dstJSON))
+		t.Error("transfer: tx don't equal")
+	}
+}

--- a/platform/ethereum/client.go
+++ b/platform/ethereum/client.go
@@ -84,3 +84,26 @@ func (c *Client) CurrentBlockNumber() (num int64, err error) {
 
 	return nodeInfo.LatestBlock, nil
 }
+
+func (c *Client) GetTokens(address string) (*TokenPage, error) {
+	path := fmt.Sprintf("%s/tokens?%s",
+		c.BaseURL,
+		url.Values{
+			"address": {address},
+		}.Encode())
+
+	res, err := http.Get(path)
+	if err != nil {
+		logrus.WithError(err).Error("Ethereum/Trust Ray: Failed to get my tokens")
+		return nil, blockatlas.ErrSourceConn
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != 200 {
+		return nil, fmt.Errorf("http %s (%s)", res.Status, path)
+	}
+
+	tks := new(TokenPage)
+	err = json.NewDecoder(res.Body).Decode(tks)
+	return tks, err
+}

--- a/platform/ethereum/model.go
+++ b/platform/ethereum/model.go
@@ -5,6 +5,16 @@ type Page struct {
 	Docs  []Doc `json:"docs"`
 }
 
+type TokenPage struct {
+	Total uint    `json:"total"`
+	Docs  []Token `json:"docs"`
+}
+
+type Token struct {
+	Balance  string   `json:"balance"`
+	Contract Contract `json:"contract"`
+}
+
 type Doc struct {
 	Ops         []Op   `json:"operations"`
 	Contract    string `json:"contract"`
@@ -37,8 +47,9 @@ type Contract struct {
 	Address     string `json:"address"`
 	Symbol      string `json:"symbol"`
 	Decimals    uint   `json:"decimals"`
-	TotalSupply string `json:"totalSupply"`
+	TotalSupply string `json:"totalSupply,omitempty"`
 	Name        string `json:"name"`
+	Contract    string `json:"contract,omitempty"`
 }
 
 type NodeInfo struct {

--- a/tx.go
+++ b/tx.go
@@ -108,8 +108,8 @@ type ContractCall struct {
 // TokenPage is a page of transactions.
 type TokenPage []Token
 
-// TokenTransfer describes the non-native tokens.
-// Examples: ERC-20, TRC20
+// Token describes the non-native tokens.
+// Examples: ERC-20, TRC-20, BEP-2
 type Token struct {
 	Name     string `json:"name"`
 	Symbol   string `json:"symbol"`

--- a/tx.go
+++ b/tx.go
@@ -104,3 +104,16 @@ type ContractCall struct {
 	Input string `json:"input"`
 	Value string `json:"value"`
 }
+
+// TokenPage is a page of transactions.
+type TokenPage []Token
+
+// TokenTransfer describes the non-native tokens.
+// Examples: ERC-20, TRC20
+type Token struct {
+	Name     string `json:"name"`
+	Symbol   string `json:"symbol"`
+	Decimals uint   `json:"decimals"`
+	TokenId  string `json:"tokenID"`
+	Coin     uint   `coin:"data"`
+}

--- a/tx.go
+++ b/tx.go
@@ -115,5 +115,5 @@ type Token struct {
 	Symbol   string `json:"symbol"`
 	Decimals uint   `json:"decimals"`
 	TokenId  string `json:"tokenID"`
-	Coin     uint   `coin:"data"`
+	Coin     uint   `json:"coin"`
 }


### PR DESCRIPTION
**Headline:**
- Add a new API interface for list all tokens from a specific address and coin;

**Problem:**
- Now, the Blockatlas API doesn't have support to fetch all token for an address;

**Changes:**
- Create new API interface `TokenAPI`;
- Create new route `v2/tokens/:address`;
- Create Ethereum support and tests;
- Create Binance support and tests;
- Run `go fmt` for some files;

**How to Test:**
- Configure your `config.yaml` and `coin.yaml`;
- Run Blockatlas locally;
- Test the Binance support: `/v2/binance/tokens/:address`;
e.g.: `http://localhost:8420/v2/binance/tokens/bnb1jxfh2g85q3v0tdq56fnevx6xcxtcnhtsmcu64m`

- Test the Ethereum support: `/v2/ethereum/tokens/:address`;
e.g.:`http://localhost:8420/v2/ethereum/tokens/0xBBf52Eb09f0254AeFcC45675Bd2Eed4F38745aC8`