### PR TITLE
Remove token_id omitempty property

### DIFF
--- a/tx.go
+++ b/tx.go
@@ -146,7 +146,7 @@ type AnyAction struct {
 	Coin     uint   `json:"coin"`
 	Title    string `json:"title"`
 	Key      string `json:"key"`
-	TokenID  string `json:"tokenID,omitempty"`
+	TokenID  string `json:"tokenID"`
 	Name     string `json:"name"`
 	Symbol   string `json:"symbol"`
 	Decimals uint   `json:"decimals"`


### PR DESCRIPTION
iOS/Android clients expect this to be non optional