### PR TITLE
ZIL: config change to public [DO NOT MERGE YET]

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -68,6 +68,5 @@ func loadDefaults() {
 	viper.SetDefault("iotex.api", "https://pharos.iotex.io/v1")
 	viper.SetDefault("waves.api", "https://nodes.wavesnodes.com")
 	viper.SetDefault("aeternity.api", "https://mdw.aepps.com/")
-	viper.SetDefault("zilliqa.api", "https://api.viewblock.io/v1/zilliqa")
 	viper.SetDefault("zilliqa.rpc", "https://api.zilliqa.com/")
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -13,7 +13,7 @@ func loadConfig(confPath string) {
 	loadDefaults()
 
 	// Load config from environment
-	viper.SetEnvPrefix("atlas")
+	viper.SetEnvPrefix("atlas") // will be uppercased automatically => ATLAS
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	viper.AutomaticEnv()
 
@@ -29,7 +29,7 @@ func loadConfig(confPath string) {
 		} else if err != nil {
 			logrus.Fatal(err)
 		} else {
-			logrus.Info("Using config.yml")
+			logrus.Info("Viper using ", viper.ConfigFileUsed())
 		}
 	} else {
 		viper.SetConfigFile(confPath)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -22,8 +22,7 @@ var app = cobra.Command{
 		loadConfig(confPath)
 
 		// Load coin index
-		coinFile := viper.GetString("coins")
-		coin.Load(coinFile)
+		coin.Load(viper.GetString("coins"))
 
 		// Load app components
 		platform.Init()

--- a/coin/coin.go
+++ b/coin/coin.go
@@ -55,6 +55,7 @@ func load(fPath string) error {
 		}
 		Coins[coin.ID] = coin
 	}
+	println("Coins loaded successfully")
 
 	return nil
 }

--- a/config.yml
+++ b/config.yml
@@ -116,10 +116,10 @@ ontology:
   api: https://explorer.ont.io/api/v1/explorer
 
 # [ZIL] Zilliqa: https://zilliqa.com
-# zilliqa:
+ zilliqa:
 #  api: https://api.viewblock.io/v1/zilliqa
 #  key: YOUR_API_KEY
-#  rpc: https://api.zilliqa.com/
+  rpc: https://api.zilliqa.com/
 
 #[IoTeX] IoTeX: https://iotex.io/
 iotex:

--- a/config.yml
+++ b/config.yml
@@ -116,7 +116,7 @@ ontology:
   api: https://explorer.ont.io/api/v1/explorer
 
 # [ZIL] Zilliqa: https://zilliqa.com
- zilliqa:
+zilliqa:
 #  api: https://api.viewblock.io/v1/zilliqa
 #  key: YOUR_API_KEY
   rpc: https://api.zilliqa.com/


### PR DESCRIPTION
Reason for changes:
1. ZIL RPC is public, no reason ho make it private
3. Making `api` endpoint as default a default donesn't make sense as far as it required api key which is private and plus too that env vars `ATLAS_ZILLIQA_API` and `ATLAS_ZILLIQA_KEY` already set up in Heroku so BA will pick it up. For those who want to use `api` endpoint to need get it's own private key.