### PR TITLE
Fix XRP block parse

### DIFF
--- a/platform/ripple/model.go
+++ b/platform/ripple/model.go
@@ -33,7 +33,7 @@ type Payment struct {
 }
 
 type Meta struct {
-	DeliveredAmount string `json:"delivered_amount"`
+	DeliveredAmount string `json:"delivered_amount,omitempty"`
 }
 
 type LedgerResponse struct {

--- a/platform/ripple/model.go
+++ b/platform/ripple/model.go
@@ -33,7 +33,14 @@ type Payment struct {
 }
 
 type Meta struct {
-	DeliveredAmount string `json:"delivered_amount,omitempty"`
+	DeliveredAmount    string          `json:"delivered_amount,omitempty"`
+	DeliveredAmountObj DeliveredAmount `json:"delivered_amount,omitempty"`
+}
+
+type DeliveredAmount struct {
+	Value    string `json:"value"`
+	Currency string `json:"currency"`
+	Issuer   string `json:"issuer"`
 }
 
 type LedgerResponse struct {


### PR DESCRIPTION
# Headline

Some XRP transactions can be a transaction receipt about from other coins. Like the payload bellow, this is an ETH transaction inside the XRP ledger.

## Problem
We have a problem when we go to marshall the payload because we expect a string from `delivered_amount` field.

## Solution
Create an object to marshall and add `omitempty` flag to the struct.


```
{
  "hash": "1D849E3A0041357EE373C7E17C9564F890047475492D9530B5F20A3BD6D95822",
  "ledger_index": 49841027,
  "date": "2019-09-06T01:48:32+00:00",
  "tx": {
    "TransactionType": "Payment",
    "Flags": 2147942400,
    "Sequence": 292765,
    "LastLedgerSequence": 49841035,
    "Amount": {
      "value": "100000",
      "currency": "ETH",
      "issuer": "rJavT3eWaX9FubZFHtCvymJ6ZhSgJdMyNx"
    },
    "Fee": "162",
    "SendMax": "100000000000",
    "Account": "r4NT6UfELQyoS689VLye22B3SfgvpM3nHY",
    "Destination": "rJavT3eWaX9FubZFHtCvymJ6ZhSgJdMyNx"
  },
  "meta": {
    "TransactionIndex": 16,
    "DeliveredAmount": {
      "value": "533.92",
      "currency": "ETH",
      "issuer": "rJavT3eWaX9FubZFHtCvymJ6ZhSgJdMyNx"
    },
    "TransactionResult": "tesSUCCESS",
    "delivered_amount": {
      "value": "533.92",
      "currency": "ETH",
      "issuer": "rJavT3eWaX9FubZFHtCvymJ6ZhSgJdMyNx"
    }
  }
}
```