### PR TITLE
Fix http2curl dependencies

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ pool:
 
 variables:
   GOBIN:  '$(GOPATH)/bin' # Go binaries path
-  GOROOT: '/usr/local/go1.11' # Go installation path
+  GOROOT: '/usr/local/go1.12' # Go installation path
   GOPATH: '$(system.defaultWorkingDirectory)/gopath' # Go workspace path
   modulePath: '$(GOPATH)/src/github.com/trustwallet/blockatlas' # Path to the module's code
 
@@ -27,13 +27,17 @@ steps:
         curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
         dep ensure
     fi
+  workingDirectory: '$(modulePath)'
+  displayName: 'Get dependencies'
+
+- script: |
     go get github.com/jstemmer/go-junit-report
     go get github.com/axw/gocov/gocov
     go get github.com/AlekSi/gocov-xml
     go get -u gopkg.in/matm/v1/gocov-html
-    go get github.com/gavv/httpexpect
+    go get github.com/Pantani/httpexpect
   workingDirectory: '$(modulePath)'
-  displayName: 'Get dependencies'
+  displayName: 'Get test dependencies'
 
 - powershell: |
   env:

--- a/pkg/integration/http.go
+++ b/pkg/integration/http.go
@@ -4,7 +4,7 @@ package integration
 
 import (
 	"fmt"
-	"github.com/gavv/httpexpect"
+	"github.com/Pantani/httpexpect"
 	"net/http"
 	"sync"
 	"testing"


### PR DESCRIPTION
# Headline
Fix http2curl dependencies for integration tests.

## Problem
The httpexpect use a wrong import of package http2curl in file `printer.go`

`package github.com/moul/http2curl: code in directory $GOPATH/src/github.com/moul/http2curl expects import "moul.io/http2curl"`

## Solution
Fork the code and fix to use the package `moul.io/http2curl` instead `github.com/moul/http2curl`