### PR TITLE
Add retry for GetBlockByNumber method

### DIFF
--- a/observer/retry.go
+++ b/observer/retry.go
@@ -1,0 +1,31 @@
+package observer
+
+import (
+	"github.com/trustwallet/blockatlas"
+	"math/rand"
+	"time"
+)
+
+type GetBlockByNumber func(num int64) (*blockatlas.Block, error)
+
+type stop struct {
+	error
+}
+
+func retry(attempts int, sleep time.Duration, f GetBlockByNumber, n int64) (*blockatlas.Block, error) {
+	r, err := f(n)
+	if err != nil {
+		if s, ok := err.(stop); ok {
+			return nil, s.error
+		}
+		if attempts--; attempts > 0 {
+			// Add some randomness to prevent creating a Thundering Herd
+			jitter := time.Duration(rand.Int63n(int64(sleep)))
+			sleep = sleep + jitter/2
+
+			time.Sleep(sleep)
+			return retry(attempts, sleep*2, f, n)
+		}
+	}
+	return r, err
+}

--- a/observer/retry_test.go
+++ b/observer/retry_test.go
@@ -2,6 +2,7 @@ package observer
 
 import (
 	"errors"
+	"github.com/sirupsen/logrus"
 	"github.com/trustwallet/blockatlas"
 	"testing"
 	"time"
@@ -15,7 +16,8 @@ func getBlock(num int64) (*blockatlas.Block, error) {
 }
 
 func TestRetry(t *testing.T) {
-	block, err := retry(3, time.Second*1, getBlock, 1)
+	l := logrus.WithField("test", "retry")
+	block, err := retry(3, time.Second*1, getBlock, 1, l)
 	if err != nil {
 		t.Error(err)
 	}
@@ -26,8 +28,9 @@ func TestRetry(t *testing.T) {
 }
 
 func TestRetryError(t *testing.T) {
+	l := logrus.WithField("test", "retry_error")
 	now := time.Now()
-	block, err := retry(3, time.Second*1, getBlock, 0)
+	block, err := retry(3, time.Second*1, getBlock, 0, l)
 	elapsed := time.Since(now)
 	if err == nil {
 		t.Error("retry method need fail")

--- a/observer/retry_test.go
+++ b/observer/retry_test.go
@@ -1,0 +1,43 @@
+package observer
+
+import (
+	"errors"
+	"github.com/trustwallet/blockatlas"
+	"testing"
+	"time"
+)
+
+func getBlock(num int64) (*blockatlas.Block, error) {
+	if num == 0 {
+		return nil, errors.New("teste")
+	}
+	return &blockatlas.Block{}, nil
+}
+
+func TestRetry(t *testing.T) {
+	block, err := retry(3, time.Second*1, getBlock, 1)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if block == nil {
+		t.Error("block is nil")
+	}
+}
+
+func TestRetryError(t *testing.T) {
+	now := time.Now()
+	block, err := retry(3, time.Second*1, getBlock, 0)
+	elapsed := time.Since(now)
+	if err == nil {
+		t.Error("retry method need fail")
+	}
+
+	if block != nil {
+		t.Error("block object need be nil")
+	}
+
+	if elapsed > time.Second*6 {
+		t.Error("Thundering Herd prevent doesn't work")
+	}
+}

--- a/observer/stream.go
+++ b/observer/stream.go
@@ -87,7 +87,7 @@ func (s *Stream) loadBlock(c chan<- *blockatlas.Block, num int64) {
 	s.semaphore.Acquire()
 	defer s.semaphore.Release()
 
-	block, err := s.BlockAPI.GetBlockByNumber(num)
+	block, err := retry(3, time.Second*1, s.BlockAPI.GetBlockByNumber, num)
 	if err != nil {
 		s.log.WithError(err).Errorf("Polling failed: could not get block %d", num)
 		return
@@ -104,3 +104,5 @@ func (s *Stream) loadBlock(c chan<- *blockatlas.Block, num int64) {
 		return
 	}
 }
+
+

--- a/observer/stream.go
+++ b/observer/stream.go
@@ -87,7 +87,7 @@ func (s *Stream) loadBlock(c chan<- *blockatlas.Block, num int64) {
 	s.semaphore.Acquire()
 	defer s.semaphore.Release()
 
-	block, err := retry(3, time.Second*1, s.BlockAPI.GetBlockByNumber, num)
+	block, err := retry(5, time.Second*5, s.BlockAPI.GetBlockByNumber, num, s.log)
 	if err != nil {
 		s.log.WithError(err).Errorf("Polling failed: could not get block %d", num)
 		return
@@ -104,5 +104,3 @@ func (s *Stream) loadBlock(c chan<- *blockatlas.Block, num int64) {
 		return
 	}
 }
-
-


### PR DESCRIPTION
# Headline
Add retry mechanism to the observer fetch transactions inside a block 

Issue [234](https://github.com/trustwallet/blockatlas/issues/234)