### PR TITLE
remove backslash from meta print

### DIFF
--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -66,7 +66,7 @@ func (e *Error) Meta() string {
 func (e *Error) JSON() interface{} {
 	p := Params{}
 	if e.meta != nil {
-		p["meta"] = e.Meta()
+		p["meta"] = e.meta
 	}
 	if e.Err != nil {
 		p["error"] = e.Err.Error()


### PR DESCRIPTION
Remove escape backslash when we print the errors

<img width="858" alt="Screen Shot 2019-10-02 at 21 03 52" src="https://user-images.githubusercontent.com/2406457/66090074-2b6da700-e558-11e9-82ad-f02cf9d36bcf.png">
