### PR TITLE
Fix ERC1155 token list support

### DIFF
--- a/platform/ethereum/api.go
+++ b/platform/ethereum/api.go
@@ -15,6 +15,7 @@ import (
 
 var (
 	supportedTypes = map[string]bool{"ERC721": true, "ERC1155": true}
+	slugTokens     = map[string]bool{"ERC1155": true}
 )
 
 type Platform struct {
@@ -223,16 +224,17 @@ func NormalizeCollectionPage(collections []Collection, coinIndex uint, owner str
 }
 
 func NormalizeCollection(c Collection, coinIndex uint, owner string) blockatlas.Collection {
-	var symbol, version = "", ""
-	cType := "ERC1155"
+	var symbol, version, cType, categoryAddress = "", "", "", ""
 	description := c.Description
-	categoryAddress := c.Slug
 	if len(c.Contracts) > 0 {
 		description = getValidParameter(c.Contracts[0].Description, description)
 		symbol = getValidParameter(c.Contracts[0].Symbol, symbol)
 		categoryAddress = getValidParameter(c.Contracts[0].Address, categoryAddress)
 		version = getValidParameter(c.Contracts[0].NftVersion, version)
 		cType = getValidParameter(c.Contracts[0].Type, cType)
+	}
+	if _, ok := slugTokens[cType]; ok {
+		categoryAddress = c.Slug
 	}
 	return blockatlas.Collection{
 		Name:            c.Name,
@@ -262,13 +264,14 @@ func NormalizeCollectiblePage(c *Collection, srcPage []Collectible, coinIndex ui
 }
 
 func NormalizeCollectible(c *Collection, a Collectible, coinIndex uint) blockatlas.Collectible {
-	var address, externalLink = "", ""
-	cType := "ERC1155"
-	collectionID := c.Slug
+	var address, externalLink, collectionID, cType = "", "", "", ""
 	if len(c.Contracts) > 0 {
 		address = getValidParameter(c.Contracts[0].Address, address)
 		cType = getValidParameter(c.Contracts[0].Type, cType)
 		collectionID = address
+	}
+	if _, ok := slugTokens[cType]; ok {
+		collectionID = c.Slug
 	}
 	externalLink = getValidParameter(a.ExternalLink, a.AssetContract.ExternalLink)
 	return blockatlas.Collectible{

--- a/platform/ethereum/api.go
+++ b/platform/ethereum/api.go
@@ -256,6 +256,9 @@ func NormalizeCollection(c Collection, coinIndex uint, owner string) blockatlas.
 }
 
 func NormalizeCollectiblePage(c *Collection, srcPage []Collectible, coinIndex uint) (page blockatlas.CollectiblePage) {
+	if len(c.Contracts) == 0 {
+		return
+	}
 	for _, src := range srcPage {
 		item := NormalizeCollectible(c, src, coinIndex)
 		if _, ok := supportedTypes[item.Type]; !ok {
@@ -267,16 +270,13 @@ func NormalizeCollectiblePage(c *Collection, srcPage []Collectible, coinIndex ui
 }
 
 func NormalizeCollectible(c *Collection, a Collectible, coinIndex uint) blockatlas.Collectible {
-	var address, externalLink, collectionID, collectionType = "", "", "", ""
-	if len(c.Contracts) > 0 {
-		address = getValidParameter(c.Contracts[0].Address, address)
-		collectionType = getValidParameter(c.Contracts[0].Type, collectionType)
-		collectionID = address
-	}
+	address := getValidParameter(c.Contracts[0].Address, "")
+	collectionType := getValidParameter(c.Contracts[0].Type, "")
+	collectionID := address
 	if _, ok := slugTokens[collectionType]; ok {
-		collectionID = c.Slug
+		collectionID = createCategoryAddress(address, c.Slug)
 	}
-	externalLink = getValidParameter(a.ExternalLink, a.AssetContract.ExternalLink)
+	externalLink := getValidParameter(a.ExternalLink, a.AssetContract.ExternalLink)
 	return blockatlas.Collectible{
 		CollectionID:     collectionID,
 		ContractAddress:  address,

--- a/platform/ethereum/api_test.go
+++ b/platform/ethereum/api_test.go
@@ -323,33 +323,46 @@ const collectionsSrc = `
   {
     "primary_asset_contracts": [
       {
-        "address": "0xfaafdc07907ff5120a76b34b731b278c38d6043c",
-        "name": "Enjin",
-        "symbol": "",
-        "description": "",
-        "external_link": null,
-        "nft_version": null,
-        "schema_name": "ERC1155",
-        "display_data": {}
+        "address": "0x06012c8cf97bead5deae237070f9587f8e7a266d",
+        "name": "CryptoKitties",
+        "symbol": "CKITTY",
+        "description": "CryptoKitties is a game centered around breedable, collectible, and oh-so-adorable creatures we call CryptoKitties! Each cat is one-of-a-kind and 100% owned by you; it cannot be replicated, taken away, or destroyed.",
+        "external_link": "https://www.cryptokitties.co/",
+        "nft_version": "1.0",
+        "schema_name": "ERC721",
+        "display_data": {
+          "images": [
+            "https://storage.googleapis.com/ck-kitty-image/0x06012c8cf97bead5deae237070f9587f8e7a266d/564155.svg",
+            "https://storage.googleapis.com/ck-kitty-image/0x06012c8cf97bead5deae237070f9587f8e7a266d/546630.svg",
+            "https://storage.googleapis.com/ck-kitty-image/0x06012c8cf97bead5deae237070f9587f8e7a266d/441529.svg",
+            "https://storage.googleapis.com/ck-kitty-image/0x06012c8cf97bead5deae237070f9587f8e7a266d/552435.svg",
+            "https://storage.googleapis.com/ck-kitty-image/0x06012c8cf97bead5deae237070f9587f8e7a266d/524748.png",
+            "https://storage.googleapis.com/ck-kitty-image/0x06012c8cf97bead5deae237070f9587f8e7a266d/540800.svg"
+          ],
+          "card_display_style": "padded"
+        },
+        "image_url": "https://storage.opensea.io/0x06012c8cf97bead5deae237070f9587f8e7a266d-featured-1556588705.png"
       }
     ],
-    "name": "Enjin",
-    "slug": "enjin",
-    "image_url": "https://storage.opensea.io/0x8562c38485b1e8ccd82e44f89823da76c98eb0ab-featured-1556588805.png",
-    "description": "Enjin assets are unique digital ERC1155 assets used in a variety of games in the Enjin multiverse.",
-    "external_url": "https://enj1155.com",
-    "owned_asset_count": 1
+    "name": "CryptoKitties",
+    "slug": "cryptokitties",
+    "image_url": "https://storage.opensea.io/0x06012c8cf97bead5deae237070f9587f8e7a266d-featured-1556588705.png",
+    "description": "CryptoKitties is a game centered around breedable, collectible, and oh-so-adorable creatures we call CryptoKitties! Each cat is one-of-a-kind and 100% owned by you; it cannot be replicated, taken away, or destroyed.",
+    "external_url": "https://www.cryptokitties.co/",
+    "featured_image_url": "https://storage.opensea.io/0x06012c8cf97bead5deae237070f9587f8e7a266d-featured-1556589429.png",
+    "created_date": "2019-04-26T22:13:04.207050",
+    "owned_asset_count": 3
   },
   {
     "primary_asset_contracts": [
       {
         "address": "0xf629cbd94d3791c9250152bd8dfbdf380e2a3b9c",
-        "name": "EnjinCoin",
+        "name": "Coin",
         "symbol": "",
         "description": null,
         "external_link": null,
         "nft_version": null,
-		"schema_name": "ERC20",
+        "schema_name": "ERC20",
         "display_data": {}
       }
     ],
@@ -361,41 +374,57 @@ const collectionsSrc = `
     "owned_asset_count": 20000000000000000000
   },
   {
-    "primary_asset_contracts": [],
-    "name": "Dissolution",
-    "slug": "dissolution",
-    "image_url": "https://storage.opensea.io/dissolution-1566503734.png",
-    "description": "tactical FPS combat in a cutthroat universe ravaged by an ongoing war of extinction between humanity and AI. Fight for loot backed by blockchain in competitive game modes.",
-    "external_url": "https://dissolution.online",
-    "owned_asset_count": 20
+    "primary_asset_contracts": [
+      {
+        "address": "0xfaafdc07907ff5120a76b34b731b278c38d6043c",
+        "name": "Enjin",
+        "symbol": "",
+        "description": "",
+        "external_link": null,
+        "nft_version": null,
+        "schema_name": "ERC1155",
+        "display_data": {},
+        "owner": null,
+        "created_date": "2019-08-02T23:43:14.666153",
+        "asset_contract_type": "semi-fungible"
+      }
+    ],
+    "name": "Age of Rust",
+    "slug": "age-of-rust",
+    "image_url": "https://storage.opensea.io/age-of-rust-1561960816.jpg",
+    "description": "Year 4424: The search begins for new life on the other side of the galaxy. Explore abandoned space stations, mysterious caverns, and ruins on far away worlds in order to unlock puzzles and secrets! Beware the rogue machines!",
+    "external_url": "https://www.ageofrust.games/",
+    "featured_image_url": null,
+    "created_date": "2019-09-03T02:35:56.063685",
+    "owned_asset_count": 1
   }
 ]
 `
 
 var collection1Dst = blockatlas.Collection{
-	Name:            "Enjin",
-	Symbol:          "",
-	Slug:            "enjin",
-	ImageUrl:        "https://storage.opensea.io/0x8562c38485b1e8ccd82e44f89823da76c98eb0ab-featured-1556588805.png",
-	Description:     "Enjin assets are unique digital ERC1155 assets used in a variety of games in the Enjin multiverse.",
-	ExternalLink:    "https://enj1155.com",
-	Total:           1,
-	CategoryAddress: "0xfaafdc07907ff5120a76b34b731b278c38d6043c",
+	Name:            "CryptoKitties",
+	Symbol:          "CKITTY",
+	Slug:            "cryptokitties",
+	ImageUrl:        "https://storage.opensea.io/0x06012c8cf97bead5deae237070f9587f8e7a266d-featured-1556588705.png",
+	Description:     "CryptoKitties is a game centered around breedable, collectible, and oh-so-adorable creatures we call CryptoKitties! Each cat is one-of-a-kind and 100% owned by you; it cannot be replicated, taken away, or destroyed.",
+	ExternalLink:    "https://www.cryptokitties.co/",
+	Total:           3,
+	CategoryAddress: "0x06012c8cf97bead5deae237070f9587f8e7a266d",
 	Address:         "0x0875BCab22dE3d02402bc38aEe4104e1239374a7",
-	Version:         "",
+	Version:         "1.0",
 	Coin:            60,
-	Type:            "ERC1155",
+	Type:            "ERC721",
 }
 
 var collection2Dst = blockatlas.Collection{
-	Name:            "Dissolution",
+	Name:            "Age of Rust",
 	Symbol:          "",
-	Slug:            "dissolution",
-	ImageUrl:        "https://storage.opensea.io/dissolution-1566503734.png",
-	Description:     "tactical FPS combat in a cutthroat universe ravaged by an ongoing war of extinction between humanity and AI. Fight for loot backed by blockchain in competitive game modes.",
-	ExternalLink:    "https://dissolution.online",
-	Total:           20,
-	CategoryAddress: "dissolution",
+	Slug:            "age-of-rust",
+	ImageUrl:        "https://storage.opensea.io/age-of-rust-1561960816.jpg",
+	Description:     "Year 4424: The search begins for new life on the other side of the galaxy. Explore abandoned space stations, mysterious caverns, and ruins on far away worlds in order to unlock puzzles and secrets! Beware the rogue machines!",
+	ExternalLink:    "https://www.ageofrust.games/",
+	Total:           1,
+	CategoryAddress: "age-of-rust",
 	Address:         "0x0875BCab22dE3d02402bc38aEe4104e1239374a7",
 	Version:         "",
 	Coin:            60,
@@ -415,34 +444,36 @@ func TestNormalizeCollection(t *testing.T) {
 const collectibleSrc = `
 [
   {
-    "token_id": "36185027886661312632864264926498481399258436586721613871817000674017446723584",
-    "image_url": "https://storage.opensea.io/0xfaafdc07907ff5120a76b34b731b278c38d6043c/36185027886661312632864264926498481399258436586721613871817000674017446723584-1565973585.jpg",
-    "image_preview_url": "https://storage.opensea.io/0xfaafdc07907ff5120a76b34b731b278c38d6043c-preview/36185027886661312632864264926498481399258436586721613871817000674017446723584-1565973586.png",
-    "name": "Aeonclipse Key",
-    "description": "Forged by unknown, mystical entities at the very beginning of the multiverse, countless Aeonclipse keys were taken by a group of Architects and dispersed through their creations—entire universes. The keys are said to unlock Primythical Chests, legendary vaults hiding immense treasures.",
+    "token_id": "54277541829991970107421667568590323026590803461896874578610080514640537714688",
+    "image_url": "https://storage.opensea.io/0xfaafdc07907ff5120a76b34b731b278c38d6043c/54277541829991970107421667568590323026590803461896874578610080514640537714688-1564858806.png",
+    "image_preview_url": "https://storage.opensea.io/0xfaafdc07907ff5120a76b34b731b278c38d6043c-preview/54277541829991970107421667568590323026590803461896874578610080514640537714688-1564858807.png",
+    "name": "Rustbits",
+    "description": "Rustbits are the main token of use within the Age of Rust game universe. You need Rustbits to not only play Age of Rust, but also to purchase in-game cryptoitems as well. Rustbits are radioactive rust scraped off of hulls of abandoned ships that are in orbit around a hidden planet, which is also a gas giant. The planet is so radioactive, it damages ships and kills anyone that gets close to it. Getting bits of rust off of ships is highly rare and prized.",
     "external_link": "",
     "asset_contract": {
       "address": "0xfaafdc07907ff5120a76b34b731b278c38d6043c",
       "name": "Enjin",
       "external_link": null,
       "nft_version": null,
-      "schema_name": "ERC1155"
+      "schema_name": "ERC1155",
+	  "display_data": {}
     },
-    "permalink": "https://opensea.io/assets/0xfaafdc07907ff5120a76b34b731b278c38d6043c/36185027886661312632864264926498481399258436586721613871817000674017446723584"
+    "permalink": "https://opensea.io/assets/0xfaafdc07907ff5120a76b34b731b278c38d6043c/54277541829991970107421667568590323026590803461896874578610080514640537714688"
   }
 ]
 `
 
 var collectibleCollectionDst = Collection{
-	Name:        "Enjin",
-	ImageUrl:    "https://storage.opensea.io/0x8562c38485b1e8ccd82e44f89823da76c98eb0ab-featured-1556588805.png",
-	Description: "Enjin assets are unique digital ERC1155 assets used in a variety of games in the Enjin multiverse.",
-	ExternalUrl: "https://enj1155.com",
+	Name:        "Age of Rust",
+	ImageUrl:    "https://storage.opensea.io/age-of-rust-1561960816.jpg",
+	Description: "Year 4424: The search begins for new life on the other side of the galaxy. Explore abandoned space stations, mysterious caverns, and ruins on far away worlds in order to unlock puzzles and secrets! Beware the rogue machines!",
+	ExternalUrl: "https://www.ageofrust.games/",
 	Total:       big.NewInt(1),
+	Slug:        "age-of-rust",
 	Contracts: []PrimaryAssetContract{
 		{
-			Name:        "Enjin",
-			Address:     "0xfaafdc07907ff5120a76b34b731b278c38d6043c",
+			Name:        "Age of Rust",
+			Address:     "0x5574Cd97432cEd0D7Caf58ac3c4fEDB2061C98fB",
 			NftVersion:  "",
 			Symbol:      "",
 			Description: "",
@@ -453,18 +484,18 @@ var collectibleCollectionDst = Collection{
 }
 
 var collectibleDst = blockatlas.Collectible{
-	CollectionID:     "0xfaafdc07907ff5120a76b34b731b278c38d6043c",
-	TokenID:          "36185027886661312632864264926498481399258436586721613871817000674017446723584",
+	CollectionID:     "age-of-rust",
+	TokenID:          "54277541829991970107421667568590323026590803461896874578610080514640537714688",
 	CategoryContract: "0xfaafdc07907ff5120a76b34b731b278c38d6043c",
-	ContractAddress:  "0xfaafdc07907ff5120a76b34b731b278c38d6043c",
-	Category:         "Enjin",
-	ImageUrl:         "https://storage.opensea.io/0xfaafdc07907ff5120a76b34b731b278c38d6043c-preview/36185027886661312632864264926498481399258436586721613871817000674017446723584-1565973586.png",
+	ContractAddress:  "0x5574Cd97432cEd0D7Caf58ac3c4fEDB2061C98fB",
+	Category:         "Age of Rust",
+	ImageUrl:         "https://storage.opensea.io/0xfaafdc07907ff5120a76b34b731b278c38d6043c-preview/54277541829991970107421667568590323026590803461896874578610080514640537714688-1564858807.png",
 	ExternalLink:     "",
-	ProviderLink:     "https://opensea.io/assets/0xfaafdc07907ff5120a76b34b731b278c38d6043c/36185027886661312632864264926498481399258436586721613871817000674017446723584",
+	ProviderLink:     "https://opensea.io/assets/0xfaafdc07907ff5120a76b34b731b278c38d6043c/54277541829991970107421667568590323026590803461896874578610080514640537714688",
 	Type:             "ERC1155",
-	Description:      "Forged by unknown, mystical entities at the very beginning of the multiverse, countless Aeonclipse keys were taken by a group of Architects and dispersed through their creations—entire universes. The keys are said to unlock Primythical Chests, legendary vaults hiding immense treasures.",
+	Description:      "Rustbits are the main token of use within the Age of Rust game universe. You need Rustbits to not only play Age of Rust, but also to purchase in-game cryptoitems as well. Rustbits are radioactive rust scraped off of hulls of abandoned ships that are in orbit around a hidden planet, which is also a gas giant. The planet is so radioactive, it damages ships and kills anyone that gets close to it. Getting bits of rust off of ships is highly rare and prized.",
 	Coin:             60,
-	Name:             "Aeonclipse Key",
+	Name:             "Rustbits",
 }
 
 func TestNormalizeCollectible(t *testing.T) {

--- a/platform/ethereum/api_test.go
+++ b/platform/ethereum/api_test.go
@@ -484,7 +484,7 @@ var collectibleCollectionDst = Collection{
 }
 
 var collectibleDst = blockatlas.Collectible{
-	CollectionID:     "age-of-rust",
+	CollectionID:     "0x5574Cd97432cEd0D7Caf58ac3c4fEDB2061C98fB---age-of-rust",
 	TokenID:          "54277541829991970107421667568590323026590803461896874578610080514640537714688",
 	CategoryContract: "0xfaafdc07907ff5120a76b34b731b278c38d6043c",
 	ContractAddress:  "0x5574Cd97432cEd0D7Caf58ac3c4fEDB2061C98fB",

--- a/platform/ethereum/api_test.go
+++ b/platform/ethereum/api_test.go
@@ -424,7 +424,7 @@ var collection2Dst = blockatlas.Collection{
 	Description:     "Year 4424: The search begins for new life on the other side of the galaxy. Explore abandoned space stations, mysterious caverns, and ruins on far away worlds in order to unlock puzzles and secrets! Beware the rogue machines!",
 	ExternalLink:    "https://www.ageofrust.games/",
 	Total:           1,
-	CategoryAddress: "age-of-rust",
+	CategoryAddress: "0xfaafdc07907ff5120a76b34b731b278c38d6043c---age-of-rust",
 	Address:         "0x0875BCab22dE3d02402bc38aEe4104e1239374a7",
 	Version:         "",
 	Coin:            60,

--- a/platform/ethereum/collections_client.go
+++ b/platform/ethereum/collections_client.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-	"strings"
 )
 
 type CollectionsClient struct {
@@ -42,7 +41,8 @@ func (c CollectionsClient) GetCollectibles(owner string, collectibleID string) (
 	if err != nil {
 		return nil, nil, err
 	}
-	collection := searchCollection(&collections, collectibleID)
+	id := getCollectionId(collectibleID)
+	collection := searchCollection(collections, id)
 	if collection == nil {
 		return nil, nil, errors.New(fmt.Sprintf("%s not found", collectibleID))
 	}
@@ -75,18 +75,4 @@ func (c CollectionsClient) GetCollectibles(owner string, collectibleID string) (
 	var page CollectiblePage
 	err = json.NewDecoder(res.Body).Decode(&page)
 	return collection, page.Collectibles, err
-}
-
-func searchCollection(collections *[]Collection, collectibleID string) *Collection {
-	for _, i := range *collections {
-		if strings.EqualFold(i.Slug, collectibleID) {
-			return &i
-		}
-		for _, contract := range i.Contracts {
-			if strings.EqualFold(contract.Address, collectibleID) {
-				return &i
-			}
-		}
-	}
-	return nil
 }

--- a/platform/ethereum/collections_client.go
+++ b/platform/ethereum/collections_client.go
@@ -51,12 +51,15 @@ func (c CollectionsClient) GetCollectibles(owner string, collectibleID string) (
 		"owner": {owner},
 		"limit": {strconv.Itoa(300)},
 	}
+
 	for _, i := range collection.Contracts {
+		if _, ok := slugTokens[i.Type]; ok {
+			uriValues.Set("collection", collection.Slug)
+			break
+		}
 		uriValues.Add("asset_contract_addresses", i.Address)
 	}
-	if len(collection.Contracts) == 0 {
-		uriValues.Set("collection", collection.Slug)
-	}
+
 	uri := fmt.Sprintf("%s/api/v1/assets/?%s",
 		c.CollectionsURL,
 		uriValues.Encode())

--- a/platform/ethereum/helper.go
+++ b/platform/ethereum/helper.go
@@ -1,0 +1,39 @@
+package ethereum
+
+import (
+	"fmt"
+	"strings"
+)
+
+func getValidParameter(first, second string) string {
+	if len(first) > 0 {
+		return first
+	}
+	return second
+}
+
+func createCategoryAddress(address, slug string) string {
+	return fmt.Sprintf("%s---%s", address, slug)
+}
+
+func getCollectionId(categoryAddress string) string {
+	s := strings.Split(categoryAddress, "---")
+	if len(s) != 2 {
+		return categoryAddress
+	}
+	return s[1]
+}
+
+func searchCollection(collections []Collection, collectibleID string) *Collection {
+	for _, i := range collections {
+		if strings.EqualFold(i.Slug, collectibleID) {
+			return &i
+		}
+		for _, contract := range i.Contracts {
+			if strings.EqualFold(contract.Address, collectibleID) {
+				return &i
+			}
+		}
+	}
+	return nil
+}

--- a/platform/ethereum/helper_test.go
+++ b/platform/ethereum/helper_test.go
@@ -1,0 +1,110 @@
+package ethereum
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGetValidParameter(t *testing.T) {
+	var tests = []struct {
+		first  string
+		second string
+		result string
+	}{
+		{"trust", "wallet", "trust"},
+		{"", "wallet", "wallet"},
+		{"trust", "", "trust"},
+	}
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("getValidParameter %d", i), func(t *testing.T) {
+			s := getValidParameter(tt.first, tt.second)
+			if s != tt.result {
+				t.Errorf("got %q, want %q", s, tt.result)
+			}
+		})
+	}
+}
+
+func TestCreateCategoryAddress(t *testing.T) {
+	var tests = []struct {
+		address string
+		slug    string
+		result  string
+	}{
+		{"0x5574Cd97", "trust", "0x5574Cd97---trust"},
+		{"0x5574Cd97", "", "0x5574Cd97---"},
+		{"", "trust", "---trust"},
+	}
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("createCategoryAddress %d", i), func(t *testing.T) {
+			s := createCategoryAddress(tt.address, tt.slug)
+			if s != tt.result {
+				t.Errorf("got %q, want %q", s, tt.result)
+			}
+		})
+	}
+}
+
+func TestGetCollectionId(t *testing.T) {
+	var tests = []struct {
+		categoryAddress string
+		result          string
+	}{
+		{"0x5574Cd97---trust", "trust"},
+		{"0x5574Cd97---", ""},
+		{"---", ""},
+		{"trust", "trust"},
+		{"---trust", "trust"},
+	}
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("getCollectionId %d", i), func(t *testing.T) {
+			s := getCollectionId(tt.categoryAddress)
+			if s != tt.result {
+				t.Errorf("got %q, want %q", s, tt.result)
+			}
+		})
+	}
+}
+
+var c1 = Collection{
+	Slug: "enjin",
+	Contracts: []PrimaryAssetContract{{
+		Address: "0xfaafdc07907ff5120a76b34b731b278c38d6043c",
+	}},
+}
+var c2 = Collection{
+	Slug: "cryptokitties",
+	Contracts: []PrimaryAssetContract{{
+		Address: "0x5574Cd97432cEd0D7Caf58ac3c4fEDB2061C98fB",
+	}},
+}
+var c3 = Collection{
+	Slug: "age-of-rust",
+	Contracts: []PrimaryAssetContract{{
+		Address: "0x0875BCab22dE3d02402bc38aEe4104e1239374a7",
+	}},
+}
+
+func TestSearchCollection(t *testing.T) {
+	var tests = []struct {
+		collections   []Collection
+		collectibleID string
+		result        *Collection
+	}{
+		{[]Collection{c1, c2, c3}, "0xfaafdc07907ff5120a76b34b731b278c38d6043c", &c1},
+		{[]Collection{c1, c2, c3}, "cryptokitties", &c2},
+		{[]Collection{c1, c2}, "age-of-rust", nil},
+		{[]Collection{c1, c2, c3}, "age-of-rust", &c3},
+		{[]Collection{c1, c2}, "0x5574Cd97432cEd0D7Caf58ac3c4fEDB2061C98fB", &c2},
+		{[]Collection{c1}, "0x5574Cd97432cEd0D7Caf58ac3c4fEDB2061C98fB", nil},
+		{[]Collection{c1, c3}, "enjin", &c1},
+	}
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("searchCollection %d", i), func(t *testing.T) {
+			s := searchCollection(tt.collections, tt.collectibleID)
+			assert.EqualValues(t, s, tt.result)
+		})
+	}
+
+}


### PR DESCRIPTION
# Headline
Fix ERC1155 token list support

## Problem
The filter for tokens ERC1155 are wrong for `collections/:address/collection/:token`, because Open Sea API is changed

## Solution
Change for the response parse e use slug to filter ERC1155 tokens

