### PR TITLE
Fix integration tests

### DIFF
--- a/pkg/integration/testdata/exclude.json
+++ b/pkg/integration/testdata/exclude.json
@@ -1,3 +1,14 @@
 [
-
+  "/v2/classic/collections/:owner",
+  "/v2/callisto/collections/:owner",
+  "/v2/poa/collections/:owner",
+  "/v2/thundertoken/collections/:owner",
+  "/v2/tomochain/collections/:owner",
+  "/v2/gochain/collections/:owner",
+  "/v2/classic/collections/:owner/collection/:collection_id",
+  "/v2/callisto/collections/:owner/collection/:collection_id",
+  "/v2/poa/collections/:owner/collection/:collection_id",
+  "/v2/thundertoken/collections/:owner/collection/:collection_id",
+  "/v2/tomochain/collections/:owner/collection/:collection_id",
+  "/v2/gochain/collections/:owner/collection/:collection_id"
 ]

--- a/pkg/integration/testdata/fixtures.json
+++ b/pkg/integration/testdata/fixtures.json
@@ -119,7 +119,7 @@
     "address": "cosmos1rw62phusuv9vzraezr55k0vsqssvz6ed52zyrl"
   },
   "iotex": {
-    "address": "io1mwekae7qqwlr23220k5n9z3fmjxz72tuchra3m"
+    "address": "io154mvzs09vkgn0hw6gg3ayzw5w39jzp47f8py9v"
   },
   "icon": {
     "address": "hxee691e7bccc4eb11fee922896e9f51490e62b12e"


### PR DESCRIPTION
# Headline
- Change the address for IOTEX in the integration tests.
- Remove the collection's tests for coins `classic`, `callisto`, `poa`, `thundertoken`, `tomochain`, `gochain`.

## Problem
- The old IOTEX address has a rate limit issue because it has a lot of transactions.
- Sometimes the integration tests for collections API's fail because the Ethereum based coins don't have collections. If you try to use the same environment from Ethereum collections API, we have a rate limit as well.

## Solution
- Use an address with fewer transactions.
- Remove the coins `classic`, `callisto`, `poa`, `thundertoken`, `tomochain`, `gochain` for collection's tests.