### PR TITLE
Fix error to parse 404 from DEX API returns

### DIFF
--- a/platform/binance/client.go
+++ b/platform/binance/client.go
@@ -71,8 +71,10 @@ func (c *Client) GetTokens() (*TokenPage, error) {
 
 func getHTTPError(res *http.Response, desc string) error {
 	switch res.StatusCode {
-	case http.StatusBadRequest, http.StatusNotFound:
+	case http.StatusBadRequest:
 		return getAPIError(res, desc)
+	case http.StatusNotFound:
+		return blockatlas.ErrNotFound
 	case http.StatusOK:
 		return nil
 	default:


### PR DESCRIPTION
# Headline
Fix da issue [288](https://github.com/trustwallet/blockatlas/issues/288)

## Problem
We try to parse a response when the DEX API returns 404

## Solution
Just parse errors for the bad requests