### PR TITLE
Handling errors gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,92 @@ or you can run manually: `TEST_CONFIG=$(TEST_CONFIG) TEST_COINS=$(TEST_COINS) go
 
 
 ## Logs
+Use the package `pkg/errors` for create a new error.
+An error in Go is any implementing interface with an Error() string method. We overwrite the error object by our error struct:
+
+```
+type Error struct {
+	Err   error
+	Type  Type
+	meta  map[string]interface{}
+	stack []string
+}
+```
+
+To be easier the error construction, the package provides a function named E, which is short and easy to type:
+
+`func E(args ...interface{}) *Error`
+
+E.g.:
+- just error:
+`errors.E(err)`
+
+- error with message:
+`errors.E(err, "new message to append")`
+
+- error with type:
+`errors.E(err, errors.TypePlatformReques)`
+
+- error with type and message:
+`errors.E(err, errors.TypePlatformReques, "new message to append")`
+
+- error with type and meta:
+```
+errors.E(err, errors.TypePlatformRequest, errors.Params{
+			"coin":   "Ethereum",
+			"method": "CurrentBlockNumber",
+		})
+```
+
+- error with meta:
+```
+errors.E(err, errors.Params{
+			"coin":   "Ethereum",
+			"method": "CurrentBlockNumber",
+		})
+```
+
+- error with type and meta:
+```
+errors.E(err, errors.TypePlatformRequest, errors.Params{
+			"coin":   "Ethereum",
+			"method": "CurrentBlockNumber",
+		})
+```
+
+- error with type, message and meta:
+```
+errors.E(err, errors.TypePlatformRequest, "new message to append", errors.Params{
+			"coin":   "Ethereum",
+			"method": "CurrentBlockNumber",
+		})
+```
+
+### Types
+
+```
+const (
+	TypeNone Type = iota
+	TypePlatformUnmarshal
+	TypePlatformNormalize
+	TypePlatformUnknown
+	TypePlatformRequest
+	TypePlatformClient
+	TypePlatformError
+	TypePlatformApi
+	TypeLoadConfig
+	TypeLoadCoins
+	TypeObserver
+	TypeStorage
+	TypeAssets
+	TypeUtil
+	TypeCmd
+	TypeUnknown
+)
+```
+
+
+## Logs
 Use the package `pkg/logger` for logs.
 
 E.g.:

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ or you can run manually: `TEST_CONFIG=$(TEST_CONFIG) TEST_COINS=$(TEST_COINS) go
 ```
 
 
-## Logs
+## Error
 Use the package `pkg/errors` for create a new error.
 An error in Go is any implementing interface with an Error() string method. We overwrite the error object by our error struct:
 

--- a/config.yml
+++ b/config.yml
@@ -6,7 +6,7 @@ gin:
   # If set, HTTP Forwarded headers will be respected
   reverse_proxy: false
 
-# Setnry error tracking
+# Sentry error tracking
 #sentry:
 #  dsn: https://xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx@sentry.io/xxxxxxx
 

--- a/pkg/errors/errorType.go
+++ b/pkg/errors/errorType.go
@@ -1,0 +1,62 @@
+package errors
+
+import (
+	"fmt"
+)
+
+type Type uint16
+
+const (
+	TypeNone Type = iota
+	TypePlatformUnmarshal
+	TypePlatformNormalize
+	TypePlatformUnknown
+	TypePlatformRequest
+	TypePlatformApi
+	TypeStorageSave
+	TypeStorageGet
+	TypeLoadConfig
+	TypeLoadCoins
+	TypeObserver
+	TypeAssets
+	TypeUtil
+	TypeCmd
+	TypeUnknown
+)
+
+func (e Type) String() string {
+	switch e {
+	case TypeNone:
+		return ""
+	case TypePlatformRequest:
+		return "Platform Request Error"
+	case TypePlatformUnmarshal:
+		return "Platform Unmarshal Error"
+	case TypePlatformApi:
+		return "Platform API Error"
+	case TypePlatformNormalize:
+		return "Platform Normalize Error"
+	case TypePlatformUnknown:
+		return "Platform Unknown Error"
+	case TypeObserver:
+		return "Observer Error"
+	case TypeStorageSave:
+		return "Storage Save Error"
+	case TypeStorageGet:
+		return "Storage Get Error"
+	case TypeLoadConfig:
+		return "Load Config Error"
+	case TypeLoadCoins:
+		return "Load Coins Error"
+	case TypeAssets:
+		return "Assets Error"
+	case TypeUtil:
+		return "Util Error"
+	case TypeCmd:
+		return "Cmd Error"
+	case TypeUnknown:
+		return "Unknown Error"
+	default:
+		return fmt.Sprintf("Error: %d", int(e))
+	}
+}

--- a/pkg/errors/errorType.go
+++ b/pkg/errors/errorType.go
@@ -12,7 +12,9 @@ const (
 	TypePlatformNormalize
 	TypePlatformUnknown
 	TypePlatformRequest
+	TypePlatformClient
 	TypePlatformApi
+	TypePlatformError
 	TypeStorageSave
 	TypeStorageGet
 	TypeLoadConfig
@@ -32,6 +34,8 @@ func (e Type) String() string {
 		return "Platform Request Error"
 	case TypePlatformUnmarshal:
 		return "Platform Unmarshal Error"
+	case TypePlatformClient:
+		return "Platform Client Generic Error"
 	case TypePlatformApi:
 		return "Platform API Error"
 	case TypePlatformNormalize:
@@ -54,6 +58,8 @@ func (e Type) String() string {
 		return "Util Error"
 	case TypeCmd:
 		return "Cmd Error"
+	case TypePlatformError:
+		return "Custom Platform Error"
 	case TypeUnknown:
 		return "Unknown Error"
 	default:

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -37,7 +37,7 @@ func (e *Error) Error() string {
 func (e *Error) String() string {
 	msg := e.Err.Error()
 	if e.Type != TypeNone {
-		msg = fmt.Sprintf("%s | Code: %s", msg, e.Type.String())
+		msg = fmt.Sprintf("%s | Type: %s", msg, e.Type.String())
 	}
 	if len(e.Meta()) > 0 {
 		msg = fmt.Sprintf("%s | Meta: %s", msg, e.Meta())
@@ -96,6 +96,9 @@ func (e *Error) JSON() interface{} {
 	}
 	if _, ok := p["type"]; !ok {
 		p["type"] = e.Type.String()
+	}
+	if _, ok := p["caller"]; !ok {
+		p["caller"] = e.caller
 	}
 	return p
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,0 +1,137 @@
+package errors
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+type Params map[string]interface{}
+
+// Error represents a error's specification.
+type Error struct {
+	Err  error
+	Type Type
+	meta interface{}
+}
+
+var (
+	_ error = (*Error)(nil)
+)
+
+func (e *Error) Error() string {
+	r, _ := e.MarshalJSON()
+	return string(r)
+}
+
+func (e *Error) String() string {
+	msg := e.Err.Error()
+	if e.Type != TypeNone {
+		msg = fmt.Sprintf("%s | Code: %s", msg, e.Type.String())
+	}
+	if len(e.Meta()) > 0 {
+		msg = fmt.Sprintf("%s | Meta: %s", msg, e.Meta())
+	}
+	return msg
+}
+
+// SetType sets the error.
+func (e *Error) SetError(err error) *Error {
+	e.Err = err
+	return e
+}
+
+// SetType sets the error from message.
+func (e *Error) SetErrorFromString(err string) *Error {
+	e.Err = errors.New(err)
+	return e
+}
+
+// SetType sets the error's type.
+func (e *Error) SetType(flags Type) *Error {
+	e.Type = flags
+	return e
+}
+
+// SetMeta sets the error's meta data.
+func (e *Error) SetMeta(data interface{}) *Error {
+	e.meta = data
+	return e
+}
+
+func E(args ...interface{}) *Error {
+	e := &Error{Type: TypeNone}
+	var message []string
+	for _, arg := range args {
+		switch arg := arg.(type) {
+		case nil:
+			continue
+		case string:
+			message = append(message, arg)
+		case error:
+			message = append([]string{arg.Error()}, message...)
+		case Type:
+			e.Type = arg
+		default:
+			e.meta = arg
+		}
+	}
+	if len(message) > 0 {
+		msg := strings.Join(message[:], ": ")
+		e.Err = errors.New(msg)
+	}
+	return e
+}
+
+func (e *Error) Meta() string {
+	var meta string
+	switch arg := e.meta.(type) {
+	case nil:
+		return ""
+	case string:
+		return meta
+	case Params:
+		r, _ := json.Marshal(arg)
+		return string(r)
+	case map[string]interface{}:
+		r, _ := json.Marshal(arg)
+		return string(r)
+	default:
+		return fmt.Sprintf("%v", arg)
+	}
+}
+
+// H is a shortcut for map[string]interface{}
+type H map[string]interface{}
+
+// JSON creates a properly formatted JSON
+func (msg *Error) JSON() interface{} {
+	json := H{}
+	if msg.meta != nil {
+		value := reflect.ValueOf(msg.Meta)
+		switch value.Kind() {
+		case reflect.Struct:
+			return msg.Meta
+		case reflect.Map:
+			for _, key := range value.MapKeys() {
+				json[key.String()] = value.MapIndex(key).Interface()
+			}
+		default:
+			json["meta"] = msg.Meta()
+		}
+	}
+	if _, ok := json["error"]; !ok {
+		json["error"] = msg.Error()
+	}
+	if _, ok := json["type"]; !ok {
+		json["type"] = msg.Type
+	}
+	return json
+}
+
+// MarshalJSON implements the json.Marshaller interface.
+func (e *Error) MarshalJSON() ([]byte, error) {
+	return json.Marshal(e.JSON())
+}

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -124,6 +124,5 @@ func E(args ...interface{}) *Error {
 		e.Err = errors.New(msg)
 	}
 
-	SendError(e)
 	return e
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"runtime"
 	"strings"
 )
 
@@ -11,9 +12,10 @@ type Params map[string]interface{}
 
 // Error represents a error's specification.
 type Error struct {
-	Err  error
-	Type Type
-	meta interface{}
+	Err    error
+	Type   Type
+	meta   interface{}
+	caller string
 }
 
 var (
@@ -39,6 +41,9 @@ func (e *Error) String() string {
 	}
 	if len(e.Meta()) > 0 {
 		msg = fmt.Sprintf("%s | Meta: %s", msg, e.Meta())
+	}
+	if len(e.caller) > 0 {
+		msg = fmt.Sprintf("%s | Caller: %s", msg, e.caller)
 	}
 	return msg
 }
@@ -120,6 +125,11 @@ func E(args ...interface{}) *Error {
 	if len(message) > 0 {
 		msg := strings.Join(message[:], ": ")
 		e.Err = errors.New(msg)
+	}
+
+	_, fn, line, ok := runtime.Caller(1)
+	if ok {
+		e.caller = fmt.Sprintf("%s:%d", fn, line)
 	}
 	return e
 }

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -25,7 +25,10 @@ func (e *Error) isEmpty() bool {
 }
 
 func (e *Error) Error() string {
-	r, _ := e.MarshalJSON()
+	r, err := e.MarshalJSON()
+	if err != nil {
+		return e.Err.Error()
+	}
 	return string(r)
 }
 
@@ -54,10 +57,16 @@ func (e *Error) Meta() string {
 	case string:
 		return meta
 	case Params:
-		r, _ := json.Marshal(arg)
+		r, err := json.Marshal(arg)
+		if err != nil {
+			return ""
+		}
 		return string(r)
 	case map[string]interface{}:
-		r, _ := json.Marshal(arg)
+		r, err := json.Marshal(arg)
+		if err != nil {
+			return ""
+		}
 		return string(r)
 	default:
 		return fmt.Sprintf("%v", arg)

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -20,6 +20,10 @@ var (
 	_ error = (*Error)(nil)
 )
 
+func (e *Error) isEmpty() bool {
+	return e.meta == nil && e.Type == TypeNone && e.Err == nil
+}
+
 func (e *Error) Error() string {
 	r, _ := e.MarshalJSON()
 	return string(r)

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -94,7 +94,7 @@ func (e *Error) JSON() interface{} {
 	if _, ok := p["error"]; !ok {
 		p["error"] = e.Err.Error()
 	}
-	if _, ok := p["type"]; !ok {
+	if _, ok := p["type"]; !ok && e.Type != TypeNone {
 		p["type"] = e.Type.String()
 	}
 	if _, ok := p["caller"]; !ok {

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"reflect"
 	"strings"
 )
 
@@ -37,28 +36,55 @@ func (e *Error) String() string {
 	return msg
 }
 
-// SetType sets the error.
-func (e *Error) SetError(err error) *Error {
-	e.Err = err
-	return e
-}
-
-// SetType sets the error from message.
-func (e *Error) SetErrorFromString(err string) *Error {
-	e.Err = errors.New(err)
-	return e
-}
-
-// SetType sets the error's type.
-func (e *Error) SetType(flags Type) *Error {
-	e.Type = flags
-	return e
-}
-
 // SetMeta sets the error's meta data.
 func (e *Error) SetMeta(data interface{}) *Error {
 	e.meta = data
 	return e
+}
+
+func (e *Error) Meta() string {
+	var meta string
+	switch arg := e.meta.(type) {
+	case nil:
+		return ""
+	case string:
+		return meta
+	case Params:
+		r, _ := json.Marshal(arg)
+		return string(r)
+	case map[string]interface{}:
+		r, _ := json.Marshal(arg)
+		return string(r)
+	default:
+		return fmt.Sprintf("%v", arg)
+	}
+}
+
+// JSON creates a properly formatted JSON
+func (e *Error) JSON() interface{} {
+	p := Params{}
+	if e.meta != nil {
+		switch arg := e.meta.(type) {
+		case Params:
+			p = arg
+		case map[string]interface{}:
+			p = arg
+		default:
+			p["meta"] = e.Meta()
+		}
+	}
+	if _, ok := p["error"]; !ok {
+		p["error"] = e.Err.Error()
+	}
+	if _, ok := p["type"]; !ok {
+		p["type"] = e.Type.String()
+	}
+	return p
+}
+
+// MarshalJSON implements the json.Marshaller interface.
+func (e *Error) MarshalJSON() ([]byte, error) {
+	return json.Marshal(e.JSON())
 }
 
 func E(args ...interface{}) *Error {
@@ -83,55 +109,4 @@ func E(args ...interface{}) *Error {
 		e.Err = errors.New(msg)
 	}
 	return e
-}
-
-func (e *Error) Meta() string {
-	var meta string
-	switch arg := e.meta.(type) {
-	case nil:
-		return ""
-	case string:
-		return meta
-	case Params:
-		r, _ := json.Marshal(arg)
-		return string(r)
-	case map[string]interface{}:
-		r, _ := json.Marshal(arg)
-		return string(r)
-	default:
-		return fmt.Sprintf("%v", arg)
-	}
-}
-
-// H is a shortcut for map[string]interface{}
-type H map[string]interface{}
-
-// JSON creates a properly formatted JSON
-func (msg *Error) JSON() interface{} {
-	json := H{}
-	if msg.meta != nil {
-		value := reflect.ValueOf(msg.Meta)
-		switch value.Kind() {
-		case reflect.Struct:
-			return msg.Meta
-		case reflect.Map:
-			for _, key := range value.MapKeys() {
-				json[key.String()] = value.MapIndex(key).Interface()
-			}
-		default:
-			json["meta"] = msg.Meta()
-		}
-	}
-	if _, ok := json["error"]; !ok {
-		json["error"] = msg.Error()
-	}
-	if _, ok := json["type"]; !ok {
-		json["type"] = msg.Type
-	}
-	return json
-}
-
-// MarshalJSON implements the json.Marshaller interface.
-func (e *Error) MarshalJSON() ([]byte, error) {
-	return json.Marshal(e.JSON())
 }

--- a/pkg/errors/helper_test.go
+++ b/pkg/errors/helper_test.go
@@ -1,0 +1,47 @@
+package errors
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestIsType(t *testing.T) {
+	var tests = []struct {
+		error     error
+		errorType Type
+		result    bool
+	}{
+		{fmt.Errorf("test"), TypePlatformRequest, false},
+		{&Error{Type: TypePlatformRequest}, TypePlatformRequest, true},
+		{&Error{Type: TypePlatformUnmarshal}, TypePlatformRequest, false},
+	}
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("TestIsType %d", i), func(t *testing.T) {
+			s := Is(tt.error, tt.errorType)
+			if s != tt.result {
+				t.Errorf("got %t, want %t", s, tt.result)
+			}
+		})
+	}
+}
+
+func TestEqual(t *testing.T) {
+	var tests = []struct {
+		err1   error
+		err2   error
+		result bool
+	}{
+		{fmt.Errorf("test"), &Error{Type: TypePlatformRequest}, false},
+		{&Error{Type: TypePlatformNormalize}, &Error{Type: TypePlatformRequest}, false},
+		{&Error{Type: TypePlatformRequest}, &Error{Type: TypePlatformRequest}, true},
+		{fmt.Errorf("err1"), fmt.Errorf("err2"), false},
+	}
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("TestEqual %d", i), func(t *testing.T) {
+			s := Equal(tt.err1, tt.err2)
+			if s != tt.result {
+				t.Errorf("got %t, want %t", s, tt.result)
+			}
+		})
+	}
+}

--- a/pkg/errors/helpers.go
+++ b/pkg/errors/helpers.go
@@ -28,9 +28,6 @@ func Equal(err1, err2 error) bool {
 	if e1.Err != nil && e2.Err != e1.Err {
 		return false
 	}
-	if e1.meta != nil && e2.meta != e1.meta {
-		return false
-	}
 	if e1.Type != TypeNone && e2.Type != e1.Type {
 		return false
 	}
@@ -43,4 +40,10 @@ func Equal(err1, err2 error) bool {
 		}
 	}
 	return true
+}
+
+func appendMap(root map[string]interface{}, tmp map[string]interface{}) {
+	for k, v := range tmp {
+		root[k] = v
+	}
 }

--- a/pkg/errors/helpers.go
+++ b/pkg/errors/helpers.go
@@ -1,0 +1,46 @@
+package errors
+
+// Is reports whether err is an *Error of the given Type.
+// If err is nil then Is returns false.
+func Is(kind Type, err error) bool {
+	e, ok := err.(*Error)
+	if !ok {
+		return false
+	}
+	if e.Type != TypeNone {
+		return e.Type == kind
+	}
+	if e.Err != nil {
+		return Is(kind, e.Err)
+	}
+	return false
+}
+
+func Equal(err1, err2 error) bool {
+	e1, ok := err1.(*Error)
+	if !ok {
+		return false
+	}
+	e2, ok := err2.(*Error)
+	if !ok {
+		return false
+	}
+	if e1.Err != nil && e2.Err != e1.Err {
+		return false
+	}
+	if e1.meta != nil && e2.meta != e1.meta {
+		return false
+	}
+	if e1.Type != TypeNone && e2.Type != e1.Type {
+		return false
+	}
+	if e1.Err != nil {
+		if _, ok := e1.Err.(*Error); ok {
+			return Equal(e1.Err, e2.Err)
+		}
+		if e2.Err == nil || e2.Err.Error() != e1.Err.Error() {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/errors/helpers.go
+++ b/pkg/errors/helpers.go
@@ -2,16 +2,16 @@ package errors
 
 // Is reports whether err is an *Error of the given Type.
 // If err is nil then Is returns false.
-func Is(kind Type, err error) bool {
+func Is(err error, t Type) bool {
 	e, ok := err.(*Error)
 	if !ok {
 		return false
 	}
 	if e.Type != TypeNone {
-		return e.Type == kind
+		return e.Type == t
 	}
 	if e.Err != nil {
-		return Is(kind, e.Err)
+		return Is(e.Err, t)
 	}
 	return false
 }

--- a/pkg/errors/sentry.go
+++ b/pkg/errors/sentry.go
@@ -17,9 +17,8 @@ func InitSentry() error {
 	return nil
 }
 
-func SendError(err error) error {
+func SendError(err error) {
 	sentry.CaptureException(err)
-	return err
 }
 
 func SendFatal(err error) {

--- a/pkg/errors/sentry.go
+++ b/pkg/errors/sentry.go
@@ -3,7 +3,6 @@ package errors
 import (
 	"github.com/getsentry/sentry-go"
 	"github.com/spf13/viper"
-	"github.com/trustwallet/blockatlas/pkg/logger"
 	"time"
 )
 
@@ -12,10 +11,7 @@ func InitSentry() error {
 		Dsn:              viper.GetString("sentry.dsn"),
 		AttachStacktrace: true,
 	})
-	if err != nil {
-		logger.Error("Set Sentry DSN error", err)
-	}
-	return err
+	return E(err, "InitSentry failed")
 }
 
 func SendError(err error) {
@@ -24,11 +20,7 @@ func SendError(err error) {
 
 func SendFatal(err error) {
 	sentry.CaptureException(err)
-	if sentry.Flush(time.Second * 5) {
-		logger.Info("All sentry queued events delivered!")
-	} else {
-		logger.Info("Sentry flush timeout reached")
-	}
+	sentry.Flush(time.Second * 5)
 }
 
 func SendMessage(msg string) {

--- a/pkg/errors/sentry.go
+++ b/pkg/errors/sentry.go
@@ -14,8 +14,9 @@ func InitSentry() error {
 	return E(err, "InitSentry failed")
 }
 
-func SendError(err error) {
+func SendError(err error) error {
 	sentry.CaptureException(err)
+	return err
 }
 
 func SendFatal(err error) {

--- a/pkg/errors/sentry.go
+++ b/pkg/errors/sentry.go
@@ -1,8 +1,9 @@
-package logger
+package errors
 
 import (
 	"github.com/getsentry/sentry-go"
 	"github.com/spf13/viper"
+	"github.com/trustwallet/blockatlas/pkg/logger"
 	"time"
 )
 
@@ -12,7 +13,7 @@ func InitSentry() error {
 		AttachStacktrace: true,
 	})
 	if err != nil {
-		Error("Set Sentry DSN error", err)
+		logger.Error("Set Sentry DSN error", err)
 	}
 	return err
 }
@@ -24,9 +25,9 @@ func SendError(err error) {
 func SendFatal(err error) {
 	sentry.CaptureException(err)
 	if sentry.Flush(time.Second * 5) {
-		Info("All sentry queued events delivered!")
+		logger.Info("All sentry queued events delivered!")
 	} else {
-		Info("Sentry flush timeout reached")
+		logger.Info("Sentry flush timeout reached")
 	}
 }
 

--- a/pkg/errors/sentry.go
+++ b/pkg/errors/sentry.go
@@ -11,7 +11,10 @@ func InitSentry() error {
 		Dsn:              viper.GetString("sentry.dsn"),
 		AttachStacktrace: true,
 	})
-	return E(err, "InitSentry failed")
+	if err != nil {
+		return E(err, "InitSentry failed")
+	}
+	return nil
 }
 
 func SendError(err error) error {

--- a/pkg/logger/error.go
+++ b/pkg/logger/error.go
@@ -42,10 +42,10 @@ func getError(args ...interface{}) *errMessage {
 	err := &errMessage{message: msg}
 	for _, arg := range args {
 		switch arg := arg.(type) {
+		case *errors.Error:
+			err.err = arg
 		case error:
 			err.err = errors.E(arg)
-		case errors.Error:
-			err.err = &arg
 		default:
 			continue
 		}

--- a/pkg/logger/error.go
+++ b/pkg/logger/error.go
@@ -16,7 +16,6 @@ func Error(args ...interface{}) {
 	}
 	e := getError(args...)
 	log.WithFields(e.params).Error(e.err)
-	SendFatal(e.err)
 }
 
 func Fatal(args ...interface{}) {
@@ -24,7 +23,7 @@ func Fatal(args ...interface{}) {
 		Panic("call to logger.Fatal with no arguments")
 	}
 	e := getError(args...)
-	SendFatal(e.err)
+	errors.SendFatal(e.err)
 	log.WithFields(e.params).Fatal(e.err)
 }
 
@@ -33,7 +32,7 @@ func Panic(args ...interface{}) {
 		Panic("call to logger.Panic with no arguments")
 	}
 	e := getError(args...)
-	SendFatal(e.err)
+	errors.SendFatal(e.err)
 	log.WithFields(e.params).Panic(e.err)
 }
 

--- a/pkg/logger/error.go
+++ b/pkg/logger/error.go
@@ -16,6 +16,7 @@ func Error(args ...interface{}) {
 	}
 	e := getError(args...)
 	log.WithFields(e.params).Error(e.err)
+	errors.SendError(e.err)
 }
 
 func Fatal(args ...interface{}) {

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -18,16 +18,16 @@ func InitLogger() {
 	}
 }
 
-type Msg struct {
-	Message string
-	Params  map[string]interface{}
+type message struct {
+	message string
+	params  map[string]interface{}
 }
 
-func (msg *Msg) String() string {
-	if len(msg.Params) > 0 {
-		return fmt.Sprintf("%s - %v", msg.Message, msg.Params)
+func (msg *message) String() string {
+	if len(msg.params) > 0 {
+		return fmt.Sprintf("%s - %v", msg.message, msg.params)
 	}
-	return fmt.Sprintf("%s", msg.Message)
+	return fmt.Sprintf("%s", msg.message)
 }
 
 func Info(args ...interface{}) {
@@ -35,7 +35,7 @@ func Info(args ...interface{}) {
 		Panic("call to logger.Info with no arguments")
 	}
 	msg := getMessage(args...)
-	log.WithFields(msg.Params).Info(msg.Message)
+	log.WithFields(msg.params).Info(msg.message)
 }
 
 func Debug(args ...interface{}) {
@@ -43,7 +43,7 @@ func Debug(args ...interface{}) {
 		Panic("call to logger.Debug with no arguments")
 	}
 	msg := getMessage(args...)
-	log.WithFields(msg.Params).Debug(msg.Message)
+	log.WithFields(msg.params).Debug(msg.message)
 }
 
 func Warn(args ...interface{}) {
@@ -51,11 +51,11 @@ func Warn(args ...interface{}) {
 		Panic("call to logger.Warn with no arguments")
 	}
 	msg := getMessage(args...)
-	log.WithFields(msg.Params).Warn(msg.Message)
+	log.WithFields(msg.params).Warn(msg.message)
 }
 
-func getMessage(args ...interface{}) *Msg {
-	msg := &Msg{Params: make(Params)}
+func getMessage(args ...interface{}) *message {
+	msg := &message{params: make(Params)}
 	var generic []string
 	var message []string
 	for _, arg := range args {
@@ -65,18 +65,18 @@ func getMessage(args ...interface{}) *Msg {
 		case string:
 			message = append(message, arg)
 		case Params:
-			appendMap(msg.Params, arg)
+			appendMap(msg.params, arg)
 		case map[string]interface{}:
-			appendMap(msg.Params, arg)
+			appendMap(msg.params, arg)
 		default:
 			generic = append(generic, fmt.Sprintf("%v", arg))
 		}
 	}
 	if len(message) > 0 {
-		msg.Message = strings.Join(message[:], ": ")
+		msg.message = strings.Join(message[:], ": ")
 	}
 	if len(generic) > 0 {
-		msg.Params["objects"] = strings.Join(generic[:], " | ")
+		msg.params["objects"] = strings.Join(generic[:], " | ")
 	}
 	return msg
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -3,6 +3,7 @@ package logger
 import (
 	"fmt"
 	log "github.com/sirupsen/logrus"
+	"github.com/trustwallet/blockatlas/pkg/errors"
 	"os"
 	"strings"
 )
@@ -12,7 +13,7 @@ type Params map[string]interface{}
 func InitLogger() {
 	log.SetFormatter(&log.TextFormatter{})
 	log.SetOutput(os.Stdout)
-	err := InitSentry()
+	err := errors.InitSentry()
 	if err != nil {
 		Error(err)
 	}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -62,6 +62,8 @@ func getMessage(args ...interface{}) *message {
 		switch arg := arg.(type) {
 		case nil:
 			continue
+		case error:
+			continue
 		case string:
 			message = append(message, arg)
 		case Params:
@@ -69,7 +71,7 @@ func getMessage(args ...interface{}) *message {
 		case map[string]interface{}:
 			appendMap(msg.params, arg)
 		default:
-			generic = append(generic, fmt.Sprintf("%v", arg))
+			generic = append(generic, fmt.Sprintf("%s", arg))
 		}
 	}
 	if len(message) > 0 {

--- a/platform/ethereum/client.go
+++ b/platform/ethereum/client.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/trustwallet/blockatlas"
+	"github.com/trustwallet/blockatlas/pkg/errors"
 	"github.com/trustwallet/blockatlas/pkg/logger"
 	"net/http"
 	"net/url"
@@ -72,14 +73,20 @@ func (c *Client) CurrentBlockNumber() (num int64, err error) {
 	path := fmt.Sprintf("%s/node_info", c.BaseURL)
 	res, err := http.Get(path)
 	if err != nil {
-		return num, err
+		return num, errors.E(err, errors.TypePlatformRequest, errors.Params{
+			"coin":   "Ethereum",
+			"method": "CurrentBlockNumber",
+		})
 	}
 	defer res.Body.Close()
 	var nodeInfo NodeInfo
 	dec := json.NewDecoder(res.Body)
 	err = dec.Decode(&nodeInfo)
 	if err != nil {
-		return num, err
+		return num, errors.E(err, errors.TypePlatformUnmarshal, errors.Params{
+			"coin":   "Ethereum",
+			"method": "CurrentBlockNumber",
+		})
 	}
 
 	return nodeInfo.LatestBlock, nil

--- a/platform/ethereum/client.go
+++ b/platform/ethereum/client.go
@@ -73,20 +73,14 @@ func (c *Client) CurrentBlockNumber() (num int64, err error) {
 	path := fmt.Sprintf("%s/node_info", c.BaseURL)
 	res, err := http.Get(path)
 	if err != nil {
-		return num, errors.E(err, errors.TypePlatformRequest, errors.Params{
-			"coin":   "Ethereum",
-			"method": "CurrentBlockNumber",
-		})
+		return num, errors.E(err, errors.TypePlatformRequest, errors.Params{"coin": "Ethereum"})
 	}
 	defer res.Body.Close()
 	var nodeInfo NodeInfo
 	dec := json.NewDecoder(res.Body)
 	err = dec.Decode(&nodeInfo)
 	if err != nil {
-		return num, errors.E(err, errors.TypePlatformUnmarshal, errors.Params{
-			"coin":   "Ethereum",
-			"method": "CurrentBlockNumber",
-		})
+		return num, errors.E(err, errors.TypePlatformUnmarshal, errors.Params{"coin": "Ethereum"})
 	}
 
 	return nodeInfo.LatestBlock, nil


### PR DESCRIPTION
# Headline

## Motivation
- Easy to build informative error messages;
- Errors easy to understand for users;
- Having errors more helpful for programmers diagnostics;

## Problem
Some errors it's hard to tracking and interpreter because some information is missing.

## Solution
An error in Go is any implementing interface with an Error() string method. We overwrite the error object by our error struct:

```
type Error struct {
	Err   error
	Type  Type
	meta  map[string]interface{}
	stack []string
}
```

To be easier the error construction, the package provides a function named E, which is short and easy to type:

`func E(args ...interface{}) *Error`

E.g.:
- just error:
`errors.E(err)`

- error with message:
`errors.E(err, "new message to append")`

- error with type:
`errors.E(err, errors.TypePlatformReques)`

- error with type and message:
`errors.E(err, errors.TypePlatformReques, "new message to append")`

- error with type and meta:
```
errors.E(err, errors.TypePlatformRequest, errors.Params{
			"coin":   "Ethereum",
			"method": "CurrentBlockNumber",
		})
```

- error with meta
```
errors.E(err, errors.Params{
			"coin":   "Ethereum",
			"method": "CurrentBlockNumber",
		})
```

- error with type and meta
```
errors.E(err, errors.TypePlatformRequest, errors.Params{
			"coin":   "Ethereum",
			"method": "CurrentBlockNumber",
		})
```

- error with type, message and meta:
```
errors.E(err, errors.TypePlatformRequest, "new message to append", errors.Params{
			"coin":   "Ethereum",
			"method": "CurrentBlockNumber",
		})
```

### Types

```
const (
	TypeNone Type = iota
	TypePlatformUnmarshal
	TypePlatformNormalize
	TypePlatformUnknown
	TypePlatformRequest
	TypePlatformClient
	TypePlatformError
	TypePlatformApi
	TypeLoadConfig
	TypeLoadCoins
	TypeObserver
	TypeStorage
	TypeAssets
	TypeUtil
	TypeCmd
	TypeUnknown
)
```

## Result
- Now the error is a simple JSON with all information and context:
`{"caller":"/Users/danilopantani/Desktop/Go/src/github.com/trustwallet/blockatlas/cmd/api/run.go:61","error":"listen tcp: lookup tcp/failed_bind: nodename nor servname provided, or not known","type":"Platform Request Error"}`

[example](https://github.com/trustwallet/blockatlas/pull/364/files#diff-5098d6c9f8c575625d507e8257bc2f88R76)
<img width="1099" alt="Screen Shot 2019-09-17 at 00 34 48" src="https://user-images.githubusercontent.com/2406457/65009424-fff58600-d8e2-11e9-9ede-a5a9f28a51b3.png">
