### PR TITLE
Change Binance DEX config url

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -27,7 +27,7 @@ observer:
 #       Binance Chain: https://explorer.binance.org
 binance:
   api: https://explorer.binance.org/api/v1
-  dex: https://dex.binance.org/api
+  dex: https://dex.binance.org/api/
 
 # [NIM] Nimiq: https://nimiq.com
 #nimiq:

--- a/platform/binance/client.go
+++ b/platform/binance/client.go
@@ -90,7 +90,7 @@ func (c *Client) GetTxsOfAddress(address string, token string) (*TxPage, error) 
 }
 
 func (c *Client) GetAccountMetadata(address string) (*Account, error) {
-	uri := fmt.Sprintf("%s/v1/account/%s", c.BaseDexURL, address)
+	uri := fmt.Sprintf("%sv1/account/%s", c.BaseDexURL, address)
 
 	res, err := c.HTTPClient.Get(uri)
 	if err != nil {
@@ -108,7 +108,7 @@ func (c *Client) GetAccountMetadata(address string) (*Account, error) {
 }
 
 func (c *Client) GetTokens() (*TokenPage, error) {
-	uri := fmt.Sprintf("%s/v1/tokens?%s",
+	uri := fmt.Sprintf("%sv1/tokens?%s",
 		c.BaseDexURL,
 		url.Values{
 			"limits": {"1000"},


### PR DESCRIPTION
Load balancer points to `.../api/`  and in order to utilize private env var `ATLAS_BINANCE_DEX` current changes required.