### PR TITLE
Add staking details to the root of delegations API

### DIFF
--- a/api/batch.go
+++ b/api/batch.go
@@ -46,6 +46,7 @@ func makeStakingDelegationsBatchRoute(router gin.IRouter) {
 				d.Error = err.Error()
 			} else {
 				d.Delegations = delegations
+				d.Details = p.GetDetails()
 			}
 			batch = append(batch, d)
 		}

--- a/pkg/blockatlas/api.go
+++ b/pkg/blockatlas/api.go
@@ -50,6 +50,7 @@ type AddressAPI interface {
 // StakingAPI provides staking information
 type StakeAPI interface {
 	Platform
+	GetDetails() StakingDetails
 	GetValidators() (ValidatorPage, error)
 	GetDelegations(address string) (DelegationsPage, error)
 }

--- a/pkg/blockatlas/staking.go
+++ b/pkg/blockatlas/staking.go
@@ -25,20 +25,23 @@ type StakingReward struct {
 	Annual float64 `json:"annual"`
 }
 
-type Validator struct {
-	ID            string        `json:"id"`
-	Status        bool          `json:"status"`
+type StakingDetails struct {
 	Reward        StakingReward `json:"reward"`
 	LockTime      int           `json:"locktime"`
 	MinimumAmount Amount        `json:"minimum_amount"`
 }
 
-type Delegation struct {
-	Delegator StakeValidator `json:"delegator"`
+type Validator struct {
+	ID      string         `json:"id"`
+	Status  bool           `json:"status"`
+	Details StakingDetails `json:"details"`
+}
 
-	Value    string           `json:"value"`
-	Status   DelegationStatus `json:"status"`
-	Metadata interface{}      `json:"metadata,omitempty"`
+type Delegation struct {
+	Delegator StakeValidator   `json:"delegator"`
+	Value     string           `json:"value"`
+	Status    DelegationStatus `json:"status"`
+	Metadata  interface{}      `json:"metadata,omitempty"`
 }
 
 type DelegationMetaDataPending struct {
@@ -53,17 +56,16 @@ type StakeValidatorInfo struct {
 }
 
 type StakeValidator struct {
-	ID            string             `json:"id"`
-	Status        bool               `json:"status,omitempty"`
-	Info          StakeValidatorInfo `json:"info,omitempty"`
-	Reward        StakingReward      `json:"reward,omitempty"`
-	LockTime      int                `json:"locktime,omitempty"`
-	MinimumAmount Amount             `json:"minimum_amount,omitempty"`
+	ID      string             `json:"id"`
+	Status  bool               `json:"status,omitempty"`
+	Info    StakeValidatorInfo `json:"info,omitempty"`
+	Details StakingDetails     `json:"details,omitempty"`
 }
 
 type DelegationsBatch struct {
 	Address     string             `json:"address"`
 	Coin        *coin.ExternalCoin `json:"coin"`
+	Details     StakingDetails     `json:"details"`
 	Delegations DelegationsPage    `json:"delegations,omitempty"`
 	Error       string             `json:"error,omitempty"`
 }

--- a/platform/cosmos/api.go
+++ b/platform/cosmos/api.go
@@ -91,6 +91,15 @@ func (p *Platform) GetValidators() (blockatlas.ValidatorPage, error) {
 	return results, nil
 }
 
+func (p *Platform) GetDetails() blockatlas.StakingDetails {
+	//TODO: Find a way to have a dynamic
+	return blockatlas.StakingDetails{
+		Reward:        blockatlas.StakingReward{Annual: 11},
+		MinimumAmount: blockatlas.Amount("0"),
+		LockTime:      1814400,
+	}
+}
+
 func (p *Platform) GetDelegations(address string) (blockatlas.DelegationsPage, error) {
 	results := make(blockatlas.DelegationsPage, 0)
 	delegations, err := p.client.GetDelegations(address)
@@ -247,11 +256,13 @@ func fillDelegate(tx *blockatlas.Tx, delegate MessageValueDelegate, msgType stri
 func normalizeValidator(v Validator, p StakingPool, inflation float64, c coin.Coin) (validator blockatlas.Validator) {
 	reward := CalculateAnnualReward(p, inflation, v)
 	return blockatlas.Validator{
-		Status:        v.Status == 2,
-		ID:            v.Address,
-		Reward:        blockatlas.StakingReward{Annual: reward},
-		MinimumAmount: "0",
-		LockTime:      1814400,
+		Status: v.Status == 2,
+		ID:     v.Address,
+		Details: blockatlas.StakingDetails{
+			Reward:        blockatlas.StakingReward{Annual: reward},
+			MinimumAmount: blockatlas.Amount("0"),
+			LockTime:      1814400,
+		},
 	}
 }
 

--- a/platform/cosmos/api_test.go
+++ b/platform/cosmos/api_test.go
@@ -374,11 +374,13 @@ func TestNormalizeValidator(t *testing.T) {
 	_ = json.Unmarshal([]byte(validatorSrc), &v)
 	coin := coin.Coin{}
 	expected := blockatlas.Validator{
-		Status:        true,
-		ID:            v.Address,
-		Reward:        blockatlas.StakingReward{Annual: 435.48749999999995},
-		LockTime:      1814400,
-		MinimumAmount: "0",
+		Status: true,
+		ID:     v.Address,
+		Details: blockatlas.StakingDetails{
+			Reward:        blockatlas.StakingReward{Annual: 435.48749999999995},
+			LockTime:      1814400,
+			MinimumAmount: "0",
+		},
 	}
 
 	result := normalizeValidator(v, stakingPool, inflation, coin)
@@ -400,11 +402,13 @@ var validator1 = blockatlas.StakeValidator{
 		Image:       "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/cosmos/validators/assets/cosmosvaloper1qwl879nx9t6kef4supyazayf7vjhennyh568ys/logo.png",
 		Website:     "https://certus.one",
 	},
-	Reward: blockatlas.StakingReward{
-		Annual: 9.259735525366604,
+	Details: blockatlas.StakingDetails{
+		Reward: blockatlas.StakingReward{
+			Annual: 9.259735525366604,
+		},
+		LockTime:      1814400,
+		MinimumAmount: "0",
 	},
-	LockTime:      1814400,
-	MinimumAmount: "0",
 }
 
 var validatorMap = blockatlas.ValidatorMap{

--- a/platform/tezos/api.go
+++ b/platform/tezos/api.go
@@ -82,16 +82,26 @@ func (p *Platform) GetValidators() (blockatlas.ValidatorPage, error) {
 	return results, nil
 }
 
+func (p *Platform) GetDetails() blockatlas.StakingDetails {
+	return blockatlas.StakingDetails{
+		Reward:        blockatlas.StakingReward{Annual: Annual},
+		MinimumAmount: blockatlas.Amount("0"),
+		LockTime:      0,
+	}
+}
+
 func normalizeValidator(v Validator) (validator blockatlas.Validator) {
 	// How to calculate Tezos APR? I have no idea. Tezos team does not know either. let's assume it's around 7% - no way to calculate in decentralized manner
 	// Delegation rewards distributed by the validators manually, it's up to them to do it.
 
 	return blockatlas.Validator{
-		Status:        true,
-		ID:            v.Address,
-		Reward:        blockatlas.StakingReward{Annual: Annual},
-		MinimumAmount: blockatlas.Amount("0"),
-		LockTime:      0,
+		Status: true,
+		ID:     v.Address,
+		Details: blockatlas.StakingDetails{
+			Reward:        blockatlas.StakingReward{Annual: Annual},
+			MinimumAmount: blockatlas.Amount("0"),
+			LockTime:      0,
+		},
 	}
 }
 

--- a/platform/tezos/api_test.go
+++ b/platform/tezos/api_test.go
@@ -91,10 +91,12 @@ func TestNormalizeValidator(t *testing.T) {
 	var v Validator
 	_ = json.Unmarshal([]byte(validatorSrc), &v)
 	expected := blockatlas.Validator{
-		Status:        true,
-		ID:            v.Address,
-		Reward:        blockatlas.StakingReward{Annual: Annual},
-		MinimumAmount: blockatlas.Amount("0"),
+		Status: true,
+		ID:     v.Address,
+		Details: blockatlas.StakingDetails{
+			Reward:        blockatlas.StakingReward{Annual: Annual},
+			MinimumAmount: blockatlas.Amount("0"),
+		},
 	}
 
 	result := normalizeValidator(v)

--- a/platform/tron/api.go
+++ b/platform/tron/api.go
@@ -133,6 +133,14 @@ func (p *Platform) GetValidators() (blockatlas.ValidatorPage, error) {
 	return results, nil
 }
 
+func (p *Platform) GetDetails() blockatlas.StakingDetails {
+	return blockatlas.StakingDetails{
+		Reward:        blockatlas.StakingReward{Annual: Annual},
+		MinimumAmount: blockatlas.Amount("1000000"),
+		LockTime:      259200,
+	}
+}
+
 func normalizeValidator(v Validator) (validator blockatlas.Validator, ok bool) {
 	address, err := HexToAddress(v.Address)
 	if err != nil {
@@ -140,11 +148,13 @@ func normalizeValidator(v Validator) (validator blockatlas.Validator, ok bool) {
 	}
 
 	return blockatlas.Validator{
-		Status:        true,
-		ID:            address,
-		Reward:        blockatlas.StakingReward{Annual: Annual},
-		MinimumAmount: blockatlas.Amount("1000000"),
-		LockTime:      259200,
+		Status: true,
+		ID:     address,
+		Details: blockatlas.StakingDetails{
+			Reward:        blockatlas.StakingReward{Annual: Annual},
+			MinimumAmount: blockatlas.Amount("1000000"),
+			LockTime:      259200,
+		},
 	}, true
 }
 

--- a/platform/tron/api_test.go
+++ b/platform/tron/api_test.go
@@ -185,11 +185,13 @@ func TestNormalizeValidator(t *testing.T) {
 	expected := blockatlas.Validator{
 		ID:     "TGzz8gjYiYRqpfmDwnLxfgPuLVNmpCswVp",
 		Status: true,
-		Reward: blockatlas.StakingReward{
-			Annual: Annual,
+		Details: blockatlas.StakingDetails{
+			Reward: blockatlas.StakingReward{
+				Annual: Annual,
+			},
+			LockTime:      259200,
+			MinimumAmount: "1000000",
 		},
-		LockTime:      259200,
-		MinimumAmount: "1000000",
 	}
 	assert.Equal(t, expected, actual)
 }
@@ -245,11 +247,13 @@ var validator1 = blockatlas.StakeValidator{
 		Image:       "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/validators/assets/tgzz8gjyiyrqpfmdwnlxfgpulvnmpcswvp/logo.png",
 		Website:     "https://www.sesameseed.org",
 	},
-	Reward: blockatlas.StakingReward{
-		Annual: 4.32,
+	Details: blockatlas.StakingDetails{
+		Reward: blockatlas.StakingReward{
+			Annual: 4.32,
+		},
+		LockTime:      259200,
+		MinimumAmount: "1000000",
 	},
-	LockTime:      259200,
-	MinimumAmount: "1000000",
 }
 
 var validator2 = blockatlas.StakeValidator{
@@ -261,11 +265,13 @@ var validator2 = blockatlas.StakeValidator{
 		Image:       "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/tron/validators/assets/tpmgfspxlqgom8skutrbhcdkthjrhfbgkw/logo.png",
 		Website:     "https://infstones.io/",
 	},
-	Reward: blockatlas.StakingReward{
-		Annual: 4.32,
+	Details: blockatlas.StakingDetails{
+		Reward: blockatlas.StakingReward{
+			Annual: 4.32,
+		},
+		LockTime:      259200,
+		MinimumAmount: "1000000",
 	},
-	LockTime:      259200,
-	MinimumAmount: "1000000",
 }
 
 var delegation1 = blockatlas.Delegation{

--- a/services/assets/client.go
+++ b/services/assets/client.go
@@ -61,9 +61,7 @@ func NormalizeValidator(plainValidator blockatlas.Validator, validator AssetVali
 			Image:       GetImage(coin, plainValidator.ID),
 			Website:     validator.Website,
 		},
-		Reward:        plainValidator.Reward,
-		LockTime:      plainValidator.LockTime,
-		MinimumAmount: plainValidator.MinimumAmount,
+		Details: plainValidator.Details,
 	}
 }
 


### PR DESCRIPTION
New response in https://github.com/trustwallet/platform/issues/192

In order to present useful information for each delegations, we need to have details exposed