### PR TITLE
Add makefile and exclude bin folder in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Binary
 /blockatlas
 /blockatlas.exe
+/bin/*
 
 # Dev environment
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,112 @@
+VERSION := $(shell git describe --tags)
+BUILD := $(shell git rev-parse --short HEAD)
+PROJECT_NAME := $(shell basename "$(PWD)")
+START_COMMAND := api
+
+# Go related variables.
+GOBASE := $(shell pwd)
+GOBIN := $(GOBASE)/bin
+GOPKG := $(cmd)
+
+# Testable packages
+TESTABLE_PACKAGES=`find . -name *_test.go | xargs -n 1 dirname | uniq | sed -e 's|^\.|github.com/TrustWallet/blockatlas|g'`
+
+# Go files
+GOFMT_FILES?=$$(find . -name '*.go' | grep -v vendor)
+
+# Use linker flags to provide version/build settings
+LDFLAGS=-ldflags "-X=main.Version=$(VERSION) -X=main.Build=$(BUILD)"
+
+# Redirect error output to a file, so we can show it in development mode.
+STDERR := /tmp/.$(PROJECT_NAME)-stderr.txt
+
+# PID file will keep the process id of the server
+PID := /tmp/.$(PROJECT_NAME).pid
+
+# Make is verbose in Linux. Make it silent.
+MAKEFLAGS += --silent
+
+## install: Install missing dependencies. Runs `go get` internally. e.g; make install get=github.com/foo/bar
+install: go-get
+
+## start: Start in development mode. Auto-starts when code changes.
+start:
+	@bash -c "trap 'make stop' EXIT; $(MAKE) clean compile start-server watch run='make clean compile start-server'"
+
+## stop: Stop development mode.
+stop: stop-server
+
+start-server: stop-server
+	@echo "  >  Starting $(PROJECT_NAME)"
+	@-$(GOBIN)/$(PROJECT_NAME) $(START_COMMAND) 2>&1 & echo $$! > $(PID)
+	@cat $(PID) | sed "/^/s/^/  \>  PID: /"
+	@echo "  >  Error log: $(STDERR)"
+
+stop-server:
+	@-touch $(PID)
+	@-kill `cat $(PID)` 2> /dev/null || true
+	@-rm $(PID)
+
+restart-server: stop-server start-server
+
+## watch: Run given command when code changes. e.g; make watch run="echo 'hey'"
+watch:
+	go get github.com/azer/yolo
+	GOBIN=$(GOBIN) yolo -i . -i .go -e vendor -e bin -c "$(run)"
+
+## compile: Compile the binary.
+compile:
+	@-touch $(STDERR)
+	@-rm $(STDERR)
+	@-$(MAKE) -s go-compile 2> $(STDERR)
+	@cat $(STDERR) | sed -e '1s/.*/\nError:\n/'  | sed 's/make\[.*/ /' | sed "/^/s/^/     /" 1>&2
+
+## exec: Run given command. e.g; make exec run="go test ./..."
+exec:
+	GOBIN=$(GOBIN) $(run)
+
+## clean: Clean build files. Runs `go clean` internally.
+clean:
+	@-rm $(GOBIN)/$(PROJECT_NAME) 2> /dev/null
+	@-$(MAKE) go-clean
+
+## test: Run all unit tests.
+test: go-test
+
+## fmt: Run `go fmt` for all go files.
+fmt:
+	go fmt -w $(GOFMT_FILES)
+
+go-compile: go-get go-build
+
+go-build:
+	@echo "  >  Building binary..."
+	GOBIN=$(GOBIN) go build $(LDFLAGS) -o $(GOBIN)/$(PROJECT_NAME) -v ./cmd/
+
+go-generate:
+	@echo "  >  Generating dependency files..."
+	GOBIN=$(GOBIN) go generate $(generate)
+
+go-get:
+	@echo "  >  Checking if there is any missing dependencies..."
+	GOBIN=$(GOBIN) go get $(get)
+
+go-install:
+	GOBIN=$(GOBIN) go install $(GOPKG)
+
+go-clean:
+	@echo "  >  Cleaning build cache"
+	GOBIN=$(GOBIN) go clean
+
+go-test:
+	@echo "  >  Cleaning build cache"
+	GOBIN=$(GOBIN) go test -v ${TESTABLE_PACKAGES}
+
+.PHONY: help
+all: help
+help: Makefile
+	@echo
+	@echo " Choose a command run in "$(PROJECT_NAME)":"
+	@echo
+	@sed -n 's/^##//p' $< | column -t -s ':' |  sed -e 's/^/ /'
+	@echo

--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,7 @@ clean:
 test: go-test
 
 ## fmt: Run `go fmt` for all go files.
-fmt:
-	go fmt -w $(GOFMT_FILES)
+fmt: go-fmt
 
 go-compile: go-get go-build
 
@@ -101,6 +100,10 @@ go-clean:
 go-test:
 	@echo "  >  Cleaning build cache"
 	GOBIN=$(GOBIN) go test -v ${TESTABLE_PACKAGES}
+
+go-fmt:
+	@echo "  >  Format all go files"
+	GOBIN=$(GOBIN) gofmt -w ${GOFMT_FILES}
 
 .PHONY: help
 all: help


### PR DESCRIPTION
**Headline:**
- Create a `Makefile` to provide development commands more quickly. Based on [Azer Koçulu model](https://kodfabrik.com/journal/a-good-makefile-for-go/);

**Problem:**
- All commands don't have a shortcut and are verbose;

**Changes:**
- Add `Makefile`;
- Exclude `bin` folder in `.gitignore`;
- Add [`Yolo`](https://github.com/azer/yolo) to tracking project changes and rebuild the binary;

**How to Test:**
- Run `make help`;