### PR TITLE
Use block time instead of transaction time for better format consistency

### DIFF
--- a/platform/tron/api.go
+++ b/platform/tron/api.go
@@ -51,7 +51,6 @@ func Normalize(srcTx *Tx) (tx blockatlas.Tx, ok bool) {
 	switch contract.Parameter.(type) {
 	case TransferContract:
 		transfer := contract.Parameter.(TransferContract)
-
 		from, err := HexToAddress(transfer.Value.OwnerAddress)
 		if err != nil {
 			return tx, false
@@ -64,7 +63,7 @@ func Normalize(srcTx *Tx) (tx blockatlas.Tx, ok bool) {
 		return blockatlas.Tx{
 			ID:   srcTx.ID,
 			Coin: coin.TRX,
-			Date: srcTx.Data.Timestamp / 1000,
+			Date: srcTx.BlockTime,
 			From: from,
 			To:   to,
 			Fee:  "0",

--- a/platform/tron/api_test.go
+++ b/platform/tron/api_test.go
@@ -11,11 +11,11 @@ import (
 
 const transferSrc = `
 {
+	"block_timestamp": 1564797900000,
 	"raw_data": {
 		"contract": [
 			{
 				"parameter": {
-					"type_url": "type.googleapis.com/protocol.TransferContract",
 					"value": {
 						"amount": 100666888000000,
 						"owner_address": "4182dd6b9966724ae2fdc79b416c7588da67ff1b35",
@@ -24,23 +24,8 @@ const transferSrc = `
 				},
 				"type": "TransferContract"
 			}
-		],
-		"expiration": 1551357978000,
-		"fee_limit": 0,
-		"ref_block_bytes": "1c17",
-		"ref_block_hash": "b25737f0375c676b",
-		"timestamp": 1551357920889
+		]
 	},
-	"ret": [
-		{
-			"code": "SUCESS",
-			"contractRet": "SUCCESS",
-			"fee": 0
-		}
-	],
-	"signature": [
-		"f34c94cfa2ac0d9dddfa9febce257684138dcbdfb31886f249f14da7eb8d134331d07e70642cc841d6191269348bc8dd63cc9be217670453d27bfb789572e7e9009000"
-	],
 	"txID": "24a10f7a503e78adc0d7e380b68005531b09e16b9e3f7b524e33f40985d287df"
 }
 `
@@ -51,7 +36,7 @@ var transferDst = blockatlas.Tx{
 	From:   "TMuA6YqfCeX8EhbfYEg5y7S4DqzSJireY9",
 	To:     "TAUN6FwrnwwmaEqYcckffC7wYmbaS6cBiX",
 	Fee:    "0", // TODO
-	Date:   1551357920,
+	Date:   1564797900000,
 	Block:  0, // TODO
 	Status: blockatlas.StatusCompleted,
 	Meta: blockatlas.Transfer{

--- a/platform/tron/model.go
+++ b/platform/tron/model.go
@@ -12,15 +12,13 @@ type Page struct {
 }
 
 type Tx struct {
-	ID   string `json:"txID"`
-	Data TxData `json:"raw_data"`
+	ID          string `json:"txID"`
+	BlockTime   int64  `json:"block_timestamp"`
+	Data 		TxData `json:"raw_data"`
 }
 
 type TxData struct {
 	Contracts     []Contract `json:"contract"`
-	RefBlockBytes string     `json:"ref_block_bytes"`
-	RefBlockHash  string     `json:"ref_block_hash"`
-	Timestamp     int64      `json:"timestamp"`
 }
 
 type Contract struct {


### PR DESCRIPTION
Trongrid api sometime returns trx timestamp as type `string` when `int` expected. Blocktime always returns as `int`, less precise time but good enough.

Fixes https://github.com/trustwallet/blockatlas/issues/212 https://github.com/trustwallet/blockatlas/issues/159