### PR TITLE
fix xpub prefix and avoid save xpub without addresses

### DIFF
--- a/cmd/api/observer.go
+++ b/cmd/api/observer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/trustwallet/blockatlas/platform/bitcoin"
 	"net/http"
 	"strconv"
+	"strings"
 )
 
 func setupObserverAPI(router gin.IRouter) {
@@ -67,6 +68,7 @@ func addCall(c *gin.Context) {
 		}
 
 		for _, xpub := range perCoin {
+			xpub = strings.TrimPrefix(xpub, "xpub:")
 			xpubSubs = append(xpubSubs, observer.Subscription{
 				Coin:     uint(coin),
 				Address:  xpub,
@@ -88,7 +90,7 @@ func addCall(c *gin.Context) {
 func cacheXPubAddress(xpub string, coin uint) {
 	platform := bitcoin.UtxoPlatform(coin)
 	addresses, err := platform.GetAddressesFromXpub(xpub)
-	if err != nil {
+	if err != nil || len(addresses) == 0 {
 		logger.Error("GetAddressesFromXpub", err, logger.Params{
 			"xpub": xpub,
 			"coin": coin,

--- a/observer/storage/redis/storage.go
+++ b/observer/storage/redis/storage.go
@@ -40,6 +40,10 @@ func (s *Storage) SetBlockNumber(coin uint, num int64) error {
 }
 
 func (s *Storage) SaveXpubAddresses(coin uint, addresses []string, xpub string) error {
+	if len(addresses) == 0 {
+		return fmt.Errorf("no addresses for xpub: %s", xpub)
+	}
+	
 	a := make(map[string]interface{})
 	for _, address := range addresses {
 		a[address] = xpub


### PR DESCRIPTION
# Headline
- Fix xpub with wrong prefix;
- Avoid to save xpub without addresses;


[Issue 338](https://github.com/trustwallet/blockatlas/issues/338)
[Sentry](https://sentry.io/organizations/trustwallet/issues/1216671764/events/fb344014f9f14980a4b0907495034215/?project=1722581&query=is%3Aunresolved&statsPeriod=14d)