### PR TITLE
Improve Blockatlas client

### DIFF
--- a/pkg/blockatlas/client.go
+++ b/pkg/blockatlas/client.go
@@ -1,6 +1,7 @@
 package blockatlas
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -11,6 +12,7 @@ import (
 )
 
 type Request struct {
+	BaseUrl      string
 	HttpClient   *http.Client
 	ErrorHandler func(res *http.Response, uri string) error
 }
@@ -23,13 +25,22 @@ var DefaultErrorHandler = func(res *http.Response, uri string) error {
 	return nil
 }
 
-func (r *Request) Get(result interface{}, base string, path string, query url.Values) error {
+func (r *Request) Get(result interface{}, path string, query url.Values) error {
 	var queryStr = ""
 	if query != nil {
 		queryStr = query.Encode()
 	}
-	uri := strings.Join([]string{fmt.Sprintf("%s/%s", base, path), queryStr}, "?")
+	uri := strings.Join([]string{r.getBase(path), queryStr}, "?")
 	return r.Execute("GET", uri, nil, result)
+}
+
+func (r *Request) Post(result interface{}, path string, body interface{}) error {
+	buf, err := getBody(body)
+	if err != nil {
+		return err
+	}
+	uri := r.getBase(path)
+	return r.Execute("POST", uri, buf, result)
 }
 
 func (r *Request) Execute(method string, url string, body io.Reader, result interface{}) error {
@@ -41,10 +52,27 @@ func (r *Request) Execute(method string, url string, body io.Reader, result inte
 	if err != nil {
 		return err
 	}
+
 	err = r.ErrorHandler(res, url)
 	if err != nil {
 		return err
 	}
 	defer res.Body.Close()
-	return json.NewDecoder(res.Body).Decode(result)
+	err = json.NewDecoder(res.Body).Decode(result)
+	return err
+}
+
+func (r *Request) getBase(path string) string {
+	return fmt.Sprintf("%s/%s", r.BaseUrl, path)
+}
+
+func getBody(body interface{}) (buf io.ReadWriter, err error) {
+	if body != nil {
+		buf = new(bytes.Buffer)
+		err = json.NewEncoder(buf).Encode(body)
+		if err != nil {
+			return
+		}
+	}
+	return
 }

--- a/platform/binance/api.go
+++ b/platform/binance/api.go
@@ -22,7 +22,7 @@ type Platform struct {
 
 func (p *Platform) Init() error {
 	p.client = ClientInit(viper.GetString("binance.api"))
-	p.dexClient = ClientDexInit(viper.GetString("binance.dex"))
+	p.dexClient = DexClientInit(viper.GetString("binance.dex"))
 	return nil
 }
 

--- a/platform/binance/api.go
+++ b/platform/binance/api.go
@@ -16,11 +16,13 @@ const (
 )
 
 type Platform struct {
-	client Client
+	client    Client
+	dexClient DexClient
 }
 
 func (p *Platform) Init() error {
-	p.client = ClientInit(viper.GetString("binance.api"), viper.GetString("binance.dex"))
+	p.client = ClientInit(viper.GetString("binance.api"))
+	p.dexClient = ClientDexInit(viper.GetString("binance.dex"))
 	return nil
 }
 
@@ -137,11 +139,11 @@ func NormalizeTxs(srcTxs []Tx, txType string, pageSize int) (txs []blockatlas.Tx
 }
 
 func (p *Platform) GetTokenListByAddress(address string) (blockatlas.TokenPage, error) {
-	account, err := p.client.GetAccountMetadata(address)
+	account, err := p.dexClient.GetAccountMetadata(address)
 	if err != nil || len(account.Balances) == 0 {
 		return []blockatlas.Token{}, nil
 	}
-	tokens, err := p.client.GetTokens()
+	tokens, err := p.dexClient.GetTokens()
 	if err != nil {
 		return nil, err
 	}

--- a/platform/binance/client.go
+++ b/platform/binance/client.go
@@ -13,26 +13,23 @@ import (
 // TODO Headers + rate limiting
 
 type Client struct {
-	Request    blockatlas.Request
-	BaseURL    string
-	BaseDexURL string
+	Request blockatlas.Request
 }
 
-func ClientInit(baseUrl string, baseDexURL string) Client {
+func ClientInit(baseUrl string) Client {
 	return Client{
 		Request: blockatlas.Request{
 			HttpClient:   blockatlas.DefaultClient,
 			ErrorHandler: getHTTPError,
+			BaseUrl:      baseUrl,
 		},
-		BaseURL:    baseUrl,
-		BaseDexURL: baseDexURL,
 	}
 }
 
 func (c *Client) GetBlockList(count int) (*BlockList, error) {
 	result := new(BlockList)
 	query := url.Values{"rows": {strconv.Itoa(count)}, "page": {"1"}}
-	err := c.Request.Get(result, c.BaseURL, "blocks", query)
+	err := c.Request.Get(result, "blocks", query)
 	return result, err
 }
 
@@ -45,28 +42,15 @@ func (c *Client) GetBlockByNumber(num int64) (*TxPage, error) {
 		"rows": {"100"},
 		"page": {"1"},
 	}
-	err := c.Request.Get(stx, c.BaseURL, "txs", query)
+	err := c.Request.Get(stx, "txs", query)
 	return stx, err
 }
 
 func (c *Client) GetTxsOfAddress(address string, token string) (*TxPage, error) {
 	stx := new(TxPage)
 	query := url.Values{"address": {address}, "rows": {"100"}, "page": {"1"}}
-	err := c.Request.Get(stx, c.BaseURL, "txs", query)
+	err := c.Request.Get(stx, "txs", query)
 	return stx, err
-}
-
-func (c *Client) GetAccountMetadata(address string) (account *Account, err error) {
-	path := fmt.Sprintf("v1/account/%s", address)
-	err = c.Request.Get(&account, c.BaseDexURL, path, nil)
-	return account, err
-}
-
-func (c *Client) GetTokens() (*TokenPage, error) {
-	stp := new(TokenPage)
-	query := url.Values{"limit": {"1000"}, "offset": {"0"}}
-	err := c.Request.Get(stp, c.BaseDexURL, "v1/tokens", query)
-	return stp, err
 }
 
 func getHTTPError(res *http.Response, desc string) error {

--- a/platform/binance/client.go
+++ b/platform/binance/client.go
@@ -13,7 +13,7 @@ import (
 // TODO Headers + rate limiting
 
 type Client struct {
-	Request blockatlas.Request
+	blockatlas.Request
 }
 
 func ClientInit(baseUrl string) Client {
@@ -29,7 +29,7 @@ func ClientInit(baseUrl string) Client {
 func (c *Client) GetBlockList(count int) (*BlockList, error) {
 	result := new(BlockList)
 	query := url.Values{"rows": {strconv.Itoa(count)}, "page": {"1"}}
-	err := c.Request.Get(result, "blocks", query)
+	err := c.Get(result, "blocks", query)
 	return result, err
 }
 
@@ -42,14 +42,14 @@ func (c *Client) GetBlockByNumber(num int64) (*TxPage, error) {
 		"rows": {"100"},
 		"page": {"1"},
 	}
-	err := c.Request.Get(stx, "txs", query)
+	err := c.Get(stx, "txs", query)
 	return stx, err
 }
 
 func (c *Client) GetTxsOfAddress(address string, token string) (*TxPage, error) {
 	stx := new(TxPage)
 	query := url.Values{"address": {address}, "rows": {"100"}, "page": {"1"}}
-	err := c.Request.Get(stx, "txs", query)
+	err := c.Get(stx, "txs", query)
 	return stx, err
 }
 

--- a/platform/binance/dex.go
+++ b/platform/binance/dex.go
@@ -1,0 +1,36 @@
+package binance
+
+import (
+	"fmt"
+	"github.com/trustwallet/blockatlas/pkg/blockatlas"
+	"net/url"
+)
+
+// TODO Headers + rate limiting
+
+type DexClient struct {
+	Request blockatlas.Request
+}
+
+func ClientDexInit(baseUrl string) DexClient {
+	return DexClient{
+		Request: blockatlas.Request{
+			HttpClient:   blockatlas.DefaultClient,
+			ErrorHandler: getHTTPError,
+			BaseUrl:      baseUrl,
+		},
+	}
+}
+
+func (c *DexClient) GetAccountMetadata(address string) (account *Account, err error) {
+	path := fmt.Sprintf("v1/account/%s", address)
+	err = c.Request.Get(&account, path, nil)
+	return account, err
+}
+
+func (c *DexClient) GetTokens() (*TokenPage, error) {
+	stp := new(TokenPage)
+	query := url.Values{"limit": {"1000"}, "offset": {"0"}}
+	err := c.Request.Get(stp, "v1/tokens", query)
+	return stp, err
+}

--- a/platform/binance/dex.go
+++ b/platform/binance/dex.go
@@ -9,7 +9,7 @@ import (
 // TODO Headers + rate limiting
 
 type DexClient struct {
-	Request blockatlas.Request
+	blockatlas.Request
 }
 
 func ClientDexInit(baseUrl string) DexClient {
@@ -24,13 +24,13 @@ func ClientDexInit(baseUrl string) DexClient {
 
 func (c *DexClient) GetAccountMetadata(address string) (account *Account, err error) {
 	path := fmt.Sprintf("v1/account/%s", address)
-	err = c.Request.Get(&account, path, nil)
+	err = c.Get(&account, path, nil)
 	return account, err
 }
 
 func (c *DexClient) GetTokens() (*TokenPage, error) {
 	stp := new(TokenPage)
 	query := url.Values{"limit": {"1000"}, "offset": {"0"}}
-	err := c.Request.Get(stp, "v1/tokens", query)
+	err := c.Get(stp, "v1/tokens", query)
 	return stp, err
 }

--- a/platform/binance/dex_client.go
+++ b/platform/binance/dex_client.go
@@ -12,7 +12,7 @@ type DexClient struct {
 	blockatlas.Request
 }
 
-func ClientDexInit(baseUrl string) DexClient {
+func DexClientInit(baseUrl string) DexClient {
 	return DexClient{
 		Request: blockatlas.Request{
 			HttpClient:   blockatlas.DefaultClient,

--- a/platform/bitcoin/client.go
+++ b/platform/bitcoin/client.go
@@ -10,23 +10,22 @@ import (
 )
 
 type Client struct {
-	Request blockatlas.Request
-	URL     string
+	blockatlas.Request
 }
 
-func InitClient(URL string) Client {
+func InitClient(baseUrl string) Client {
 	return Client{
 		Request: blockatlas.Request{
 			HttpClient:   blockatlas.DefaultClient,
 			ErrorHandler: blockatlas.DefaultErrorHandler,
+			BaseUrl:      baseUrl,
 		},
-		URL: URL,
 	}
 }
 
 func (c *Client) GetTransactions(address string) (transactions TransactionsList, err error) {
 	path := fmt.Sprintf("address/%s", address)
-	err = c.Request.Get(&transactions, c.URL, path, url.Values{
+	err = c.Get(&transactions, path, url.Values{
 		"details":  {"txs"},
 		"pageSize": {strconv.FormatInt(blockatlas.TxPerPage*4, 10)},
 	})
@@ -40,7 +39,7 @@ func (c *Client) GetTransactionsByXpub(xpub string) (transactions TransactionsLi
 		"details":  {"txs"},
 		"tokens":   {"derived"},
 	}
-	err = c.Request.Get(&transactions, c.URL, path, args)
+	err = c.Get(&transactions, path, args)
 	return transactions, err
 }
 
@@ -52,7 +51,7 @@ func (c *Client) GetAddressesFromXpub(xpub string) (tokens []Token, err error) {
 		"tokens":   {"derived"},
 	}
 	var transactions TransactionsList
-	err = c.Request.Get(&transactions, c.URL, path, args)
+	err = c.Get(&transactions, path, args)
 	return transactions.Tokens, err
 }
 
@@ -61,7 +60,7 @@ func (c *Client) GetTransactionsByBlock(number int64, page int64) (block Block, 
 	args := url.Values{
 		"page": {strconv.FormatInt(page, 10)},
 	}
-	err = c.Request.Get(&block, c.URL, path, args)
+	err = c.Get(&block, path, args)
 	return block, err
 }
 
@@ -80,6 +79,6 @@ func (c *Client) GetTransactionsByBlockChan(number int64, page int64, out chan B
 }
 
 func (c *Client) GetBlockNumber() (status BlockchainStatus, err error) {
-	err = c.Request.Get(&status, c.URL, "v2", nil)
+	err = c.Get(&status, "v2", nil)
 	return status, err
 }

--- a/platform/cosmos/client.go
+++ b/platform/cosmos/client.go
@@ -9,17 +9,16 @@ import (
 
 // Client - the HTTP client
 type Client struct {
-	Request blockatlas.Request
-	URL     string
+	blockatlas.Request
 }
 
-func InitClient(URL string) Client {
+func InitClient(baseUrl string) Client {
 	return Client{
 		Request: blockatlas.Request{
 			HttpClient:   blockatlas.DefaultClient,
 			ErrorHandler: blockatlas.DefaultErrorHandler,
+			BaseUrl:      baseUrl,
 		},
-		URL: URL,
 	}
 }
 
@@ -31,7 +30,7 @@ func (c *Client) GetAddrTxes(address string, tag string) (txs []Tx, err error) {
 		"limit": {strconv.FormatInt(1000, 10)},
 	}
 
-	err = c.Request.Get(&txs, c.URL, "txs", query)
+	err = c.Get(&txs, "txs", query)
 	if err != nil {
 		logger.Error(err, "Cosmos: Failed to get transactions for address", logger.Params{"address": address})
 		return nil, err
@@ -45,7 +44,7 @@ func (c *Client) GetValidators() (validators []Validator, err error) {
 		"page":   {strconv.FormatInt(1, 10)},
 		"limit":  {strconv.FormatInt(blockatlas.ValidatorsPerPage, 10)},
 	}
-	err = c.Request.Get(&validators, c.URL, "staking/validators", query)
+	err = c.Get(&validators, "staking/validators", query)
 	if err != nil {
 		logger.Error(err, "Cosmos: Failed to get validators for address")
 		return validators, err
@@ -54,13 +53,13 @@ func (c *Client) GetValidators() (validators []Validator, err error) {
 }
 
 func (c *Client) GetBlockByNumber(num int64) (txs []Tx, err error) {
-	err = c.Request.Get(&txs, c.URL, "txs", url.Values{"tx.height": {strconv.FormatInt(num, 10)}})
+	err = c.Get(&txs, "txs", url.Values{"tx.height": {strconv.FormatInt(num, 10)}})
 	return txs, err
 }
 
 func (c *Client) CurrentBlockNumber() (num int64, err error) {
 	var block Block
-	err = c.Request.Get(&block, c.URL, "blocks/latest", nil)
+	err = c.Get(&block, "blocks/latest", nil)
 
 	if err != nil {
 		return num, err
@@ -76,13 +75,13 @@ func (c *Client) CurrentBlockNumber() (num int64, err error) {
 }
 
 func (c *Client) GetPool() (result StakingPool, err error) {
-	return result, c.Request.Get(&result, c.URL, "staking/pool", nil)
+	return result, c.Get(&result, "staking/pool", nil)
 }
 
 func (c *Client) GetInflation() (float64, error) {
 	var result string
 
-	err := c.Request.Get(&result, c.URL, "minting/inflation", nil)
+	err := c.Get(&result, "minting/inflation", nil)
 	if err != nil {
 		return 0, err
 	}

--- a/platform/fio/client.go
+++ b/platform/fio/client.go
@@ -5,8 +5,7 @@ import (
 )
 
 type Client struct {
-	Request blockatlas.Request
-	URL     string
+	blockatlas.Request
 }
 
 func InitClient(baseUrl string) Client {
@@ -14,7 +13,7 @@ func InitClient(baseUrl string) Client {
 		Request: blockatlas.Request{
 			HttpClient:   blockatlas.DefaultClient,
 			ErrorHandler: blockatlas.DefaultErrorHandler,
+			BaseUrl:      baseUrl,
 		},
-		URL: baseUrl,
 	}
 }

--- a/platform/iotex/client.go
+++ b/platform/iotex/client.go
@@ -9,23 +9,22 @@ import (
 )
 
 type Client struct {
-	Request blockatlas.Request
-	URL     string
+	blockatlas.Request
 }
 
-func InitClient(URL string) Client {
+func InitClient(baseUrl string) Client {
 	return Client{
 		Request: blockatlas.Request{
 			HttpClient:   blockatlas.DefaultClient,
 			ErrorHandler: blockatlas.DefaultErrorHandler,
+			BaseUrl:      baseUrl,
 		},
-		URL: URL,
 	}
 }
 
 func (c *Client) GetLatestBlock() (int64, error) {
 	var chainMeta ChainMeta
-	err := c.Request.Get(&chainMeta, c.URL, "chainmeta", nil)
+	err := c.Get(&chainMeta, "chainmeta", nil)
 	if err != nil {
 		return 0, err
 	}
@@ -35,7 +34,7 @@ func (c *Client) GetLatestBlock() (int64, error) {
 func (c *Client) GetTxsInBlock(number int64) ([]*ActionInfo, error) {
 	path := fmt.Sprintf("transfers/block/%d", number)
 	var resp Response
-	err := c.Request.Get(&resp, c.URL, path, nil)
+	err := c.Get(&resp, path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -44,7 +43,7 @@ func (c *Client) GetTxsInBlock(number int64) ([]*ActionInfo, error) {
 
 func (c *Client) GetTxsOfAddress(address string, start int64) (*Response, error) {
 	var response Response
-	err := c.Request.Get(&response, c.URL, "actions/addr/"+address, url.Values{
+	err := c.Get(&response, "actions/addr/"+address, url.Values{
 		"start": {strconv.FormatInt(start, 10)},
 		"count": {strconv.FormatInt(blockatlas.TxPerPage, 10)},
 	})
@@ -58,7 +57,7 @@ func (c *Client) GetTxsOfAddress(address string, start int64) (*Response, error)
 
 func (c *Client) GetAddressTotalTransactions(address string) (int64, error) {
 	var account AccountInfo
-	err := c.Request.Get(&account, c.URL, "accounts/"+address, nil)
+	err := c.Get(&account, "accounts/"+address, nil)
 	if err != nil {
 		return 0, nil
 	}

--- a/platform/nebulas/client.go
+++ b/platform/nebulas/client.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/trustwallet/blockatlas/pkg/blockatlas"
 	"github.com/trustwallet/blockatlas/pkg/logger"
-	"net/http"
 	"net/url"
 	"strconv"
 )
@@ -12,19 +11,16 @@ import (
 const TxTypeBinary = "binary"
 
 type Client struct {
-	HTTPClient *http.Client
-	BaseURL    string
-	Request    blockatlas.Request
-	URL        string
+	blockatlas.Request
 }
 
-func InitClient(BaseURL string) Client {
+func InitClient(baseUrl string) Client {
 	return Client{
 		Request: blockatlas.Request{
 			HttpClient:   blockatlas.DefaultClient,
 			ErrorHandler: blockatlas.DefaultErrorHandler,
+			BaseUrl:      baseUrl,
 		},
-		BaseURL: BaseURL,
 	}
 }
 
@@ -44,7 +40,7 @@ func (c *Client) GetLatestBlock() (int64, error) {
 	}
 	var response NewBlockResponse
 
-	err := c.Request.Get(&response, c.BaseURL, path, values)
+	err := c.Get(&response, path, values)
 	if err != nil || len(response.Data) == 0 {
 		logger.Error("Nebulas: Error loading latest block height")
 		return 0, err
@@ -62,7 +58,7 @@ func (c *Client) GetBlockByNumber(num int64) ([]Transaction, error) {
 
 func (c *Client) GetTransactions(values url.Values) ([]Transaction, error) {
 	var response Response
-	err := c.Request.Get(&response, c.BaseURL, "tx", values)
+	err := c.Get(&response, "tx", values)
 	if err != nil {
 		return nil, err
 	}

--- a/platform/tezos/api.go
+++ b/platform/tezos/api.go
@@ -8,13 +8,15 @@ import (
 )
 
 type Platform struct {
-	client Client
+	client    Client
+	rpcClient RpcClient
 }
 
 const Annual = 7.0
 
 func (p *Platform) Init() error {
-	p.client = InitClient(viper.GetString("tezos.api"), viper.GetString("tezos.rpc"))
+	p.client = InitClient(viper.GetString("tezos.api"))
+	p.rpcClient = InitRpcClient(viper.GetString("tezos.rpc"))
 	return nil
 }
 
@@ -62,7 +64,7 @@ func NormalizeTxs(srcTxs []Tx) (txs []blockatlas.Tx) {
 
 func (p *Platform) GetValidators() (blockatlas.ValidatorPage, error) {
 	results := make(blockatlas.ValidatorPage, 0)
-	validators, err := p.client.GetValidators()
+	validators, err := p.rpcClient.GetValidators()
 
 	if err != nil {
 		return results, err

--- a/platform/tezos/rpc.go
+++ b/platform/tezos/rpc.go
@@ -1,0 +1,29 @@
+package tezos
+
+import (
+	"github.com/trustwallet/blockatlas/pkg/blockatlas"
+	"github.com/trustwallet/blockatlas/pkg/logger"
+)
+
+type RpcClient struct {
+	blockatlas.Request
+}
+
+func InitRpcClient(baseUrl string) RpcClient {
+	return RpcClient{
+		Request: blockatlas.Request{
+			HttpClient:   blockatlas.DefaultClient,
+			ErrorHandler: blockatlas.DefaultErrorHandler,
+			BaseUrl:      baseUrl,
+		},
+	}
+}
+
+func (c *RpcClient) GetValidators() (validators []Validator, err error) {
+	err = c.Get(&validators, "chains/main/blocks/head~32768/votes/listings", nil)
+	if err != nil {
+		logger.Error(err, "Tezos: Failed to get validators for address")
+		return validators, err
+	}
+	return validators, err
+}

--- a/platform/tron/client.go
+++ b/platform/tron/client.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Client struct {
-	Request blockatlas.Request
+	blockatlas.Request
 	BaseURL string
 }
 
@@ -26,7 +26,7 @@ func (c *Client) GetTxsOfAddress(address, token string) ([]Tx, error) {
 	path := fmt.Sprintf("v1/accounts/%s/transactions", url.PathEscape(address))
 
 	var txs Page
-	err := c.Request.Get(&txs, c.BaseURL, path, url.Values{
+	err := c.Get(&txs, path, url.Values{
 		"only_confirmed": {"true"},
 		"limit":          {"200"},
 		"token_id":       {token},
@@ -39,7 +39,7 @@ func (c *Client) GetAccountMetadata(address string) (*Accounts, error) {
 	path := fmt.Sprintf("v1/accounts/%s", address)
 
 	var accounts Accounts
-	err := c.Request.Get(&accounts, c.BaseURL, path, nil)
+	err := c.Get(&accounts, path, nil)
 
 	return &accounts, err
 }
@@ -48,13 +48,13 @@ func (c *Client) GetTokenInfo(id string) (*Asset, error) {
 	path := fmt.Sprintf("v1/assets/%s", id)
 
 	var asset Asset
-	err := c.Request.Get(&asset, c.BaseURL, path, nil)
+	err := c.Get(&asset, path, nil)
 
 	return &asset, err
 }
 
 func (c *Client) GetValidators() (validators Validators, err error) {
-	err = c.Request.Get(&validators, c.BaseURL, "wallet/listwitnesses", nil)
+	err = c.Get(&validators, "wallet/listwitnesses", nil)
 	if err != nil {
 		logger.Error(err, "Tron: Failed to get validators for address")
 		return validators, err

--- a/platform/tron/client.go
+++ b/platform/tron/client.go
@@ -9,13 +9,12 @@ import (
 
 type Client struct {
 	blockatlas.Request
-	BaseURL string
 }
 
-func InitClient(BaseURL string) Client {
+func InitClient(baseUrl string) Client {
 	return Client{
-		BaseURL: BaseURL,
 		Request: blockatlas.Request{
+			BaseUrl:      baseUrl,
 			HttpClient:   blockatlas.DefaultClient,
 			ErrorHandler: blockatlas.DefaultErrorHandler,
 		},

--- a/platform/vechain/client.go
+++ b/platform/vechain/client.go
@@ -8,23 +8,22 @@ import (
 
 //Client model contains client instance and base url
 type Client struct {
-	Request blockatlas.Request
-	URL     string
+	blockatlas.Request
 }
 
-func InitClient(URL string) Client {
+func InitClient(baseUrl string) Client {
 	return Client{
 		Request: blockatlas.Request{
 			HttpClient:   blockatlas.DefaultClient,
 			ErrorHandler: blockatlas.DefaultErrorHandler,
+			BaseUrl:      baseUrl,
 		},
-		URL: URL,
 	}
 }
 
 // GetCurrentBlockInfo get request function which returns current  blockchain status model
 func (c *Client) GetCurrentBlockInfo() (cbi *CurrentBlockInfo, err error) {
-	err = c.Request.Get(&cbi, c.URL, "clientInit", nil)
+	err = c.Get(&cbi, "clientInit", nil)
 
 	return cbi, err
 }
@@ -32,7 +31,7 @@ func (c *Client) GetCurrentBlockInfo() (cbi *CurrentBlockInfo, err error) {
 // GetBlockByNumber get request function which returns block model requested by number
 func (c *Client) GetBlockByNumber(num int64) (block *Block, err error) {
 	path := fmt.Sprintf("blocks/%d", num)
-	err = c.Request.Get(&block, c.URL, path, nil)
+	err = c.Get(&block, path, nil)
 
 	return block, err
 }
@@ -40,7 +39,7 @@ func (c *Client) GetBlockByNumber(num int64) (block *Block, err error) {
 // GetTransactions get request function which returns a VET transfer transactions for given address
 func (c *Client) GetTransactions(address string) (TransferTx, error) {
 	var transfers TransferTx
-	err := c.Request.Get(&transfers, c.URL, "transactions", url.Values{
+	err := c.Get(&transfers, "transactions", url.Values{
 		"address": {address},
 		"count":   {"25"},
 		"offset":  {"0"},
@@ -51,7 +50,7 @@ func (c *Client) GetTransactions(address string) (TransferTx, error) {
 // GetTokenTransfers get request function which returns a token transfer transactions for given address
 func (c *Client) GetTokenTransfers(address string) (TokenTransferTxs, error) {
 	var transfers TokenTransferTxs
-	err := c.Request.Get(&transfers, c.URL, "tokenTransfers", url.Values{
+	err := c.Get(&transfers, "tokenTransfers", url.Values{
 		"address": {address},
 		"count":   {"25"},
 		"offset":  {"0"},
@@ -62,7 +61,7 @@ func (c *Client) GetTokenTransfers(address string) (TokenTransferTxs, error) {
 // GetTransactionReceipt get request function which returns a transaction for given id and parses it to TransferReceipt
 func (c *Client) GetTransactionReceipt(id string) (receipt *TransferReceipt, err error) {
 	path := fmt.Sprintf("transactions/%s", id)
-	err = c.Request.Get(&receipt, c.URL, path, nil)
+	err = c.Get(&receipt, path, nil)
 
 	return receipt, err
 }
@@ -70,7 +69,7 @@ func (c *Client) GetTransactionReceipt(id string) (receipt *TransferReceipt, err
 // GetTransactionByID get request function which returns a transaction for given id and parses it to NativeTransaction
 func (c *Client) GetTransactionByID(id string) (transaction *NativeTransaction, err error) {
 	path := fmt.Sprintf("transactions/%s", id)
-	err = c.Request.Get(&transaction, c.URL, path, nil)
+	err = c.Get(&transaction, path, nil)
 
 	return transaction, err
 }

--- a/platform/waves/client.go
+++ b/platform/waves/client.go
@@ -7,13 +7,12 @@ import (
 
 type Client struct {
 	blockatlas.Request
-	URL     string
 }
 
 func InitClient(baseUrl string) Client {
 	return Client{
-		URL: baseUrl,
 		Request: blockatlas.Request{
+			BaseUrl:      baseUrl,
 			HttpClient:   blockatlas.DefaultClient,
 			ErrorHandler: blockatlas.DefaultErrorHandler,
 		},

--- a/platform/waves/client.go
+++ b/platform/waves/client.go
@@ -6,7 +6,7 @@ import (
 )
 
 type Client struct {
-	Request blockatlas.Request
+	blockatlas.Request
 	URL     string
 }
 
@@ -23,7 +23,7 @@ func InitClient(baseUrl string) Client {
 func (c *Client) GetTxs(address string, limit int) ([]Transaction, error) {
 	path := fmt.Sprintf("transactions/address/%s/limit/%d", address, limit)
 	txs := make([][]Transaction, 0)
-	err := c.Request.Get(&txs, c.URL, path, nil)
+	err := c.Get(&txs, path, nil)
 
 	if len(txs) > 0 {
 		return txs[0], err
@@ -34,14 +34,14 @@ func (c *Client) GetTxs(address string, limit int) ([]Transaction, error) {
 
 func (c *Client) GetBlockByNumber(num int64) (block *Block, err error) {
 	path := fmt.Sprintf("blocks/at/%d", num)
-	err = c.Request.Get(&block, c.URL, path, nil)
+	err = c.Get(&block, path, nil)
 
 	return block, err
 }
 
 func (c *Client) GetCurrentBlock() (block *CurrentBlock, err error) {
 	path := "blocks/height"
-	err = c.Request.Get(&block, c.URL, path, nil)
+	err = c.Get(&block, path, nil)
 
 	return block, err
 }

--- a/services/assets/client.go
+++ b/services/assets/client.go
@@ -13,10 +13,11 @@ const (
 func GetValidators(coin coin.Coin) ([]AssetValidator, error) {
 	var results []AssetValidator
 	request := blockatlas.Request{
+		BaseUrl:      AssetsURL + coin.Handle,
 		HttpClient:   blockatlas.DefaultClient,
 		ErrorHandler: blockatlas.DefaultErrorHandler,
 	}
-	err := request.Get(&results, AssetsURL+coin.Handle, "/validators/list.json", nil)
+	err := request.Get(&results, "/validators/list.json", nil)
 	return results, err
 }
 


### PR DESCRIPTION
# Headline
Improve client struct and remove useless code

## Problem
We always need to pass an URL to do the requests. and the GET method it's verbose to call.

## Solution
- Pass the Base Url to the Request struct
- We can do a GET request with `c.GET`, and no more `c.request.GET`;