### PR TITLE
Add validators list to Tron platform

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -93,7 +93,7 @@ icon:
 
 # [TRX] Tron: https://tron.network/
 tron:
-  api: https://api.trongrid.io/v1
+  api: https://api.trongrid.io
 
 # [VET] VeChain: https://www.vechain.org
 vechain:

--- a/platform/tezos/api.go
+++ b/platform/tezos/api.go
@@ -69,13 +69,13 @@ func (p *Platform) GetValidators() (blockatlas.ValidatorPage, error) {
 	}
 
 	for _, v := range validators {
-		results = append(results, normalizeValidator(v, p.Coin()))
+		results = append(results, normalizeValidator(v))
 	}
 
 	return results, nil
 }
 
-func normalizeValidator(v Validator, c coin.Coin) (validator blockatlas.Validator) {
+func normalizeValidator(v Validator) (validator blockatlas.Validator) {
 	// How to calculate Tezos APR? I have no idea. Tezos team does not know either. let's assume it's around 7% - no way to calculate in decentralized manner
 	// Delegation rewards distributed by the validators manually, it's up to them to do it.
 

--- a/platform/tezos/api_test.go
+++ b/platform/tezos/api_test.go
@@ -88,14 +88,13 @@ func TestNormalize(t *testing.T) {
 func TestNormalizeValidator(t *testing.T) {
 	var v Validator
 	_ = json.Unmarshal([]byte(validatorSrc), &v)
-	coin := coin.Coin{}
 	expected := blockatlas.Validator{
 		Status: true,
 		ID:     v.Address,
 		Reward: blockatlas.StakingReward{Annual: Annual},
 	}
 
-	result := normalizeValidator(v, coin)
+	result := normalizeValidator(v)
 
 	assert.Equal(t, result, expected)
 }

--- a/platform/tron/api.go
+++ b/platform/tron/api.go
@@ -60,7 +60,7 @@ func (p *Platform) GetValidators() (blockatlas.ValidatorPage, error) {
 func normalizeValidator(v Validator) (validator blockatlas.Validator, ok bool) {
 	address, err := HexToAddress(v.Address)
 	if err != nil {
-		return blockatlas.Validator{}, false
+		return validator, false
 	}
 
 	return blockatlas.Validator{

--- a/platform/tron/api.go
+++ b/platform/tron/api.go
@@ -49,20 +49,25 @@ func (p *Platform) GetValidators() (blockatlas.ValidatorPage, error) {
 	}
 
 	for _, v := range validators.Witnesses {
-		results = append(results, normalizeValidator(v))
+		if val, ok := normalizeValidator(v); ok {
+			results = append(results, val)
+		}
 	}
 
 	return results, nil
 }
 
-func normalizeValidator(v Validator) (validator blockatlas.Validator) {
-	address, _ := HexToAddress(v.Address)
+func normalizeValidator(v Validator) (validator blockatlas.Validator, ok bool) {
+	address, err := HexToAddress(v.Address)
+	if err != nil {
+		return blockatlas.Validator{}, false
+	}
 
 	return blockatlas.Validator{
 		Status: true,
 		ID:     address,
 		Reward: blockatlas.StakingReward{Annual: Annual},
-	}
+	}, true
 }
 
 /// Normalize converts a Tron transaction into the generic model

--- a/platform/tron/api_test.go
+++ b/platform/tron/api_test.go
@@ -104,3 +104,17 @@ func TestNormalizeToken(t *testing.T) {
 
 	assert.Equal(t, tokenDst, actual)
 }
+
+func TestNormalizeValidator(t *testing.T) {
+	validator := Validator{Address: "414d1ef8673f916debb7e2515a8f3ecaf2611034aa"}
+
+	actual := normalizeValidator(validator)
+	expected := blockatlas.Validator{
+		ID:     "TGzz8gjYiYRqpfmDwnLxfgPuLVNmpCswVp",
+		Status: true,
+		Reward: blockatlas.StakingReward{
+			Annual,
+		},
+	}
+	assert.Equal(t, expected, actual)
+}

--- a/platform/tron/api_test.go
+++ b/platform/tron/api_test.go
@@ -108,7 +108,7 @@ func TestNormalizeToken(t *testing.T) {
 func TestNormalizeValidator(t *testing.T) {
 	validator := Validator{Address: "414d1ef8673f916debb7e2515a8f3ecaf2611034aa"}
 
-	actual := normalizeValidator(validator)
+	actual, _ := normalizeValidator(validator)
 	expected := blockatlas.Validator{
 		ID:     "TGzz8gjYiYRqpfmDwnLxfgPuLVNmpCswVp",
 		Status: true,

--- a/platform/tron/client.go
+++ b/platform/tron/client.go
@@ -48,7 +48,7 @@ func (c *Client) GetAccountMetadata(address string) (*Accounts, error) {
 }
 
 func (c *Client) GetTokenInfo(id string) (*Asset, error) {
-	path := fmt.Sprintf("assets/%s", id)
+	path := fmt.Sprintf("v1/assets/%s", id)
 
 	var asset Asset
 	err := c.Request.Get(&asset, c.BaseURL, path, nil)

--- a/platform/tron/client.go
+++ b/platform/tron/client.go
@@ -1,7 +1,6 @@
 package tron
 
 import (
-	"encoding/json"
 	"fmt"
 	"github.com/trustwallet/blockatlas"
 	"github.com/trustwallet/blockatlas/pkg/logger"
@@ -11,66 +10,57 @@ import (
 )
 
 type Client struct {
-	HTTPClient *http.Client
-	BaseURL    string
+	Request blockatlas.Request
+	BaseURL string
+}
+
+func InitClient(BaseURL string) Client {
+	return Client{
+		BaseURL: BaseURL,
+		Request: blockatlas.Request{
+			HttpClient: http.DefaultClient,
+			ErrorHandler: func(res *http.Response, uri string) error {
+				return nil
+			},
+		},
+	}
 }
 
 func (c *Client) GetTxsOfAddress(address string) ([]Tx, error) {
-	uri := fmt.Sprintf("%s/accounts/%s/transactions?%s",
-		c.BaseURL,
-		url.PathEscape(address),
-		url.Values{
-			"only_confirmed": {"true"},
-			"limit":          {strconv.Itoa(blockatlas.TxPerPage)},
-		}.Encode())
-	httpRes, err := c.HTTPClient.Get(uri)
-	if err != nil {
-		logger.Error(err, "Tron: Failed to get transactions")
-		return nil, blockatlas.ErrSourceConn
-	}
-	defer httpRes.Body.Close()
+	path := fmt.Sprintf("v1/accounts/%s/transactions", url.PathEscape(address))
 
-	var res Page
-	err = json.NewDecoder(httpRes.Body).Decode(&res)
-	if err != nil {
-		logger.Error(err, "Tron: Failed to decode API response")
-		return nil, blockatlas.ErrSourceConn
-	}
+	var txs Page
+	err := c.Request.Get(&txs, c.BaseURL, path, url.Values{
+		"only_confirmed": {"true"},
+		"limit":          {strconv.Itoa(blockatlas.TxPerPage)},
+	})
 
-	if !res.Success {
-		logger.Error("Tron: API returned error", res.Error)
-		return nil, blockatlas.ErrSourceConn
-	}
-
-	return res.Txs, nil
+	return txs.Txs, err
 }
 
 func (c *Client) GetAccountMetadata(address string) (*Accounts, error) {
-	uri := fmt.Sprintf("%s/accounts/%s", c.BaseURL, address)
+	path := fmt.Sprintf("v1/accounts/%s", address)
 
-	res, err := c.HTTPClient.Get(uri)
-	if err != nil {
-		logger.Error(err, "TRON: Failed to get account tokens")
-		return nil, blockatlas.ErrSourceConn
-	}
-	defer res.Body.Close()
+	var accounts Accounts
+	err := c.Request.Get(&accounts, c.BaseURL, path, nil)
 
-	v2 := new(Accounts)
-	err = json.NewDecoder(res.Body).Decode(v2)
-	return v2, nil
+	return &accounts, err
 }
 
 func (c *Client) GetTokenInfo(id string) (*Asset, error) {
-	uri := fmt.Sprintf("%s/assets/%s", c.BaseURL, id)
+	path := fmt.Sprintf("assets/%s", id)
 
-	res, err := c.HTTPClient.Get(uri)
+	var asset Asset
+	err := c.Request.Get(&asset, c.BaseURL, path, nil)
+
+	return &asset, err
+}
+
+func (c *Client) GetValidators() (validators Validators, err error) {
+	err = c.Request.Get(&validators, c.BaseURL, "wallet/listwitnesses", nil)
 	if err != nil {
-		logger.Error(err, "TRON: Failed to get token info", logger.Params{"id": id})
-		return nil, blockatlas.ErrSourceConn
+		logger.Error(err, "Tron: Failed to get validators for address")
+		return validators, err
 	}
-	defer res.Body.Close()
-
-	asset := new(Asset)
-	err = json.NewDecoder(res.Body).Decode(asset)
-	return asset, nil
+	return validators, err
 }

--- a/platform/tron/model.go
+++ b/platform/tron/model.go
@@ -12,13 +12,13 @@ type Page struct {
 }
 
 type Tx struct {
-	ID          string `json:"txID"`
-	BlockTime   int64  `json:"block_timestamp"`
-	Data 		TxData `json:"raw_data"`
+	ID        string `json:"txID"`
+	BlockTime int64  `json:"block_timestamp"`
+	Data      TxData `json:"raw_data"`
 }
 
 type TxData struct {
-	Contracts     []Contract `json:"contract"`
+	Contracts []Contract `json:"contract"`
 }
 
 type Contract struct {
@@ -57,6 +57,14 @@ type AssetInfo struct {
 	Symbol   string `json:"abbr"`
 	ID       string `json:"id"`
 	Decimals uint   `json:"precision"`
+}
+
+type Validators struct {
+	Witnesses []Validator `json:"witnesses"`
+}
+
+type Validator struct {
+	Address string `json:"address"`
 }
 
 func (c *Contract) UnmarshalJSON(buf []byte) error {

--- a/services/assets/client.go
+++ b/services/assets/client.go
@@ -2,6 +2,7 @@ package assets
 
 import (
 	"github.com/trustwallet/blockatlas"
+	"strings"
 	"time"
 
 	"github.com/trustwallet/blockatlas/coin"
@@ -55,5 +56,5 @@ func NormalizeValidator(plainValidator blockatlas.Validator, validator AssetVali
 }
 
 func GetImage(c coin.Coin, ID string) string {
-	return AssetsURL + c.Handle + "/validators/assets/" + ID + "/logo.png"
+	return AssetsURL + c.Handle + "/validators/assets/" + strings.ToLower(ID) + "/logo.png"
 }

--- a/services/assets/client_test.go
+++ b/services/assets/client_test.go
@@ -38,9 +38,9 @@ var expectedStakeValidator = blockatlas.StakeValidator{
 }
 
 func TestGetImage(t *testing.T) {
-	image := GetImage(c, "cosmosvaloper1qwl879nx9t6kef4supyazayf7vjhennyh568ys")
+	image := GetImage(c, "TGzz8gjYiYRqpfmDwnLxfgPuLVNmpCswVp")
 
-	expected := "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/cosmos/validators/assets/cosmosvaloper1qwl879nx9t6kef4supyazayf7vjhennyh568ys/logo.png"
+	expected := "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/cosmos/validators/assets/tgzz8gjyiyrqpfmdwnlxfgpulvnmpcswvp/logo.png"
 
 	assert.Equal(t, expected, image)
 }


### PR DESCRIPTION
Implemented: https://github.com/trustwallet/blockatlas/issues/246

`v2/tron/staking/validators`:
```
{
   "docs":[
      {
         "id":"TGzz8gjYiYRqpfmDwnLxfgPuLVNmpCswVp",
         "status":true,
         "info":{
            "name":"Sesameseed",
            "description":"Sesameseed is a blockchain community providing fair and transparent representation in delegated governance.",
            "image":"https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/validators/assets/tgzz8gjyiyrqpfmdwnlxfgpulvnmpcswvp/logo.png",
            "website":"https://www.sesameseed.org"
         },
         "reward":{
            "annual":4.32
         }
      }
   ]
}
```
