### PR TITLE
Add algorand transactions

### DIFF
--- a/platform/algorand/api.go
+++ b/platform/algorand/api.go
@@ -1,17 +1,19 @@
 package algorand
 
 import (
+	"github.com/spf13/viper"
 	//"github.com/spf13/viper"
 	"github.com/trustwallet/blockatlas/coin"
 	"github.com/trustwallet/blockatlas/pkg/blockatlas"
+	"strconv"
 )
 
 type Platform struct {
-	//client Client
+	client Client
 }
 
 func (p *Platform) Init() error {
-	//p.client = InitClient(viper.GetString("algorand.api"))
+	p.client = InitClient(viper.GetString("algorand.api"))
 	return nil
 }
 
@@ -19,65 +21,62 @@ func (p *Platform) Coin() coin.Coin {
 	return coin.Coins[coin.ALGO]
 }
 
-//TODO: https://github.com/trustwallet/blockatlas/issues/373
-//func (p *Platform) CurrentBlockNumber() (int64, error) {
-//	return p.client.GetLatestBlock()
-//}
-//
-//func (p *Platform) GetBlockByNumber(num int64) (*blockatlas.Block, error) {
-//	txs, err := p.client.GetTxsInBlock(num)
-//	if err != nil {
-//		return nil, err
-//	}
-//
-//	return &blockatlas.Block{
-//		Number: num,
-//		Txs:    NormalizeTxs(txs),
-//	}, nil
-//}
-
-func (p *Platform) GetTxsByAddress(address string) (page blockatlas.TxPage, err error) {
-	return page, err
-	//txs, err := p.client.GetTxsOfAddress(address)
-	//if err != nil {
-	//	return nil, err
-	//}
-	//return NormalizeTxs(txs), nil
+func (p *Platform) CurrentBlockNumber() (int64, error) {
+	return p.client.GetLatestBlock()
 }
 
-//
-//func NormalizeTxs(txs []Transaction) []blockatlas.Tx {
-//	result := make([]blockatlas.Tx, 0)
-//
-//	for _, tx := range txs {
-//		if normalized, ok := Normalize(tx); ok {
-//			result = append(result, normalized)
-//		}
-//	}
-//
-//	return result
-//}
-//
-//func Normalize(tx Transaction) (result blockatlas.Tx, ok bool) {
-//
-//	if tx.Type != TransactionTypePay {
-//		return result, false
-//	}
-//
-//	return blockatlas.Tx{
-//		ID:     tx.Hash,
-//		Coin:   coin.ALGO,
-//		From:   tx.From,
-//		To:     tx.Payment.To,
-//		Fee:    blockatlas.Amount(strconv.Itoa(int(tx.Fee))),
-//		Date:   0,
-//		Block:  uint64(tx.Round),
-//		Status: blockatlas.StatusCompleted,
-//		Type:   blockatlas.TxTransfer,
-//		Meta: blockatlas.Transfer{
-//			Value:    blockatlas.Amount(strconv.Itoa(int(tx.Payment.Amount))),
-//			Symbol:   coin.Coins[coin.ALGO].Symbol,
-//			Decimals: coin.Coins[coin.ALGO].Decimals,
-//		},
-//	}, true
-//}
+func (p *Platform) GetBlockByNumber(num int64) (*blockatlas.Block, error) {
+	txs, err := p.client.GetTxsInBlock(num)
+	if err != nil {
+		return nil, err
+	}
+
+	return &blockatlas.Block{
+		Number: num,
+		Txs:    NormalizeTxs(txs),
+	}, nil
+}
+
+func (p *Platform) GetTxsByAddress(address string) (page blockatlas.TxPage, err error) {
+	txs, err := p.client.GetTxsOfAddress(address)
+	if err != nil {
+		return nil, err
+	}
+	return NormalizeTxs(txs), nil
+}
+
+func NormalizeTxs(txs []Transaction) []blockatlas.Tx {
+	result := make([]blockatlas.Tx, 0)
+
+	for _, tx := range txs {
+		if normalized, ok := Normalize(tx); ok {
+			result = append(result, normalized)
+		}
+	}
+
+	return result
+}
+
+func Normalize(tx Transaction) (result blockatlas.Tx, ok bool) {
+
+	if tx.Type != TransactionTypePay {
+		return result, false
+	}
+
+	return blockatlas.Tx{
+		ID:     tx.Hash,
+		Coin:   coin.ALGO,
+		From:   tx.From,
+		To:     tx.Payment.To,
+		Fee:    blockatlas.Amount(strconv.Itoa(int(tx.Fee))),
+		Date:   int64(tx.Timestamp),
+		Block:  uint64(tx.Round),
+		Status: blockatlas.StatusCompleted,
+		Type:   blockatlas.TxTransfer,
+		Meta: blockatlas.Transfer{
+			Value:    blockatlas.Amount(strconv.Itoa(int(tx.Payment.Amount))),
+			Symbol:   coin.Coins[coin.ALGO].Symbol,
+			Decimals: coin.Coins[coin.ALGO].Decimals,
+		},
+	}, true
+}

--- a/platform/algorand/api.go
+++ b/platform/algorand/api.go
@@ -37,7 +37,7 @@ func (p *Platform) GetBlockByNumber(num int64) (*blockatlas.Block, error) {
 	}, nil
 }
 
-func (p *Platform) GetTxsByAddress(address string) (page blockatlas.TxPage, err error) {
+func (p *Platform) GetTxsByAddress(address string) (blockatlas.TxPage, error) {
 	txs, err := p.client.GetTxsOfAddress(address)
 	if err != nil {
 		return nil, err
@@ -70,7 +70,7 @@ func Normalize(tx Transaction) (result blockatlas.Tx, ok bool) {
 		To:     tx.Payment.To,
 		Fee:    blockatlas.Amount(strconv.Itoa(int(tx.Fee))),
 		Date:   int64(tx.Timestamp),
-		Block:  uint64(tx.Round),
+		Block:  tx.Round,
 		Status: blockatlas.StatusCompleted,
 		Type:   blockatlas.TxTransfer,
 		Meta: blockatlas.Transfer{

--- a/platform/algorand/api_test.go
+++ b/platform/algorand/api_test.go
@@ -1,78 +1,76 @@
 package algorand
 
-//TODO: https://github.com/trustwallet/blockatlas/issues/373
-//
-//import (
-//	"encoding/json"
-//	"github.com/stretchr/testify/assert"
-//	"github.com/trustwallet/blockatlas"
-//	"github.com/trustwallet/blockatlas/coin"
-//	"testing"
-//)
-//
-//const (
-//	transfer = `
-//{
-//   "transactions":[
-//      {
-//         "type":"pay",
-//         "tx":"C2LK3CGBPIGERLPFUXE6INSBJGHOXU7YZMEGELWMVSBASFJYOOQQ",
-//         "from":"5TSQNIL54GB545B3WLC6OVH653SHAELMHU6MSVNGTUNMOEHAMWG7EC3AA4",
-//         "fee":1000,
-//         "first-round":2031300,
-//         "last-round":2031749,
-//         "noteb64":"6OZ0TFd0HPw=",
-//         "round":2031351,
-//         "poolerror":"",
-//         "payment":{
-//            "to":"4EZFQABCVQTHQCK3HQBIYGC4NV2VM42FZHEFTVH77ROG4ZGREC6Y7V5T2U",
-//            "close":"",
-//            "closeamount":0,
-//            "amount":1,
-//            "torewards":3237690,
-//            "closerewards":0
-//         },
-//         "fromrewards":0,
-//         "genesisID":"mainnet-v1.0",
-//         "genesishashb64":"wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=",
-//         "group":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
-//      }
-//   ]
-//}
-//`
-//)
-//
-//var expected = []*blockatlas.Tx{
-//	{
-//		ID:     "C2LK3CGBPIGERLPFUXE6INSBJGHOXU7YZMEGELWMVSBASFJYOOQQ",
-//		Coin:   coin.ALGO,
-//		From:   "5TSQNIL54GB545B3WLC6OVH653SHAELMHU6MSVNGTUNMOEHAMWG7EC3AA4",
-//		To:     "4EZFQABCVQTHQCK3HQBIYGC4NV2VM42FZHEFTVH77ROG4ZGREC6Y7V5T2U",
-//		Fee:    blockatlas.Amount("1000"),
-//		Date:   int64(0),
-//		Block:  2031351,
-//		Status: blockatlas.StatusCompleted,
-//		Type:   blockatlas.TxTransfer,
-//		Meta: blockatlas.Transfer{
-//			Value:    blockatlas.Amount("1"),
-//			Symbol:   "ALGO",
-//			Decimals: 6,
-//		},
-//	},
-//	nil,
-//	nil,
-//}
-//
-//func TestNormalize(t *testing.T) {
-//	a := assert.New(t)
-//
-//	var act TransactionsResponse
-//	a.NoError(json.Unmarshal([]byte(transfer), &act))
-//	a.Equal(1, len(act.Transactions))
-//
-//	for i, v := range act.Transactions {
-//		tx, ok := Normalize(v)
-//		assert.True(t, ok)
-//		assert.Equal(t, expected[i], &tx)
-//	}
-//}
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"github.com/trustwallet/blockatlas/coin"
+	"github.com/trustwallet/blockatlas/pkg/blockatlas"
+	"testing"
+)
+
+const (
+	transfer = `
+{
+  "transactions":[
+     {
+        "type":"pay",
+        "tx":"C2LK3CGBPIGERLPFUXE6INSBJGHOXU7YZMEGELWMVSBASFJYOOQQ",
+        "from":"5TSQNIL54GB545B3WLC6OVH653SHAELMHU6MSVNGTUNMOEHAMWG7EC3AA4",
+        "fee":1000,
+        "first-round":2031300,
+        "last-round":2031749,
+        "noteb64":"6OZ0TFd0HPw=",
+        "round":2031351,
+        "poolerror":"",
+        "payment":{
+           "to":"4EZFQABCVQTHQCK3HQBIYGC4NV2VM42FZHEFTVH77ROG4ZGREC6Y7V5T2U",
+           "close":"",
+           "closeamount":0,
+           "amount":1,
+           "torewards":3237690,
+           "closerewards":0
+        },
+        "fromrewards":0,
+        "genesisID":"mainnet-v1.0",
+        "genesishashb64":"wGHE2Pwdvd7S12BL5FaOP20EGYesN73ktiC1qzkkit8=",
+        "group":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+     }
+  ]
+}
+`
+)
+
+var expected = []*blockatlas.Tx{
+	{
+		ID:     "C2LK3CGBPIGERLPFUXE6INSBJGHOXU7YZMEGELWMVSBASFJYOOQQ",
+		Coin:   coin.ALGO,
+		From:   "5TSQNIL54GB545B3WLC6OVH653SHAELMHU6MSVNGTUNMOEHAMWG7EC3AA4",
+		To:     "4EZFQABCVQTHQCK3HQBIYGC4NV2VM42FZHEFTVH77ROG4ZGREC6Y7V5T2U",
+		Fee:    blockatlas.Amount("1000"),
+		Date:   int64(0),
+		Block:  2031351,
+		Status: blockatlas.StatusCompleted,
+		Type:   blockatlas.TxTransfer,
+		Meta: blockatlas.Transfer{
+			Value:    blockatlas.Amount("1"),
+			Symbol:   "ALGO",
+			Decimals: 6,
+		},
+	},
+	nil,
+	nil,
+}
+
+func TestNormalize(t *testing.T) {
+	a := assert.New(t)
+
+	var act TransactionsResponse
+	a.NoError(json.Unmarshal([]byte(transfer), &act))
+	a.Equal(1, len(act.Transactions))
+
+	for i, v := range act.Transactions {
+		tx, ok := Normalize(v)
+		assert.True(t, ok)
+		assert.Equal(t, expected[i], &tx)
+	}
+}

--- a/platform/algorand/api_test.go
+++ b/platform/algorand/api_test.go
@@ -47,7 +47,7 @@ var expected = []*blockatlas.Tx{
 		From:   "5TSQNIL54GB545B3WLC6OVH653SHAELMHU6MSVNGTUNMOEHAMWG7EC3AA4",
 		To:     "4EZFQABCVQTHQCK3HQBIYGC4NV2VM42FZHEFTVH77ROG4ZGREC6Y7V5T2U",
 		Fee:    blockatlas.Amount("1000"),
-		Date:   int64(0),
+		Date:   0,
 		Block:  2031351,
 		Status: blockatlas.StatusCompleted,
 		Type:   blockatlas.TxTransfer,
@@ -62,11 +62,9 @@ var expected = []*blockatlas.Tx{
 }
 
 func TestNormalize(t *testing.T) {
-	a := assert.New(t)
-
 	var act TransactionsResponse
-	a.NoError(json.Unmarshal([]byte(transfer), &act))
-	a.Equal(1, len(act.Transactions))
+	assert.NoError(t, json.Unmarshal([]byte(transfer), &act))
+	assert.Equal(t, 1, len(act.Transactions))
 
 	for i, v := range act.Transactions {
 		tx, ok := Normalize(v)

--- a/platform/algorand/client.go
+++ b/platform/algorand/client.go
@@ -64,9 +64,9 @@ func (c *Client) GetTxsOfAddress(address string) ([]Transaction, error) {
 	}
 	results := make([]Transaction, 0)
 
-	//FIXME. Currently fetching the last 8 transactions and get 6 blocks for each to retrieve timestamp.
+	//FIXME. Currently fetching the last 6 transactions and get 6 blocks for each to retrieve timestamp.
 	//Algorand team promised to provide endpoint soon that will contain timestamp value inside TransactionsResponse response
-	//Get latest 8 transactions, which is enough until new endpoint fixes it.
+	//Get latest 6 transactions, which is enough until new endpoint fixes it.
 	txs := response.Transactions[:util.Min(6, len(response.Transactions))]
 
 	for _, t := range txs {

--- a/platform/algorand/client.go
+++ b/platform/algorand/client.go
@@ -1,54 +1,88 @@
 package algorand
 
-//
-//import (
-//	"fmt"
-//	"github.com/trustwallet/blockatlas"
-//	"net/http"
-//)
-//
-//type Client struct {
-//	Request blockatlas.Request
-//	URL     string
-//}
-//
-//func InitClient(URL string) Client {
-//	return Client{
-//		Request: blockatlas.Request{
-//			HttpClient: http.DefaultClient,
-//			ErrorHandler: func(res *http.Response, uri string) error {
-//				return nil
-//			},
-//		},
-//		URL: URL,
-//	}
-//}
-//
-//func (c *Client) GetLatestBlock() (int64, error) {
-//	var status Status
-//	err := c.Request.Get(&status, c.URL, "v1/status", nil)
-//	if err != nil {
-//		return 0, err
-//	}
-//	return int64(status.LastRound), nil
-//}
-//
-//func (c *Client) GetTxsInBlock(number int64) ([]Transaction, error) {
-//	path := fmt.Sprintf("v1/block/%d", number)
-//	var resp BlockResponse
-//	err := c.Request.Get(&resp, c.URL, path, nil)
-//	if err != nil {
-//		return nil, err
-//	}
-//	return resp.Transactions.Transactions, nil
-//}
-//
-//func (c *Client) GetTxsOfAddress(address string) ([]Transaction, error) {
-//	var response TransactionsResponse
-//	path := fmt.Sprintf("v1/account/%s/transactions", address)
-//	err := c.Request.Get(&response, c.URL, path, nil)
-//	if err != nil {
-//		return nil, blockatlas.ErrSourceConn
-//	}
-//	return response.Transactions, err
-//}
+import (
+	"fmt"
+	"github.com/trustwallet/backend/common"
+	"github.com/trustwallet/blockatlas/pkg/blockatlas"
+)
+
+type Client struct {
+	Request blockatlas.Request
+	URL     string
+}
+
+func InitClient(URL string) Client {
+	return Client{
+		Request: blockatlas.Request{
+			HttpClient:   blockatlas.DefaultClient,
+			ErrorHandler: blockatlas.DefaultErrorHandler,
+			BaseUrl:      URL,
+		},
+	}
+}
+
+func (c *Client) GetLatestBlock() (int64, error) {
+	var status Status
+	err := c.Request.Get(&status, "v1/status", nil)
+	if err != nil {
+		return 0, err
+	}
+	return int64(status.LastRound), nil
+}
+
+func (c *Client) GetBlock(number int64) (BlockResponse, error) {
+	path := fmt.Sprintf("v1/block/%d", number)
+	var resp BlockResponse
+	err := c.Request.Get(&resp, path, nil)
+	if err != nil {
+		return resp, err
+	}
+
+	normalizedTxs := make([]Transaction, 0)
+	//TODO: Read GetTxsOfAddress explanation
+	for _, t := range resp.Transactions.Transactions {
+		normalized := normalizeTx(&t, resp)
+		normalizedTxs = append(normalizedTxs, *normalized)
+	}
+	resp.Transactions.Transactions = normalizedTxs
+
+	return resp, nil
+}
+
+func (c *Client) GetTxsInBlock(number int64) ([]Transaction, error) {
+	block, err := c.GetBlock(number)
+	return block.Transactions.Transactions, err
+}
+
+func (c *Client) GetTxsOfAddress(address string) ([]Transaction, error) {
+	var response TransactionsResponse
+	path := fmt.Sprintf("v1/account/%s/transactions", address)
+
+	err := c.Request.Get(&response, path, nil)
+	if err != nil {
+		return nil, blockatlas.ErrSourceConn
+	}
+	results := make([]Transaction, 0)
+
+	//FIXME. Currently fetching the last 8 transactions and get 6 blocks for each to retrieve timestamp.
+	//Algorand team promised to provide endpoint soon that will contain timestamp value inside TransactionsResponse response
+	//Get latest 8 transactions, which is enough until new endpoint fixes it.
+	txs := response.Transactions[:common.Min(6, len(response.Transactions))]
+
+	for _, t := range txs {
+		block, err := c.GetBlock(int64(t.Round))
+		if err != nil {
+			continue
+		} else {
+			normalizeTx(&t, block)
+			results = append(results, t)
+		}
+	}
+
+	return results, err
+}
+
+func normalizeTx(transaction *Transaction, block BlockResponse) *Transaction {
+	transaction.Timestamp = block.Timestamp
+	return transaction
+}

--- a/platform/algorand/client.go
+++ b/platform/algorand/client.go
@@ -7,8 +7,8 @@ import (
 )
 
 type Client struct {
-	Request blockatlas.Request
-	URL     string
+	blockatlas.Request
+	URL string
 }
 
 func InitClient(URL string) Client {
@@ -23,17 +23,17 @@ func InitClient(URL string) Client {
 
 func (c *Client) GetLatestBlock() (int64, error) {
 	var status Status
-	err := c.Request.Get(&status, "v1/status", nil)
+	err := c.Get(&status, "v1/status", nil)
 	if err != nil {
 		return 0, err
 	}
-	return int64(status.LastRound), nil
+	return status.LastRound, nil
 }
 
 func (c *Client) GetBlock(number int64) (BlockResponse, error) {
 	path := fmt.Sprintf("v1/block/%d", number)
 	var resp BlockResponse
-	err := c.Request.Get(&resp, path, nil)
+	err := c.Get(&resp, path, nil)
 	if err != nil {
 		return resp, err
 	}
@@ -58,7 +58,7 @@ func (c *Client) GetTxsOfAddress(address string) ([]Transaction, error) {
 	var response TransactionsResponse
 	path := fmt.Sprintf("v1/account/%s/transactions", address)
 
-	err := c.Request.Get(&response, path, nil)
+	err := c.Get(&response, path, nil)
 	if err != nil {
 		return nil, blockatlas.ErrSourceConn
 	}
@@ -71,9 +71,7 @@ func (c *Client) GetTxsOfAddress(address string) ([]Transaction, error) {
 
 	for _, t := range txs {
 		block, err := c.GetBlock(int64(t.Round))
-		if err != nil {
-			continue
-		} else {
+		if err == nil {
 			normalizeTx(&t, block)
 			results = append(results, t)
 		}

--- a/platform/algorand/client.go
+++ b/platform/algorand/client.go
@@ -2,8 +2,8 @@ package algorand
 
 import (
 	"fmt"
-	"github.com/trustwallet/backend/common"
 	"github.com/trustwallet/blockatlas/pkg/blockatlas"
+	"github.com/trustwallet/blockatlas/util"
 )
 
 type Client struct {
@@ -67,7 +67,7 @@ func (c *Client) GetTxsOfAddress(address string) ([]Transaction, error) {
 	//FIXME. Currently fetching the last 8 transactions and get 6 blocks for each to retrieve timestamp.
 	//Algorand team promised to provide endpoint soon that will contain timestamp value inside TransactionsResponse response
 	//Get latest 8 transactions, which is enough until new endpoint fixes it.
-	txs := response.Transactions[:common.Min(6, len(response.Transactions))]
+	txs := response.Transactions[:util.Min(6, len(response.Transactions))]
 
 	for _, t := range txs {
 		block, err := c.GetBlock(int64(t.Round))

--- a/platform/algorand/model.go
+++ b/platform/algorand/model.go
@@ -11,6 +11,7 @@ type TransactionsResponse struct {
 }
 
 type BlockResponse struct {
+	Timestamp    uint64            `json:"timestamp"`
 	Transactions BlockTransactions `json:"txns"`
 }
 
@@ -19,12 +20,13 @@ type BlockTransactions struct {
 }
 
 type Transaction struct {
-	Type    TransactionType    `json:"type"`
-	Hash    string             `json:"tx"`
-	From    string             `json:"from"`
-	Fee     uint64             `json:"fee"`
-	Round   uint64             `json:"round"`
-	Payment TransactionPayment `json:"payment"`
+	Type      TransactionType    `json:"type"`
+	Hash      string             `json:"tx"`
+	From      string             `json:"from"`
+	Fee       uint64             `json:"fee"`
+	Round     uint64             `json:"round"`
+	Payment   TransactionPayment `json:"payment"`
+	Timestamp uint64             `json:"timestamp,omitempty"`
 }
 
 type TransactionPayment struct {

--- a/util/number.go
+++ b/util/number.go
@@ -1,0 +1,15 @@
+package util
+
+func Min(x, y int) int {
+	if x < y {
+		return x
+	}
+	return y
+}
+
+func Max(x, y int) int {
+	if x > y {
+		return x
+	}
+	return y
+}

--- a/util/number_test.go
+++ b/util/number_test.go
@@ -1,0 +1,15 @@
+package util
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestMin(t *testing.T) {
+	assert.Equal(t, Min(1, 5), 1)
+	assert.Equal(t, Min(22, 5), 5)
+}
+func TestMax(t *testing.T) {
+	assert.Equal(t, Max(1, 5), 5)
+	assert.Equal(t, Max(22, 5), 22)
+}


### PR DESCRIPTION
Algorand promised to deliver an endpoint that will have ability to see timestamp of each transaction, but for now we need to have a hack to get block for each transaction and then merge that value.

Currently it only fetches last 6 transactions, which is enough - once Algorand deliver new endpoint we will change this logic.

SHITCODE DETECTED IN THIS PR.  💥 