### PR TITLE
Return latest cosmos transactions from the API

### DIFF
--- a/platform/cosmos/api.go
+++ b/platform/cosmos/api.go
@@ -3,6 +3,7 @@ package cosmos
 import (
 	"github.com/trustwallet/blockatlas"
 	"net/http"
+	"sort"
 	"strconv"
 	"time"
 
@@ -40,7 +41,11 @@ func (p *Platform) GetTxsByAddress(address string) (blockatlas.TxPage, error) {
 		normalisedTxes = append(normalisedTxes, normalisedOutputTx)
 	}
 
-	return normalisedTxes, nil
+	sort.Slice(normalisedTxes, func(i, j int) bool {
+		return normalisedTxes[i].Date > normalisedTxes[j].Date
+	})
+
+	return normalisedTxes[0:blockatlas.TxPerPage], nil
 }
 
 func (p *Platform) GetValidators() (blockatlas.ValidatorPage, error) {

--- a/platform/cosmos/api.go
+++ b/platform/cosmos/api.go
@@ -45,7 +45,7 @@ func (p *Platform) GetTxsByAddress(address string) (blockatlas.TxPage, error) {
 		return normalisedTxes[i].Date > normalisedTxes[j].Date
 	})
 
-	return normalisedTxes[0:blockatlas.TxPerPage], nil
+	return normalisedTxes, nil
 }
 
 func (p *Platform) GetValidators() (blockatlas.ValidatorPage, error) {

--- a/platform/cosmos/client.go
+++ b/platform/cosmos/client.go
@@ -27,7 +27,7 @@ func (c *Client) GetAddrTxes(address string, inOrOut string) (txs []Tx, err erro
 			url.Values{
 				"recipient": {address},
 				"page":      {strconv.FormatInt(1, 10)},
-				"limit":     {strconv.FormatInt(blockatlas.TxPerPage, 10)},
+				"limit":     {strconv.FormatInt(1000, 10)},
 			}.Encode())
 	} else {
 		uri = fmt.Sprintf("%s/txs?%s",
@@ -35,7 +35,7 @@ func (c *Client) GetAddrTxes(address string, inOrOut string) (txs []Tx, err erro
 			url.Values{
 				"sender": {address},
 				"page":   {strconv.FormatInt(1, 10)},
-				"limit":  {strconv.FormatInt(blockatlas.TxPerPage, 10)},
+				"limit":  {strconv.FormatInt(1000, 10)},
 			}.Encode())
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/TrustWallet/blockatlas/issues/179

There is no easy way to get transactions from the cosmos RPC, there is a conversation in the slack group: https://tendermint-friends.slack.com/archives/C6HFTK9A6/p1564465764087300?thread_ts=1564445288.080400&cid=C6HFTK9A6

but for now, the solution to get all transactions with a max value and then sort by date and return latest 25