### PR TITLE
improve regex for public metrics

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -11,6 +11,6 @@ func init() {
 }
 
 func removeSensitiveInfo(info string) string {
-	reg := regexp.MustCompile(`([a-zA-Z0-9\s]{30,})|([0-9]{4,})|(=(.*?)[^(&|$)]+)`)
+	reg := regexp.MustCompile(`([a-zA-Z0-9\s]{30,})|([0-9]{4,})|(=(.*?)[^(&|$)]+)|(--[^$]+)`)
 	return reg.ReplaceAllString(info, "")
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -11,6 +11,6 @@ func init() {
 }
 
 func removeSensitiveInfo(info string) string {
-	reg := regexp.MustCompile(`([a-zA-Z0-9]{30,})|([0-9]{4,})|([A-Z0-9\s]{44})`)
+	reg := regexp.MustCompile(`([a-zA-Z0-9\s]{30,})|([0-9]{4,})|(=(.*?)[^(&|$)]+)`)
 	return reg.ReplaceAllString(info, "")
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -10,7 +10,7 @@ func Test_removeSensitiveInfo(t *testing.T) {
 	}{
 		{"Remove Nimiq address", "/v1/nimiq/NQ43 J7G6 K6T8 H5KJ 5CXN Q5JK 2GJ4 6DSB 7PUH", "/v1/nimiq/"},
 		{"Remove Tezos address", "/v1/tezos/tz1WCd2jm4uSt4vntk4vSuUWoZQGhLcDuR9q", "/v1/tezos/"},
-		{"Remove Tron info", "https://api.trongrid.io/v1/accounts/TPJYCz8ppZNyvw7pTwmjajcx4Kk1MmEUhD/transactions?limit=200&only_confirmed=true&token_id=1000011", "https://api.trongrid.io/v1/accounts//transactions?limit=200&only_confirmed=true&token_id="},
+		{"Remove Tron info", "https://api.trongrid.io/v1/accounts/TPJYCz8ppZNyvw7pTwmjajcx4Kk1MmEUhD/transactions?limit=200&only_confirmed=true&token_id=1000011", "https://api.trongrid.io/v1/accounts//transactions?limit&only_confirmed&token_id"},
 		{"Remove asset id", "https://api.trongrid.io/v1/assets/1000570?", "https://api.trongrid.io/v1/assets/?"},
 	}
 	for _, tt := range tests {

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -12,6 +12,7 @@ func Test_removeSensitiveInfo(t *testing.T) {
 		{"Remove Tezos address", "/v1/tezos/tz1WCd2jm4uSt4vntk4vSuUWoZQGhLcDuR9q", "/v1/tezos/"},
 		{"Remove Tron info", "https://api.trongrid.io/v1/accounts/TPJYCz8ppZNyvw7pTwmjajcx4Kk1MmEUhD/transactions?limit=200&only_confirmed=true&token_id=1000011", "https://api.trongrid.io/v1/accounts//transactions?limit&only_confirmed&token_id"},
 		{"Remove asset id", "https://api.trongrid.io/v1/assets/1000570?", "https://api.trongrid.io/v1/assets/?"},
+		{"Remove collection id", "/v2/ethereum/collections//collection/---enjin-old", "/v2/ethereum/collections//collection/"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
improve regex to remove more params to have public metrics

<img width="536" alt="Screen Shot 2019-10-03 at 01 36 29" src="https://user-images.githubusercontent.com/2406457/66099697-405d3100-e57e-11e9-9dfc-c515ee87e5c3.png">
<img width="749" alt="Screen Shot 2019-10-03 at 01 36 20" src="https://user-images.githubusercontent.com/2406457/66099698-405d3100-e57e-11e9-839c-06bd39d2a49a.png">
