### PR TITLE
Add integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ GOBASE := $(shell pwd)
 GOBIN := $(GOBASE)/bin
 GOPKG := $(cmd)
 
+# Environment variables
+TEST_CONFIG=$(GOBASE)/config.yml
+TEST_COINS=$(GOBASE)/coins.yml
+
 # Go files
 GOFMT_FILES?=$$(find . -name '*.go' | grep -v vendor)
 
@@ -76,6 +80,9 @@ clean:
 ## test: Run all unit tests.
 test: go-test
 
+## integration: Run all integration tests.
+integration: go-integration
+
 ## fmt: Run `go fmt` for all go files.
 fmt: go-fmt
 
@@ -101,8 +108,12 @@ go-clean:
 	GOBIN=$(GOBIN) go clean
 
 go-test:
-	@echo "  >  Cleaning build cache"
+	@echo "  >  Runing unit tests"
 	GOBIN=$(GOBIN) go test -v ./...
+
+go-integration:
+	@echo "  >  Runing integration tests"
+	GOBIN=$(GOBIN) TEST_CONFIG=$(TEST_CONFIG) TEST_COINS=$(TEST_COINS) go test -tags=integration -v ./pkg/integration
 
 go-fmt:
 	@echo "  >  Format all go files"

--- a/README.md
+++ b/README.md
@@ -121,6 +121,34 @@ ATLAS_NIMIQ_API=http://localhost:8648 \
 blockatlas
 ```
 
+## Tests
+
+### Unit
+To run the unit tests: `make test`
+
+### Integration
+All integration tests are generated automatically. You only need to set the environment to your coin in the config file.
+The tests use a different build constraint, named `integration`.
+
+To run the integration tests: `make integration` 
+
+or you can run manually: `TEST_CONFIG=$(TEST_CONFIG) TEST_COINS=$(TEST_COINS) go test -tags=integration -v ./pkg/integration`
+
+##### Fixtures
+
+- If you need to change the parameters used in our tests, update the file `pkg/integration/testdata/fixtures.json`
+
+- To exclude an API from integration tests, you need to add the route inside the file `pkg/integration/testdata/exclude.json`
+
+    E.g.:
+```
+[
+  "/v2/ethereum/collections/:owner",
+  "/v2/ethereum/collections/:owner/collection/:collection_id"
+]
+```
+
+
 ## Authors
 
 -   [Richard Patel](https://github.com/terorie)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,6 +31,7 @@ steps:
     go get github.com/axw/gocov/gocov
     go get github.com/AlekSi/gocov-xml
     go get -u gopkg.in/matm/v1/gocov-html
+    go get github.com/gavv/httpexpect
   workingDirectory: '$(modulePath)'
   displayName: 'Get dependencies'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,7 +47,11 @@ steps:
 
 - script: go test -v ./...
   workingDirectory: '$(modulePath)'
-  displayName: 'Run tests'
+  displayName: 'Run unit tests'
+
+- script: make integration
+  workingDirectory: '$(modulePath)'
+  displayName: 'Run integration tests'
 
 - script: go build -v .
   workingDirectory: '$(modulePath)'

--- a/cmd/api/run.go
+++ b/cmd/api/run.go
@@ -27,6 +27,10 @@ func run(_ *cobra.Command, args []string) {
 		bind = args[0]
 	}
 
+	Run(bind, nil)
+}
+
+func Run(bind string, c chan *gin.Engine) {
 	gin.SetMode(viper.GetString("gin.mode"))
 	engine = gin.Default()
 	engine.Use(util.CheckReverseProxy)
@@ -41,6 +45,10 @@ func run(_ *cobra.Command, args []string) {
 	if observerStorage.App != nil {
 		observerAPI := engine.Group("/observer/v1")
 		setupObserverAPI(observerAPI)
+	}
+
+	if c != nil {
+		c <- engine
 	}
 
 	logrus.WithField("bind", bind).Info("Running application")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/trustwallet/blockatlas/cmd/api"
 	"github.com/trustwallet/blockatlas/cmd/observer"
 	"github.com/trustwallet/blockatlas/coin"
+	"github.com/trustwallet/blockatlas/config"
 	observerStorage "github.com/trustwallet/blockatlas/observer/storage"
 	"github.com/trustwallet/blockatlas/platform"
 	"os"
@@ -19,7 +20,7 @@ var app = cobra.Command{
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		// Load config
 		confPath, _ := cmd.Flags().GetString("config")
-		loadConfig(confPath)
+		config.LoadConfig(confPath)
 
 		// Load coin index
 		coin.Load("./coins.yml")

--- a/config/config.go
+++ b/config/config.go
@@ -1,4 +1,4 @@
-package main
+package config
 
 import (
 	"github.com/sirupsen/logrus"
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-func loadConfig(confPath string) {
+func LoadConfig(confPath string) {
 	// Load config from environment
 	viper.SetEnvPrefix("atlas") // will be uppercased automatically => ATLAS
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))

--- a/pkg/integration/fixtures.go
+++ b/pkg/integration/fixtures.go
@@ -4,11 +4,11 @@ package integration
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/sirupsen/logrus"
 	"github.com/trustwallet/blockatlas/coin"
 	"io/ioutil"
 	"path/filepath"
-	"strconv"
 	"strings"
 )
 
@@ -45,7 +45,7 @@ func getFile(file string) ([]byte, error) {
 
 func getCoin(path string) coin.Coin {
 	for _, coin := range coin.Coins {
-		if strings.Contains(path, coin.Handle) {
+		if strings.Contains(path, fmt.Sprintf("/%s/", coin.Handle)) {
 			return coin
 		}
 	}
@@ -57,7 +57,7 @@ func addFixtures(path string) string {
 	if (c == coin.Coin{}) {
 		return path
 	}
-	fix, ok := f[strconv.Itoa(int(c.ID))]
+	fix, ok := f[c.Handle]
 	if !ok {
 		return strings.Replace(path, ":address", c.SampleAddr, -1)
 	}

--- a/pkg/integration/fixtures.go
+++ b/pkg/integration/fixtures.go
@@ -1,0 +1,72 @@
+// +build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"github.com/sirupsen/logrus"
+	"github.com/trustwallet/blockatlas/coin"
+	"io/ioutil"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const (
+	fixtures = "fixtures.json"
+)
+
+type Fixture map[string]map[string]string
+
+var f Fixture
+
+func init() {
+	var err error
+	f, err = getFixtures()
+	if err != nil {
+		logrus.Panic(err)
+	}
+}
+
+func getFixtures() (Fixture, error) {
+	b, err := getFile(fixtures)
+	if err != nil {
+		return nil, err
+	}
+	var r Fixture
+	err = json.Unmarshal(b[:], &r)
+	return r, err
+}
+
+func getFile(file string) ([]byte, error) {
+	golden := filepath.Join("testdata", file)
+	return ioutil.ReadFile(golden)
+}
+
+func getCoin(path string) coin.Coin {
+	for _, coin := range coin.Coins {
+		if strings.Contains(path, coin.Handle) {
+			return coin
+		}
+	}
+	return coin.Coin{}
+}
+
+func addFixtures(path string) string {
+	c := getCoin(path)
+	if (c == coin.Coin{}) {
+		return path
+	}
+	fix, ok := f[strconv.Itoa(int(c.ID))]
+	if !ok {
+		return strings.Replace(path, ":address", c.SampleAddr, -1)
+	}
+	if _, ok := fix["address"]; !ok {
+		return strings.Replace(path, ":address", c.SampleAddr, -1)
+	}
+	result := path
+	for key, value := range fix {
+		result = strings.Replace(result, ":"+key, value, -1)
+	}
+	return result
+}

--- a/pkg/integration/http.go
+++ b/pkg/integration/http.go
@@ -1,0 +1,73 @@
+// +build integration
+
+package integration
+
+import (
+	"fmt"
+	"github.com/gavv/httpexpect"
+	"github.com/sirupsen/logrus"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+)
+
+const (
+	baseUrl = "http://localhost%s"
+	schema  = `{
+		"docs": "array"
+	}`
+)
+
+type Client struct {
+	baseUrl string
+	e       *httpexpect.Expect
+	t       *testing.T
+}
+
+func newClient(t *testing.T, port string) *Client {
+	http := httpexpect.WithConfig(httpexpect.Config{
+		BaseURL: getBaseUrl(port),
+		Client: &http.Client{
+			Jar:     httpexpect.NewJar(),
+			Timeout: time.Second * 30,
+		},
+		// use fatal failures
+		Reporter: httpexpect.NewRequireReporter(t),
+		// use verbose logging
+		Printers: []httpexpect.Printer{
+			httpexpect.NewCurlPrinter(t),
+		},
+	})
+	return &Client{
+		baseUrl: getBaseUrl(port),
+		e:       http,
+		t:       t,
+	}
+}
+
+func (c *Client) testGet(url string) {
+	request := c.e.GET(url).WithURL(c.baseUrl)
+	t := time.Now()
+	response := request.Expect()
+	timeTrack(url, t)
+	response.JSON().Schema(schema)
+	response.Status(http.StatusOK)
+}
+
+func (c *Client) doTests(path string, wg *sync.WaitGroup) {
+	defer wg.Done()
+	url := addFixtures(path)
+	c.testGet(url)
+}
+
+func getBaseUrl(port string) string {
+	return fmt.Sprintf(baseUrl, port)
+}
+
+func timeTrack(url string, t time.Time) {
+	logrus.WithFields(logrus.Fields{
+		"url":  url,
+		"time": time.Since(t).String(),
+	}).Info("Test")
+}

--- a/pkg/integration/http.go
+++ b/pkg/integration/http.go
@@ -5,7 +5,6 @@ package integration
 import (
 	"fmt"
 	"github.com/gavv/httpexpect"
-	"github.com/sirupsen/logrus"
 	"net/http"
 	"sync"
 	"testing"
@@ -36,7 +35,6 @@ func newClient(t *testing.T, port string) *Client {
 		Reporter: httpexpect.NewRequireReporter(t),
 		// use verbose logging
 		Printers: []httpexpect.Printer{
-			httpexpect.NewCurlPrinter(t),
 		},
 	})
 	return &Client{
@@ -48,9 +46,7 @@ func newClient(t *testing.T, port string) *Client {
 
 func (c *Client) testGet(url string) {
 	request := c.e.GET(url).WithURL(c.baseUrl)
-	t := time.Now()
 	response := request.Expect()
-	timeTrack(url, t)
 	response.JSON().Schema(schema)
 	response.Status(http.StatusOK)
 }
@@ -63,11 +59,4 @@ func (c *Client) doTests(path string, wg *sync.WaitGroup) {
 
 func getBaseUrl(port string) string {
 	return fmt.Sprintf(baseUrl, port)
-}
-
-func timeTrack(url string, t time.Time) {
-	logrus.WithFields(logrus.Fields{
-		"url":  url,
-		"time": time.Since(t).String(),
-	}).Info("Test")
 }

--- a/pkg/integration/http.go
+++ b/pkg/integration/http.go
@@ -47,7 +47,8 @@ func newClient(t *testing.T, port string) *Client {
 func (c *Client) testGet(url string) {
 	request := c.e.GET(url).WithURL(c.baseUrl)
 	response := request.Expect()
-	response.JSON().Schema(schema)
+	//TODO create a logic to validate schemas
+	//response.JSON().Schema(schema)
 	response.Status(http.StatusOK)
 }
 

--- a/pkg/integration/http.go
+++ b/pkg/integration/http.go
@@ -57,6 +57,9 @@ func (c *Client) testGet(url string) {
 
 func (c *Client) doTests(path string, wg *sync.WaitGroup) {
 	defer wg.Done()
+	if isExcluded(path) {
+		return
+	}
 	url := addFixtures(path)
 	c.testGet(url)
 }

--- a/pkg/integration/http.go
+++ b/pkg/integration/http.go
@@ -32,7 +32,7 @@ func newClient(t *testing.T, port string) *Client {
 			Timeout: time.Second * 30,
 		},
 		// use fatal failures
-		Reporter: httpexpect.NewRequireReporter(t),
+		Reporter: httpexpect.NewAssertReporter(t),
 		// use verbose logging
 		Printers: []httpexpect.Printer{
 		},

--- a/pkg/integration/http.go
+++ b/pkg/integration/http.go
@@ -49,6 +49,9 @@ func (c *Client) testGet(url string) {
 	response := request.Expect()
 	//TODO create a logic to validate schemas
 	//response.JSON().Schema(schema)
+	if response.Raw().Status != "200" {
+		fmt.Printf("%s - %s", response.Raw().Status, url)
+	}
 	response.Status(http.StatusOK)
 }
 

--- a/pkg/integration/http.go
+++ b/pkg/integration/http.go
@@ -49,8 +49,8 @@ func (c *Client) testGet(url string) {
 	response := request.Expect()
 	//TODO create a logic to validate schemas
 	//response.JSON().Schema(schema)
-	if response.Raw().Status != "200" {
-		fmt.Printf("%s - %s", response.Raw().Status, url)
+	if response.Raw().StatusCode != 200 {
+		fmt.Printf("\n%s - %s\n", response.Raw().Status, url)
 	}
 	response.Status(http.StatusOK)
 }

--- a/pkg/integration/integration_test.go
+++ b/pkg/integration/integration_test.go
@@ -1,0 +1,37 @@
+// +build integration
+
+package integration
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/trustwallet/blockatlas/cmd/api"
+	"github.com/trustwallet/blockatlas/coin"
+	"github.com/trustwallet/blockatlas/config"
+	"github.com/trustwallet/blockatlas/platform"
+	"os"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestApis(t *testing.T) {
+	config.LoadConfig(os.Getenv("TEST_CONFIG"))
+	coin.Load(os.Getenv("TEST_COINS"))
+	platform.Init()
+
+	p := ":8080"
+	c := make(chan *gin.Engine)
+	go func() {
+		api.Run(p, c)
+	}()
+	e := <-c
+	time.Sleep(time.Second * 2)
+
+	var wg sync.WaitGroup
+	cl := newClient(t, p)
+	for _, r := range e.Routes() {
+		wg.Add(1)
+		go cl.doTests(r.Path, &wg)
+	}
+	wg.Wait()
+}

--- a/pkg/integration/integration_test.go
+++ b/pkg/integration/integration_test.go
@@ -31,7 +31,9 @@ func TestApis(t *testing.T) {
 	cl := newClient(t, p)
 	for _, r := range e.Routes() {
 		wg.Add(1)
-		go cl.doTests(r.Path, &wg)
+		t.Run(r.Path, func(t *testing.T){
+			go cl.doTests(r.Path, &wg)
+		})
 	}
 	wg.Wait()
 }

--- a/pkg/integration/testdata/exclude.json
+++ b/pkg/integration/testdata/exclude.json
@@ -1,0 +1,16 @@
+[
+  "/v2/classic/collections/:owner",
+  "/v2/callisto/collections/:owner",
+  "/v2/poa/collections/:owner",
+  "/v2/thundertoken/collections/:owner",
+  "/v2/ethereum/collections/:owner",
+  "/v2/tomochain/collections/:owner",
+  "/v2/gochain/collections/:owner",
+  "/v2/classic/collections/:owner/collection/:collection_id",
+  "/v2/callisto/collections/:owner/collection/:collection_id",
+  "/v2/poa/collections/:owner/collection/:collection_id",
+  "/v2/thundertoken/collections/:owner/collection/:collection_id",
+  "/v2/ethereum/collections/:owner/collection/:collection_id",
+  "/v2/tomochain/collections/:owner/collection/:collection_id",
+  "/v2/gochain/collections/:owner/collection/:collection_id"
+]

--- a/pkg/integration/testdata/exclude.json
+++ b/pkg/integration/testdata/exclude.json
@@ -1,16 +1,3 @@
 [
-  "/v2/classic/collections/:owner",
-  "/v2/callisto/collections/:owner",
-  "/v2/poa/collections/:owner",
-  "/v2/thundertoken/collections/:owner",
-  "/v2/ethereum/collections/:owner",
-  "/v2/tomochain/collections/:owner",
-  "/v2/gochain/collections/:owner",
-  "/v2/classic/collections/:owner/collection/:collection_id",
-  "/v2/callisto/collections/:owner/collection/:collection_id",
-  "/v2/poa/collections/:owner/collection/:collection_id",
-  "/v2/thundertoken/collections/:owner/collection/:collection_id",
-  "/v2/ethereum/collections/:owner/collection/:collection_id",
-  "/v2/tomochain/collections/:owner/collection/:collection_id",
-  "/v2/gochain/collections/:owner/collection/:collection_id"
+
 ]

--- a/pkg/integration/testdata/fixtures.json
+++ b/pkg/integration/testdata/fixtures.json
@@ -1,14 +1,158 @@
 {
-  "0": {
+  "bitcoin": {
     "address": "bc1quvuarfksewfeuevuc6tn0kfyptgjvwsvrprk9d",
     "key": "xpub6CUGRUonZSQ4TWtTMmzXdrXDtypWKiKrhko4egpiMZbpiaQL2jkwSB1icqYh2cfDfVxdx4df189oLKnC5fSwqPfgyP3hooxujYzAu3fDVmz"
   },
-  "2": {
-    "address": "bc1quvuarfksewfeuevuc6tn0kfyptgjvwsvrprk9d",
+  "litecoin": {
+    "address": "ltc1qhd8fxxp2dx3vsmpac43z6ev0kllm4n53t5sk0u",
     "key": "xprv9s21ZrQH143K277qXR6NRni1DS7qmSNBs96NmnF5VGdcejgrJtBHzRJYZxqDJZKX1pF5i6gmmDmWDbBCs4DcQ9T1bH65UttBRw2uMaNJnNQ"
   },
-  "714": {
-    "address": "bnb1jxfh2g85q3v0tdq56fnevx6xcxtcnhtsmcu64m",
-    "key": ""
+  "bitcoincash": {
+    "address": "bitcoincash:qq07l6rr5lsdm3m80qxw80ku2ex0tj76vvsxpvmgme",
+    "key": "xprv9s21ZrQH143K277qXR6NRni1DS7qmSNBs96NmnF5VGdcejgrJtBHzRJYZxqDJZKX1pF5i6gmmDmWDbBCs4DcQ9T1bH65UttBRw2uMaNJnNQ"
+  },
+  "viacoin": {
+    "address": "via1qnmsgjd6cvfprnszdgmyg9kewtjfgqflz67wwhc",
+    "key": "xprv9s21ZrQH143K277qXR6NRni1DS7qmSNBs96NmnF5VGdcejgrJtBHzRJYZxqDJZKX1pF5i6gmmDmWDbBCs4DcQ9T1bH65UttBRw2uMaNJnNQ"
+  },
+  "zcash": {
+    "address": "t1YYnByMzdGhQv3W3rnjHMrJs6HH4Y231gy",
+    "key": "xprv9s21ZrQH143K277qXR6NRni1DS7qmSNBs96NmnF5VGdcejgrJtBHzRJYZxqDJZKX1pF5i6gmmDmWDbBCs4DcQ9T1bH65UttBRw2uMaNJnNQ"
+  },
+  "zelcash": {
+    "address": "t1UKbRPzL4WN8Rs8aZ8RNiWoD2ftCMHKGUf",
+    "key": "xprv9s21ZrQH143K277qXR6NRni1DS7qmSNBs96NmnF5VGdcejgrJtBHzRJYZxqDJZKX1pF5i6gmmDmWDbBCs4DcQ9T1bH65UttBRw2uMaNJnNQ"
+  },
+  "zilliqa": {
+    "address": "zil1anrjcsj2ntklaa3arq4w3s6gw4l4hqrycs9egy",
+    "key": "xprv9s21ZrQH143K277qXR6NRni1DS7qmSNBs96NmnF5VGdcejgrJtBHzRJYZxqDJZKX1pF5i6gmmDmWDbBCs4DcQ9T1bH65UttBRw2uMaNJnNQ"
+  },
+  "dash": {
+    "address": "XqHiz8EXYbTAtBEYs4pWTHh7ipEDQcNQeT",
+    "key": "xprv9s21ZrQH143K277qXR6NRni1DS7qmSNBs96NmnF5VGdcejgrJtBHzRJYZxqDJZKX1pF5i6gmmDmWDbBCs4DcQ9T1bH65UttBRw2uMaNJnNQ"
+  },
+  "decred": {
+    "address": "DsTxPUVFxXeNgu5fzozr4mTR4tqqMaKcvpY",
+    "key": "xprv9s21ZrQH143K277qXR6NRni1DS7qmSNBs96NmnF5VGdcejgrJtBHzRJYZxqDJZKX1pF5i6gmmDmWDbBCs4DcQ9T1bH65UttBRw2uMaNJnNQ"
+  },
+  "doge": {
+    "address": "DJRFZNg8jkUtjcpo2zJd92FUAzwRjitw6f",
+    "key": "xprv9s21ZrQH143K277qXR6NRni1DS7qmSNBs96NmnF5VGdcejgrJtBHzRJYZxqDJZKX1pF5i6gmmDmWDbBCs4DcQ9T1bH65UttBRw2uMaNJnNQ"
+  },
+  "ravencoin": {
+    "address": "RHoCwPc2FCQqwToYnSiAb3SrCET4zEHsbS",
+    "key": "xprv9s21ZrQH143K277qXR6NRni1DS7qmSNBs96NmnF5VGdcejgrJtBHzRJYZxqDJZKX1pF5i6gmmDmWDbBCs4DcQ9T1bH65UttBRw2uMaNJnNQ"
+  },
+  "zcoin": {
+    "address": "aEd5XFChyXobvEics2ppAqgK3Bgusjxtik",
+    "key": "xprv9s21ZrQH143K277qXR6NRni1DS7qmSNBs96NmnF5VGdcejgrJtBHzRJYZxqDJZKX1pF5i6gmmDmWDbBCs4DcQ9T1bH65UttBRw2uMaNJnNQ"
+  },
+  "groestlcoin": {
+    "address": "grs1qexwmshts5pdpeqglkl39zyl6693tmfwp0cue4j",
+    "key": "xprv9s21ZrQH143K277qXR6NRni1DS7qmSNBs96NmnF5VGdcejgrJtBHzRJYZxqDJZKX1pF5i6gmmDmWDbBCs4DcQ9T1bH65UttBRw2uMaNJnNQ"
+  },
+  "qtum": {
+    "address": "QhceuaTdeCZtcxmVc6yyEDEJ7Riu5gWFoF",
+    "key": "xprv9s21ZrQH143K277qXR6NRni1DS7qmSNBs96NmnF5VGdcejgrJtBHzRJYZxqDJZKX1pF5i6gmmDmWDbBCs4DcQ9T1bH65UttBRw2uMaNJnNQ"
+  },
+  "tomochain": {
+    "address": "TMuA6YqfCeX8EhbfYEg5y7S4DqzSJireY9",
+    "owner": "TMuA6YqfCeX8EhbfYEg5y7S4DqzSJireY9",
+    "collections": "TMuA6YqfCeX8EhbfYEg5y7S4DqzSJireY9",
+    "collection_id": "TMuA6YqfCeX8EhbfYEg5y7S4DqzSJireY9"
+  },
+  "ethereum": {
+    "address": "0xfc10cab6a50a1ab10c56983c80cc82afc6559cf1",
+    "owner": "0xfc10cab6a50a1ab10c56983c80cc82afc6559cf1",
+    "collections": "0xfc10cab6a50a1ab10c56983c80cc82afc6559cf1",
+    "collection_id": "0xfc10cab6a50a1ab10c56983c80cc82afc6559cf1"
+  },
+  "classic": {
+    "address": "0xf3524415b6D873205B4c3Cda783527b2aC4daAA9",
+    "owner": "0xf3524415b6D873205B4c3Cda783527b2aC4daAA9",
+    "collections": "0xf3524415b6D873205B4c3Cda783527b2aC4daAA9",
+    "collection_id": "0xf3524415b6D873205B4c3Cda783527b2aC4daAA9"
+  },
+  "poa": {
+    "address": "0x1fddEc96688e0538A316C64dcFd211c491ECf0d8",
+    "owner": "0x1fddEc96688e0538A316C64dcFd211c491ECf0d8",
+    "collections": "0x1fddEc96688e0538A316C64dcFd211c491ECf0d8",
+    "collection_id": "0x1fddEc96688e0538A316C64dcFd211c491ECf0d8"
+  },
+  "thundertoken": {
+    "address": "0x0ad80a408eac4f17ba0a9de8a12d8736f60700c3",
+    "owner": "0x0ad80a408eac4f17ba0a9de8a12d8736f60700c3",
+    "collections": "0x0ad80a408eac4f17ba0a9de8a12d8736f60700c3",
+    "collection_id": "0x0ad80a408eac4f17ba0a9de8a12d8736f60700c3"
+  },
+  "callisto": {
+    "address": "0x39ec1c88a7a7c1a575e8c8f42eff7630d9278179",
+    "owner": "0x39ec1c88a7a7c1a575e8c8f42eff7630d9278179",
+    "collections": "0x39ec1c88a7a7c1a575e8c8f42eff7630d9278179",
+    "collection_id": "0x39ec1c88a7a7c1a575e8c8f42eff7630d9278179"
+  },
+  "gochain": {
+    "address": "0x76c2F81716A8D198a00502Ae9a59126418899FDe",
+    "owner": "0x76c2F81716A8D198a00502Ae9a59126418899FDe",
+    "collections": "0x76c2F81716A8D198a00502Ae9a59126418899FDe",
+    "collection_id": "0x76c2F81716A8D198a00502Ae9a59126418899FDe"
+  },
+  "theta": {
+    "address": "0xac0eeb6ee3e32e2c74e14ac74155063e4f4f981f"
+  },
+  "binance": {
+    "address": "bnb1jxfh2g85q3v0tdq56fnevx6xcxtcnhtsmcu64m"
+  },
+  "tezos": {
+    "address": "tz1WCd2jm4uSt4vntk4vSuUWoZQGhLcDuR9q"
+  },
+  "tron": {
+    "address": "TMuA6YqfCeX8EhbfYEg5y7S4DqzSJireY9"
+  },
+  "vechain": {
+    "address": "0xB5e883349e68aB59307d1604555AC890fAC47128"
+  },
+  "ripple": {
+    "address": "rMQ98K56yXJbDGv49ZSmW51sLn94Xe1mu1"
+  },
+  "cosmos": {
+    "address": "cosmos1rw62phusuv9vzraezr55k0vsqssvz6ed52zyrl"
+  },
+  "iotex": {
+    "address": "io1mwekae7qqwlr23220k5n9z3fmjxz72tuchra3m"
+  },
+  "icon": {
+    "address": "hxee691e7bccc4eb11fee922896e9f51490e62b12e"
+  },
+  "stellar": {
+    "address": "GDKIJJIKXLOM2NRMPNQZUUYK24ZPVFC6426GZAEP3KUK6KEJLACCWNMX"
+  },
+  "semux": {
+    "address": "0x8197987c401a3466ad678b2080b24838ebd95b41"
+  },
+  "nimiq": {
+    "address": "NQ86%202H8F%20YGU5%20RM77%20QSN9%20LYLH%20C56A%20CYYR%200MLA"
+  },
+  "nebulas": {
+    "address": "n1RCYwrpLMpSpUCQ8QUDzGRg6B2PnY8R94a"
+  },
+  "aeternity": {
+    "address": "ak_2p5878zbFhxnrm7meL7TmqwtvBaqcBddyp5eGzZbovZ5FeVfcw"
+  },
+  "aion": {
+    "address": "0xa07981da70ce919e1db5f051c3c386eb526e6ce8b9e2bfd56e3f3d754b0a17f3"
+  },
+  "fio": {
+    "address": "FIO5J2xdfWygeNdHZNZRzRws8YGbVxjUXtp4eP8KoGkGKoLFQ7CaU"
+  },
+  "kin": {
+    "address": "GBHKUZ7C2SZ5N3X2S7O6TT6LNUWSEA2BXMSR5GTTSR6VZARSVAXIQNGH"
+  },
+  "ontology": {
+    "address": "AUyL4TZ1zFEcSKDJrjFnD7vsq5iFZMZqT7"
+  },
+  "waves": {
+    "address": "3P7wz6TXienpw3BHe8eHUEuZWb6WE58kgnQ"
   }
 }
+

--- a/pkg/integration/testdata/fixtures.json
+++ b/pkg/integration/testdata/fixtures.json
@@ -1,0 +1,14 @@
+{
+  "0": {
+    "address": "bc1quvuarfksewfeuevuc6tn0kfyptgjvwsvrprk9d",
+    "key": "xpub6CUGRUonZSQ4TWtTMmzXdrXDtypWKiKrhko4egpiMZbpiaQL2jkwSB1icqYh2cfDfVxdx4df189oLKnC5fSwqPfgyP3hooxujYzAu3fDVmz"
+  },
+  "2": {
+    "address": "bc1quvuarfksewfeuevuc6tn0kfyptgjvwsvrprk9d",
+    "key": "xprv9s21ZrQH143K277qXR6NRni1DS7qmSNBs96NmnF5VGdcejgrJtBHzRJYZxqDJZKX1pF5i6gmmDmWDbBCs4DcQ9T1bH65UttBRw2uMaNJnNQ"
+  },
+  "714": {
+    "address": "bnb1jxfh2g85q3v0tdq56fnevx6xcxtcnhtsmcu64m",
+    "key": ""
+  }
+}

--- a/pkg/integration/testdata/fixtures.json
+++ b/pkg/integration/testdata/fixtures.json
@@ -56,46 +56,46 @@
     "key": "xprv9s21ZrQH143K277qXR6NRni1DS7qmSNBs96NmnF5VGdcejgrJtBHzRJYZxqDJZKX1pF5i6gmmDmWDbBCs4DcQ9T1bH65UttBRw2uMaNJnNQ"
   },
   "tomochain": {
-    "address": "0x7cB1Ae1a095Eb51AEd8a1488E866c030E0A78E29",
-    "owner": "0x7cB1Ae1a095Eb51AEd8a1488E866c030E0A78E29",
+    "address": "0x0875BCab22dE3d02402bc38aEe4104e1239374a7",
+    "owner": "0x0875BCab22dE3d02402bc38aEe4104e1239374a7",
     "collections": "0x0875BCab22dE3d02402bc38aEe4104e1239374a7",
-    "collection_id": "0x06012c8cf97bead5deae237070f9587f8e7a266d"
+    "collection_id": "0xfaafdc07907ff5120a76b34b731b278c38d6043c"
   },
   "ethereum": {
     "address": "0x0875BCab22dE3d02402bc38aEe4104e1239374a7",
     "owner": "0x0875BCab22dE3d02402bc38aEe4104e1239374a7",
     "collections": "0x0875BCab22dE3d02402bc38aEe4104e1239374a7",
-    "collection_id": "0x06012c8cf97bead5deae237070f9587f8e7a266d"
+    "collection_id": "0xfaafdc07907ff5120a76b34b731b278c38d6043c"
   },
   "classic": {
-    "address": "0xf3524415b6D873205B4c3Cda783527b2aC4daAA9",
-    "owner": "0xf3524415b6D873205B4c3Cda783527b2aC4daAA9",
+    "address": "0x0875BCab22dE3d02402bc38aEe4104e1239374a7",
+    "owner": "0x0875BCab22dE3d02402bc38aEe4104e1239374a7",
     "collections": "0x0875BCab22dE3d02402bc38aEe4104e1239374a7",
-    "collection_id": "0x06012c8cf97bead5deae237070f9587f8e7a266d"
+    "collection_id": "0xfaafdc07907ff5120a76b34b731b278c38d6043c"
   },
   "poa": {
-    "address": "0x1fddEc96688e0538A316C64dcFd211c491ECf0d8",
-    "owner": "0x1fddEc96688e0538A316C64dcFd211c491ECf0d8",
+    "address": "0x0875BCab22dE3d02402bc38aEe4104e1239374a7",
+    "owner": "0x0875BCab22dE3d02402bc38aEe4104e1239374a7",
     "collections": "0x0875BCab22dE3d02402bc38aEe4104e1239374a7",
-    "collection_id": "0x06012c8cf97bead5deae237070f9587f8e7a266d"
+    "collection_id": "0xfaafdc07907ff5120a76b34b731b278c38d6043c"
   },
   "thundertoken": {
-    "address": "0x0ad80a408eac4f17ba0a9de8a12d8736f60700c3",
-    "owner": "0x0ad80a408eac4f17ba0a9de8a12d8736f60700c3",
+    "address": "0x0875BCab22dE3d02402bc38aEe4104e1239374a7",
+    "owner": "0x0875BCab22dE3d02402bc38aEe4104e1239374a7",
     "collections": "0x0875BCab22dE3d02402bc38aEe4104e1239374a7",
-    "collection_id": "0x06012c8cf97bead5deae237070f9587f8e7a266d"
+    "collection_id": "0xfaafdc07907ff5120a76b34b731b278c38d6043c"
   },
   "callisto": {
-    "address": "0x39ec1c88a7a7c1a575e8c8f42eff7630d9278179",
-    "owner": "0x39ec1c88a7a7c1a575e8c8f42eff7630d9278179",
+    "address": "0x0875BCab22dE3d02402bc38aEe4104e1239374a7",
+    "owner": "0x0875BCab22dE3d02402bc38aEe4104e1239374a7",
     "collections": "0x0875BCab22dE3d02402bc38aEe4104e1239374a7",
-    "collection_id": "0x06012c8cf97bead5deae237070f9587f8e7a266d"
+    "collection_id": "0xfaafdc07907ff5120a76b34b731b278c38d6043c"
   },
   "gochain": {
-    "address": "0x76c2F81716A8D198a00502Ae9a59126418899FDe",
-    "owner": "0x76c2F81716A8D198a00502Ae9a59126418899FDe",
+    "address": "0x0875BCab22dE3d02402bc38aEe4104e1239374a7",
+    "owner": "0x0875BCab22dE3d02402bc38aEe4104e1239374a7",
     "collections": "0x0875BCab22dE3d02402bc38aEe4104e1239374a7",
-    "collection_id": "0x06012c8cf97bead5deae237070f9587f8e7a266d"
+    "collection_id": "0xfaafdc07907ff5120a76b34b731b278c38d6043c"
   },
   "theta": {
     "address": "0xac0eeb6ee3e32e2c74e14ac74155063e4f4f981f"

--- a/pkg/integration/testdata/fixtures.json
+++ b/pkg/integration/testdata/fixtures.json
@@ -58,44 +58,44 @@
   "tomochain": {
     "address": "0x7cB1Ae1a095Eb51AEd8a1488E866c030E0A78E29",
     "owner": "0x7cB1Ae1a095Eb51AEd8a1488E866c030E0A78E29",
-    "collections": "0x7cB1Ae1a095Eb51AEd8a1488E866c030E0A78E29",
-    "collection_id": "0x7cB1Ae1a095Eb51AEd8a1488E866c030E0A78E29"
+    "collections": "0x0875BCab22dE3d02402bc38aEe4104e1239374a7",
+    "collection_id": "0x06012c8cf97bead5deae237070f9587f8e7a266d"
   },
   "ethereum": {
-    "address": "0x52bc44d5378309ee2abf1539bf71de1b7d7be3b5",
-    "owner": "0x52bc44d5378309ee2abf1539bf71de1b7d7be3b5",
-    "collections": "0x52bc44d5378309ee2abf1539bf71de1b7d7be3b5",
-    "collection_id": "0x52bc44d5378309ee2abf1539bf71de1b7d7be3b5"
+    "address": "0x0875BCab22dE3d02402bc38aEe4104e1239374a7",
+    "owner": "0x0875BCab22dE3d02402bc38aEe4104e1239374a7",
+    "collections": "0x0875BCab22dE3d02402bc38aEe4104e1239374a7",
+    "collection_id": "0x06012c8cf97bead5deae237070f9587f8e7a266d"
   },
   "classic": {
     "address": "0xf3524415b6D873205B4c3Cda783527b2aC4daAA9",
     "owner": "0xf3524415b6D873205B4c3Cda783527b2aC4daAA9",
-    "collections": "0xf3524415b6D873205B4c3Cda783527b2aC4daAA9",
-    "collection_id": "0xf3524415b6D873205B4c3Cda783527b2aC4daAA9"
+    "collections": "0x0875BCab22dE3d02402bc38aEe4104e1239374a7",
+    "collection_id": "0x06012c8cf97bead5deae237070f9587f8e7a266d"
   },
   "poa": {
     "address": "0x1fddEc96688e0538A316C64dcFd211c491ECf0d8",
     "owner": "0x1fddEc96688e0538A316C64dcFd211c491ECf0d8",
-    "collections": "0x1fddEc96688e0538A316C64dcFd211c491ECf0d8",
-    "collection_id": "0x1fddEc96688e0538A316C64dcFd211c491ECf0d8"
+    "collections": "0x0875BCab22dE3d02402bc38aEe4104e1239374a7",
+    "collection_id": "0x06012c8cf97bead5deae237070f9587f8e7a266d"
   },
   "thundertoken": {
     "address": "0x0ad80a408eac4f17ba0a9de8a12d8736f60700c3",
     "owner": "0x0ad80a408eac4f17ba0a9de8a12d8736f60700c3",
-    "collections": "0x0ad80a408eac4f17ba0a9de8a12d8736f60700c3",
-    "collection_id": "0x0ad80a408eac4f17ba0a9de8a12d8736f60700c3"
+    "collections": "0x0875BCab22dE3d02402bc38aEe4104e1239374a7",
+    "collection_id": "0x06012c8cf97bead5deae237070f9587f8e7a266d"
   },
   "callisto": {
     "address": "0x39ec1c88a7a7c1a575e8c8f42eff7630d9278179",
     "owner": "0x39ec1c88a7a7c1a575e8c8f42eff7630d9278179",
-    "collections": "0x39ec1c88a7a7c1a575e8c8f42eff7630d9278179",
-    "collection_id": "0x39ec1c88a7a7c1a575e8c8f42eff7630d9278179"
+    "collections": "0x0875BCab22dE3d02402bc38aEe4104e1239374a7",
+    "collection_id": "0x06012c8cf97bead5deae237070f9587f8e7a266d"
   },
   "gochain": {
     "address": "0x76c2F81716A8D198a00502Ae9a59126418899FDe",
     "owner": "0x76c2F81716A8D198a00502Ae9a59126418899FDe",
-    "collections": "0x76c2F81716A8D198a00502Ae9a59126418899FDe",
-    "collection_id": "0x76c2F81716A8D198a00502Ae9a59126418899FDe"
+    "collections": "0x0875BCab22dE3d02402bc38aEe4104e1239374a7",
+    "collection_id": "0x06012c8cf97bead5deae237070f9587f8e7a266d"
   },
   "theta": {
     "address": "0xac0eeb6ee3e32e2c74e14ac74155063e4f4f981f"

--- a/pkg/integration/testdata/fixtures.json
+++ b/pkg/integration/testdata/fixtures.json
@@ -56,16 +56,16 @@
     "key": "xprv9s21ZrQH143K277qXR6NRni1DS7qmSNBs96NmnF5VGdcejgrJtBHzRJYZxqDJZKX1pF5i6gmmDmWDbBCs4DcQ9T1bH65UttBRw2uMaNJnNQ"
   },
   "tomochain": {
-    "address": "TMuA6YqfCeX8EhbfYEg5y7S4DqzSJireY9",
-    "owner": "TMuA6YqfCeX8EhbfYEg5y7S4DqzSJireY9",
-    "collections": "TMuA6YqfCeX8EhbfYEg5y7S4DqzSJireY9",
-    "collection_id": "TMuA6YqfCeX8EhbfYEg5y7S4DqzSJireY9"
+    "address": "0x7cB1Ae1a095Eb51AEd8a1488E866c030E0A78E29",
+    "owner": "0x7cB1Ae1a095Eb51AEd8a1488E866c030E0A78E29",
+    "collections": "0x7cB1Ae1a095Eb51AEd8a1488E866c030E0A78E29",
+    "collection_id": "0x7cB1Ae1a095Eb51AEd8a1488E866c030E0A78E29"
   },
   "ethereum": {
-    "address": "0xfc10cab6a50a1ab10c56983c80cc82afc6559cf1",
-    "owner": "0xfc10cab6a50a1ab10c56983c80cc82afc6559cf1",
-    "collections": "0xfc10cab6a50a1ab10c56983c80cc82afc6559cf1",
-    "collection_id": "0xfc10cab6a50a1ab10c56983c80cc82afc6559cf1"
+    "address": "0x52bc44d5378309ee2abf1539bf71de1b7d7be3b5",
+    "owner": "0x52bc44d5378309ee2abf1539bf71de1b7d7be3b5",
+    "collections": "0x52bc44d5378309ee2abf1539bf71de1b7d7be3b5",
+    "collection_id": "0x52bc44d5378309ee2abf1539bf71de1b7d7be3b5"
   },
   "classic": {
     "address": "0xf3524415b6D873205B4c3Cda783527b2aC4daAA9",
@@ -131,7 +131,7 @@
     "address": "0x8197987c401a3466ad678b2080b24838ebd95b41"
   },
   "nimiq": {
-    "address": "NQ86%202H8F%20YGU5%20RM77%20QSN9%20LYLH%20C56A%20CYYR%200MLA"
+    "address": "NQ94HC9AK9D83FSJM6PT8XGNNMXLR0E53Y07"
   },
   "nebulas": {
     "address": "n1RCYwrpLMpSpUCQ8QUDzGRg6B2PnY8R94a"


### PR DESCRIPTION
# Headline
Add integration tests for Blockatlas API
- [x] Update README

## Solution
All the integration tests are tagged to a different build. Run `make integration` to run the tests. The API application and all tests going be started

To change the fixtures like `address`, `owner` and `collection_id`, change in the `fixtures.json` file. If do you need to exclude some route, just put the route in the file `exclude.json`