### PR TITLE
Fix xpub webhook for tx receiver

### DIFF
--- a/observer/entries.go
+++ b/observer/entries.go
@@ -18,4 +18,5 @@ type Storage interface {
 	Delete([]Subscription) error
 	SaveXpubAddresses(coin uint, addresses []string, xpub string) error
 	GetXpubFromAddress(coin uint, address string) (string, error)
+	GetAddressFromXpub(coin uint, xpub string) ([]string, error)
 }

--- a/observer/observer.go
+++ b/observer/observer.go
@@ -43,7 +43,7 @@ func (o *Observer) processBlock(events chan<- Event, block *blockatlas.Block) {
 	}
 
 	// Emit events
-	emitted := make(map[string]blockatlas.Direction)
+	emittedUtxo := make(map[string]blockatlas.Direction)
 	platform := bitcoin.UtxoPlatform(o.Coin)
 	for _, sub := range subs {
 
@@ -69,17 +69,16 @@ func (o *Observer) processBlock(events chan<- Event, block *blockatlas.Block) {
 					Symbol:   coin.Coins[o.Coin].Symbol,
 					Decimals: coin.Coins[o.Coin].Decimals,
 				}
-			}
 
-			if d, ok := emitted[tx.ID]; ok {
-				if d == tx.Direction || d == blockatlas.DirectionSelf {
-					continue
+				if d, ok := emittedUtxo[tx.ID]; ok {
+					if d == tx.Direction || d == blockatlas.DirectionSelf {
+						continue
+					}
+					emittedUtxo[tx.ID] = blockatlas.DirectionSelf
+				} else {
+					emittedUtxo[tx.ID] = tx.Direction
 				}
-				emitted[tx.ID] = blockatlas.DirectionSelf
-			} else {
-				emitted[tx.ID] = tx.Direction
 			}
-
 			events <- Event{
 				Subscription: sub,
 				Tx:           &tx,

--- a/observer/storage/memory/storage.go
+++ b/observer/storage/memory/storage.go
@@ -11,6 +11,7 @@ type Storage struct {
 	blockNumbers map[uint]int64
 	observers    map[string]observer.Subscription
 	addresses    map[string]string
+	xpub         map[string][]string
 }
 
 func New() *Storage {
@@ -18,6 +19,7 @@ func New() *Storage {
 		blockNumbers: make(map[uint]int64),
 		observers:    make(map[string]observer.Subscription),
 		addresses:    make(map[string]string),
+		xpub:         make(map[string][]string),
 	}
 }
 
@@ -70,7 +72,12 @@ func (s *Storage) SaveXpubAddresses(coin uint, addresses []string, xpub string) 
 	for _, addr := range addresses {
 		s.addresses[addr] = xpub
 	}
+	s.xpub[xpub] = addresses
 	return nil
+}
+
+func (s *Storage) GetAddressFromXpub(coin uint, xpub string) ([]string, error) {
+	return s.xpub[xpub], nil
 }
 
 func (s *Storage) GetXpubFromAddress(coin uint, address string) (string, error) {

--- a/observer/storage/memory/storage.go
+++ b/observer/storage/memory/storage.go
@@ -8,18 +8,18 @@ import (
 )
 
 type Storage struct {
-	blockNumbers map[uint]int64
-	observers    map[string]observer.Subscription
-	addresses    map[string]string
-	xpub         map[string][]string
+	blockNumbers  map[uint]int64
+	observers     map[string]observer.Subscription
+	addresses     map[string]string
+	xpubAddresses map[string][]string
 }
 
 func New() *Storage {
 	return &Storage{
-		blockNumbers: make(map[uint]int64),
-		observers:    make(map[string]observer.Subscription),
-		addresses:    make(map[string]string),
-		xpub:         make(map[string][]string),
+		blockNumbers:  make(map[uint]int64),
+		observers:     make(map[string]observer.Subscription),
+		addresses:     make(map[string]string),
+		xpubAddresses: make(map[string][]string),
 	}
 }
 
@@ -72,12 +72,12 @@ func (s *Storage) SaveXpubAddresses(coin uint, addresses []string, xpub string) 
 	for _, addr := range addresses {
 		s.addresses[addr] = xpub
 	}
-	s.xpub[xpub] = addresses
+	s.xpubAddresses[xpub] = addresses
 	return nil
 }
 
 func (s *Storage) GetAddressFromXpub(coin uint, xpub string) ([]string, error) {
-	return s.xpub[xpub], nil
+	return s.xpubAddresses[xpub], nil
 }
 
 func (s *Storage) GetXpubFromAddress(coin uint, address string) (string, error) {

--- a/observer/storage/memory/storage_test.go
+++ b/observer/storage/memory/storage_test.go
@@ -144,8 +144,10 @@ func TestMemoryStorage_Contains(t *testing.T) {
 
 func TestMemoryStorage_SaveAddresses(t *testing.T) {
 	var addresses = make(map[string]string)
+	var xAddresses = make(map[string][]string)
 	var storage observer.Storage = &Storage{
-		addresses: addresses,
+		addresses:     addresses,
+		xpubAddresses: xAddresses,
 	}
 
 	err := storage.SaveXpubAddresses(coin.BTC, xpubAddresses, xpub)
@@ -155,12 +157,17 @@ func TestMemoryStorage_SaveAddresses(t *testing.T) {
 	if len(addresses) == 0 {
 		t.Error("addresses not added")
 	}
+	if len(xAddresses) == 0 {
+		t.Error("xpub not added")
+	}
 }
 
 func TestMemoryStorage_GetAddresses(t *testing.T) {
 	var addresses = make(map[string]string)
+	var xAddresses = make(map[string][]string)
 	var storage observer.Storage = &Storage{
 		addresses: addresses,
+		xpubAddresses: xAddresses,
 	}
 
 	err := storage.SaveXpubAddresses(coin.BTC, xpubAddresses, xpub)
@@ -176,5 +183,12 @@ func TestMemoryStorage_GetAddresses(t *testing.T) {
 	}
 	if !reflect.DeepEqual(res, xpub) {
 		t.Error("wrong addresses")
+	}
+	a, err := storage.GetAddressFromXpub(coin.BTC, xpub)
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(xpubAddresses, a) {
+		t.Error("wrong xpub addresses")
 	}
 }

--- a/observer/storage/redis/storage.go
+++ b/observer/storage/redis/storage.go
@@ -59,19 +59,21 @@ func (s *Storage) SaveXpubAddresses(coin uint, addresses []string, xpub string) 
 
 func (s *Storage) GetAddressFromXpub(coin uint, xpub string) ([]string, error) {
 	key := fmt.Sprintf(keyXpub, coin)
-	r, err := s.getHashMap(key, xpub)
+	results, err := s.getHashMap(key, xpub)
 	if err != nil {
 		return nil, err
 	}
-	if len(r) == 0 {
+	if len(results) == 0 {
 		return nil, fmt.Errorf("xpub not found: %s", xpub)
 	}
-	var list []string
-	err = json.Unmarshal([]byte(r[0].(string)), &list)
-	if err != nil {
-		return nil, err
+	var addresses []string
+	for _, result := range results {
+		addr, ok := result.(string)
+		if ok {
+			addresses = append(addresses, addr)
+		}
 	}
-	return list, nil
+	return addresses, nil
 }
 
 func (s *Storage) GetXpubFromAddress(coin uint, address string) (string, error) {

--- a/observer/storage/redis/storage.go
+++ b/observer/storage/redis/storage.go
@@ -59,21 +59,19 @@ func (s *Storage) SaveXpubAddresses(coin uint, addresses []string, xpub string) 
 
 func (s *Storage) GetAddressFromXpub(coin uint, xpub string) ([]string, error) {
 	key := fmt.Sprintf(keyXpub, coin)
-	results, err := s.getHashMap(key, xpub)
+	r, err := s.getHashMap(key, xpub)
 	if err != nil {
 		return nil, err
 	}
-	if len(results) == 0 {
+	if len(r) == 0 {
 		return nil, fmt.Errorf("xpub not found: %s", xpub)
 	}
-	var addresses []string
-	for _, result := range results {
-		addr, ok := result.(string)
-		if ok {
-			addresses = append(addresses, addr)
-		}
+	var list []string
+	err = json.Unmarshal([]byte(r[0].(string)), &list)
+	if err != nil {
+		return nil, err
 	}
-	return addresses, nil
+	return list, nil
 }
 
 func (s *Storage) GetXpubFromAddress(coin uint, address string) (string, error) {

--- a/observer/storage/redis/storage.go
+++ b/observer/storage/redis/storage.go
@@ -1,6 +1,7 @@
 package redis
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"github.com/go-redis/redis"
@@ -43,8 +44,34 @@ func (s *Storage) SaveXpubAddresses(coin uint, addresses []string, xpub string) 
 	for _, address := range addresses {
 		a[address] = xpub
 	}
+
 	key := fmt.Sprintf(keyXpub, coin)
-	return s.saveHashMap(key, a)
+	err := s.saveHashMap(key, a)
+	if err != nil {
+		return err
+	}
+	j, err := json.Marshal(addresses)
+	if err != nil {
+		return err
+	}
+	return s.saveHashMap(key, map[string]interface{}{xpub: j})
+}
+
+func (s *Storage) GetAddressFromXpub(coin uint, xpub string) ([]string, error) {
+	key := fmt.Sprintf(keyXpub, coin)
+	r, err := s.getHashMap(key, xpub)
+	if err != nil {
+		return nil, err
+	}
+	if len(r) == 0 {
+		return nil, fmt.Errorf("xpub not found: %s", xpub)
+	}
+	var list []string
+	err = json.Unmarshal([]byte(r[0].(string)), &list)
+	if err != nil {
+		return nil, err
+	}
+	return list, nil
 }
 
 func (s *Storage) GetXpubFromAddress(coin uint, address string) (string, error) {

--- a/observer/storage/redis/storage.go
+++ b/observer/storage/redis/storage.go
@@ -54,11 +54,11 @@ func (s *Storage) GetXpubFromAddress(coin uint, address string) (string, error) 
 		return "", err
 	}
 	if len(r) == 0 {
-		return "", errors.New(fmt.Sprintf("xpub not found for the address: %s", address))
+		return "", fmt.Errorf("xpub not found for the address: %s", address)
 	}
 	xpub, ok := r[0].(string)
 	if !ok || len(xpub) == 0 {
-		return "", errors.New(fmt.Sprintf("invalid type for xpub: %s - %s", xpub, address))
+		return "", fmt.Errorf("invalid type for xpub: %s - %s", xpub, address)
 	}
 	return xpub, nil
 }


### PR DESCRIPTION
# Headline
Fix webhook to send a request for transaction receiver for UTXO's coins.

## Problem
If you register a webhook for the sender and receiver, just the sender receives the webhook. Because to addresses to infer the direction are wrong.

## Solution
Save a list of addresses per xpub, to know the addresses, and infer the direction for tx