### PR TITLE
Add endpoint to list all available coins

### DIFF
--- a/cmd/api/generic.go
+++ b/cmd/api/generic.go
@@ -151,7 +151,11 @@ func makeTokenRoute(router gin.IRouter, api blockatlas.Platform) {
 
 func makeCoinRoute(router gin.IRouter) {
 	router.GET("/coins", func(c *gin.Context) {
-		c.JSON(http.StatusOK, coin.Coins)
+		coins := make([]coin.Coin, 0)
+		for _, coin := range coin.Coins {
+			coins = append(coins, coin)
+		}
+		c.JSON(http.StatusOK, coins)
 	})
 }
 

--- a/cmd/api/generic.go
+++ b/cmd/api/generic.go
@@ -7,7 +7,6 @@ import (
 	services "github.com/trustwallet/blockatlas/services/assets"
 	"log"
 	"net/http"
-	"strconv"
 )
 
 func makeTxRouteV1(router gin.IRouter, api blockatlas.Platform) {
@@ -153,20 +152,6 @@ func makeTokenRoute(router gin.IRouter, api blockatlas.Platform) {
 func makeCoinRoute(router gin.IRouter) {
 	router.GET("/coins", func(c *gin.Context) {
 		c.JSON(http.StatusOK, coin.Coins)
-	})
-
-	router.GET("/coin/:id", func(c *gin.Context) {
-		id := c.Param("id")
-		u, err := strconv.ParseUint(id, 10, 64)
-		if err != nil {
-			c.String(http.StatusBadRequest, "Invalid coin")
-			return
-		}
-		if val, ok := coin.Coins[uint(u)]; ok {
-			c.JSON(http.StatusOK, val)
-			return
-		}
-		c.String(http.StatusBadRequest, "Coin not found")
 	})
 }
 

--- a/cmd/api/generic.go
+++ b/cmd/api/generic.go
@@ -3,9 +3,11 @@ package api
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/trustwallet/blockatlas"
+	"github.com/trustwallet/blockatlas/coin"
 	services "github.com/trustwallet/blockatlas/services/assets"
 	"log"
 	"net/http"
+	"strconv"
 )
 
 func makeTxRouteV1(router gin.IRouter, api blockatlas.Platform) {
@@ -145,6 +147,26 @@ func makeTokenRoute(router gin.IRouter, api blockatlas.Platform) {
 		}
 
 		c.JSON(http.StatusOK, blockatlas.DocsResponse{Docs: tl})
+	})
+}
+
+func makeCoinRoute(router gin.IRouter) {
+	router.GET("/coins", func(c *gin.Context) {
+		c.JSON(http.StatusOK, coin.Coins)
+	})
+
+	router.GET("/coin/:id", func(c *gin.Context) {
+		id := c.Param("id")
+		u, err := strconv.ParseUint(id, 10, 64)
+		if err != nil {
+			c.String(http.StatusBadRequest, "Invalid coin")
+			return
+		}
+		if val, ok := coin.Coins[uint(u)]; ok {
+			c.JSON(http.StatusOK, val)
+			return
+		}
+		c.String(http.StatusBadRequest, "Coin not found")
 	})
 }
 

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -42,8 +42,6 @@ func loadPlatforms(root gin.IRouter) {
 	}
 
 	makeCoinRoute(root)
-	makeCoinRoute(getRouter(v1, ""))
-	makeCoinRoute(getRouter(v2, ""))
 
 	logrus.WithField("routes", len(routers)).Info("Routes set up")
 

--- a/cmd/api/routes.go
+++ b/cmd/api/routes.go
@@ -41,6 +41,10 @@ func loadPlatforms(root gin.IRouter) {
 		customAPI.RegisterRoutes(router)
 	}
 
+	makeCoinRoute(root)
+	makeCoinRoute(getRouter(v1, ""))
+	makeCoinRoute(getRouter(v2, ""))
+
 	logrus.WithField("routes", len(routers)).Info("Routes set up")
 
 	v1.GET("/", getEnabledEndpoints)

--- a/coin/coin.go
+++ b/coin/coin.go
@@ -14,13 +14,13 @@ var Coins map[uint]Coin
 
 // Coin is the native currency of a blockchain
 type Coin struct {
-	ID         uint   `json:"id";yaml:"id"`                       // SLIP-44 ID (e.g. 242)
-	Handle     string `json:"handle";yaml:"handle"`               // Trust Wallet handle (e.g. nimiq)
-	Symbol     string `json:"symbol";yaml:"symbol"`               // Symbol of native currency
-	Title      string `json:"name";yaml:"name"`                   // Full name of native currency
-	Decimals   uint   `json:"decimals";yaml:"decimals"`           // Number of decimals
-	BlockTime  int    `json:"blockTime";yaml:"blockTime"`         // Average time between blocks (ms)
-	SampleAddr string `json:"sampleAddress";yaml:"sampleAddress"` // Random address seen on chain
+	ID         uint   `yaml:"id" json:"id"`                       // SLIP-44 ID (e.g. 242)
+	Handle     string `yaml:"handle" json:"handle"`               // Trust Wallet handle (e.g. nimiq)
+	Symbol     string `yaml:"symbol" json:"symbol"`               // Symbol of native currency
+	Title      string `yaml:"name" json:"name"`                   // Full name of native currency
+	Decimals   uint   `yaml:"decimals" json:"decimals"`           // Number of decimals
+	BlockTime  int    `yaml:"blockTime" json:"blockTime"`         // Average time between blocks (ms)
+	SampleAddr string `yaml:"sampleAddress" json:"sampleAddress"` // Random address seen on chain
 }
 
 func (c Coin) String() string {

--- a/coin/coin.go
+++ b/coin/coin.go
@@ -14,13 +14,13 @@ var Coins map[uint]Coin
 
 // Coin is the native currency of a blockchain
 type Coin struct {
-	ID         uint   `yaml:"id"`            // SLIP-44 ID (e.g. 242)
-	Handle     string `yaml:"handle"`        // Trust Wallet handle (e.g. nimiq)
-	Symbol     string `yaml:"symbol"`        // Symbol of native currency
-	Title      string `yaml:"name"`          // Full name of native currency
-	Decimals   uint   `yaml:"decimals"`      // Number of decimals
-	BlockTime  int    `yaml:"blockTime"`     // Average time between blocks (ms)
-	SampleAddr string `yaml:"sampleAddress"` // Random address seen on chain
+	ID         uint   `json:"id";yaml:"id"`                       // SLIP-44 ID (e.g. 242)
+	Handle     string `json:"handle";yaml:"handle"`               // Trust Wallet handle (e.g. nimiq)
+	Symbol     string `json:"symbol";yaml:"symbol"`               // Symbol of native currency
+	Title      string `json:"name";yaml:"name"`                   // Full name of native currency
+	Decimals   uint   `json:"decimals";yaml:"decimals"`           // Number of decimals
+	BlockTime  int    `json:"blockTime";yaml:"blockTime"`         // Average time between blocks (ms)
+	SampleAddr string `json:"sampleAddress";yaml:"sampleAddress"` // Random address seen on chain
 }
 
 func (c Coin) String() string {


### PR DESCRIPTION
## Summary

Add endpoint to list all available coins.

## Problem Definition

The new endpoint was going help to create the integration tests and other services.

## Proposal

Create new routes `/coins` to list all coins and `/coin/:id` to get a unique coin.

Response sample:
```
[
  {
    "ID": 0,
    "Handle": "bitcoin",
    "Symbol": "BTC",
    "Title": "Bitcoin",
    "Decimals": 8,
    "BlockTime": 600000,
    "SampleAddr": "bc1quvuarfksewfeuevuc6tn0kfyptgjvwsvrprk9d"
  }
]
```
