### PR TITLE
Fix false Sentry alert

### DIFF
--- a/observer/observer.go
+++ b/observer/observer.go
@@ -31,6 +31,10 @@ func (o *Observer) run(events chan<- Event, blocks <-chan *blockatlas.Block) {
 
 func (o *Observer) processBlock(events chan<- Event, block *blockatlas.Block) {
 	txMap := GetTxs(block)
+	if len(txMap) == 0 {
+		return
+	}
+
 	// Build list of unique addresses
 	var addresses []string
 	for address := range txMap {


### PR DESCRIPTION
Fix false Sentry alert:
https://sentry.io/organizations/trustwallet/issues/1250003248/?project=1722581&query=is%3Aunresolved&statsPeriod=14d


This is not an issue, we just received blocks without transactions for lookup 