### PR TITLE
Push error to sentry

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,13 @@ errors.E(err, errors.TypePlatformRequest, "new message to append", errors.Params
 		})
 ```
 
+
+- You can send the errors to sentry using `.PushToSentry()`
+`errors.E(err, errors.TypePlatformReques).PushToSentry()`
+
+
+*All fatal errors emitted by logger package already send the error to Sentry*
+
 ### Types
 
 ```

--- a/observer/dispatcher.go
+++ b/observer/dispatcher.go
@@ -49,7 +49,7 @@ func (d *Dispatcher) dispatch(event Event) {
 func (d *Dispatcher) postWebhook(hook string, data []byte, logParams logger.Params) {
 	_, err := d.Client.Post(hook, "application/json", bytes.NewReader(data))
 	if err != nil {
-		err = errors.E(err, errors.Params{"hook": hook})
+		err = errors.E(err, errors.Params{"hook": hook}).PushToSentry()
 		logger.Error(err, "Failed to dispatch event", logger.Params{"webhook": hook}, logParams)
 	}
 	logger.Info("Webhook dispatched", logger.Params{"webhook": hook}, logParams)

--- a/observer/storage.go
+++ b/observer/storage.go
@@ -47,7 +47,7 @@ func (s *Storage) SetBlockNumber(coin uint, num int64) error {
 	b := Block{Coin: coin, BlockHeight: num}
 	err := s.CreateOrUpdate(&b)
 	if err != nil {
-		return errors.E(err, errors.Params{"block": num, "coin": coin})
+		return errors.E(err, errors.Params{"block": num, "coin": coin}).PushToSentry()
 	}
 	return nil
 }
@@ -61,7 +61,7 @@ type Xpub struct {
 
 func (s *Storage) SaveXpubAddresses(coin uint, addresses []string, xpub string) error {
 	if len(addresses) == 0 {
-		return errors.E("no addresses for xpub", errors.Params{"xpub": xpub})
+		return errors.E("no addresses for xpub", errors.Params{"xpub": xpub}).PushToSentry()
 	}
 
 	a := make([]interface{}, 0)
@@ -112,7 +112,7 @@ type Subscription struct {
 
 func (s *Storage) Lookup(coin uint, addresses ...string) (observers []Subscription, err error) {
 	if len(addresses) == 0 {
-		return nil, errors.E("cannot look up an empty list", errors.Params{"coin": coin})
+		return nil, errors.E("cannot look up an empty list", errors.Params{"coin": coin}).PushToSentry()
 	}
 	s.Client.
 		Table("subscriptions").

--- a/observer/storage/memory/storage.go
+++ b/observer/storage/memory/storage.go
@@ -84,7 +84,7 @@ func (s *Storage) GetXpubFromAddress(coin uint, address string) (string, error) 
 	if ad, ok := s.addresses[address]; ok {
 		return ad, nil
 	}
-	return "", errors.E("xpub not found for the address", errors.Params{"address": address, "coin": coin})
+	return "", errors.E("xpub not found for the address", errors.Params{"address": address, "coin": coin}).PushToSentry()
 }
 
 func key(coin uint, address string) string {

--- a/observer/storage/redis/storage.go
+++ b/observer/storage/redis/storage.go
@@ -38,14 +38,14 @@ func (s *Storage) SetBlockNumber(coin uint, num int64) error {
 	key := fmt.Sprintf(keyBlockNumber, coin)
 	err := s.client.Set(key, num, 0).Err()
 	if err != nil {
-		return errors.E(err, errors.Params{"block": num, "coin": coin})
+		return errors.E(err, errors.Params{"block": num, "coin": coin}).PushToSentry()
 	}
 	return nil
 }
 
 func (s *Storage) SaveXpubAddresses(coin uint, addresses []string, xpub string) error {
 	if len(addresses) == 0 {
-		return errors.E("no addresses for xpub", errors.Params{"xpub": xpub})
+		return errors.E("no addresses for xpub", errors.Params{"xpub": xpub}).PushToSentry()
 	}
 
 	a := make(map[string]interface{})
@@ -60,7 +60,7 @@ func (s *Storage) SaveXpubAddresses(coin uint, addresses []string, xpub string) 
 	}
 	j, err := json.Marshal(addresses)
 	if err != nil {
-		return errors.E(err, errors.Params{"addresses": addresses, "coin": coin, "xpub": xpub})
+		return errors.E(err, errors.Params{"addresses": addresses, "coin": coin, "xpub": xpub}).PushToSentry()
 	}
 	err = s.saveHashMap(key, map[string]interface{}{xpub: j})
 	if err != nil {
@@ -76,16 +76,16 @@ func (s *Storage) GetAddressFromXpub(coin uint, xpub string) ([]string, error) {
 		return nil, err
 	}
 	if len(hm) == 0 {
-		return nil, errors.E("xpub not found", errors.Params{"coin": coin, "xpub": xpub})
+		return nil, errors.E("xpub not found", errors.Params{"coin": coin, "xpub": xpub}).PushToSentry()
 	}
 	r, ok := hm[0].(string)
 	if !ok {
-		return nil, errors.E("failed to cast address list from xpub", errors.Params{"coin": coin, "xpub": xpub, "hm": hm})
+		return nil, errors.E("failed to cast address list from xpub", errors.Params{"coin": coin, "xpub": xpub, "hm": hm}).PushToSentry()
 	}
 	var list []string
 	err = json.Unmarshal([]byte(r), &list)
 	if err != nil {
-		return nil, errors.E(err, errors.Params{"coin": coin, "xpub": xpub, "hm": hm, "r": r})
+		return nil, errors.E(err, errors.Params{"coin": coin, "xpub": xpub, "hm": hm, "r": r}).PushToSentry()
 	}
 	return list, nil
 }
@@ -101,14 +101,14 @@ func (s *Storage) GetXpubFromAddress(coin uint, address string) (string, error) 
 	}
 	xpub, ok := r[0].(string)
 	if !ok {
-		return "", errors.E("invalid type for xpub", errors.Params{"coin": coin, "address": address, "xpub": xpub})
+		return "", errors.E("invalid type for xpub", errors.Params{"coin": coin, "address": address, "xpub": xpub}).PushToSentry()
 	}
 	return xpub, nil
 }
 
 func (s *Storage) Lookup(coin uint, addresses ...string) (observers []observer.Subscription, err error) {
 	if len(addresses) == 0 {
-		return nil, errors.E("cannot look up an empty list", errors.Params{"coin": coin})
+		return nil, errors.E("cannot look up an empty list", errors.Params{"coin": coin}).PushToSentry()
 	}
 
 	keys := make([]string, len(addresses))
@@ -203,7 +203,7 @@ func (s *Storage) updateWebHooks(subs []observer.Subscription, operation webHook
 func (s *Storage) deleteHashMapKey(db string, fields []string) error {
 	err := s.client.HDel(db, fields...).Err()
 	if err != nil {
-		return errors.E(err, errors.Params{"db": db, "fields": fields})
+		return errors.E(err, errors.Params{"db": db, "fields": fields}).PushToSentry()
 	}
 	return nil
 }
@@ -211,7 +211,7 @@ func (s *Storage) deleteHashMapKey(db string, fields []string) error {
 func (s *Storage) saveHashMap(db string, field map[string]interface{}) error {
 	err := s.client.HMSet(db, field).Err()
 	if err != nil {
-		return errors.E(err, errors.Params{"db": db, "field": field})
+		return errors.E(err, errors.Params{"db": db, "field": field}).PushToSentry()
 	}
 	return nil
 }
@@ -219,7 +219,7 @@ func (s *Storage) saveHashMap(db string, field map[string]interface{}) error {
 func (s *Storage) getHashMap(db string, keys ...string) ([]interface{}, error) {
 	cmd := s.client.HMGet(db, keys...)
 	if err := cmd.Err(); err != nil {
-		return nil, errors.E(err, errors.Params{"db": db, "keys": keys})
+		return nil, errors.E(err, errors.Params{"db": db, "keys": keys}).PushToSentry()
 	}
 	return cmd.Val(), nil
 }

--- a/pkg/blockatlas/client.go
+++ b/pkg/blockatlas/client.go
@@ -60,7 +60,7 @@ func (r *Request) Execute(method string, url string, body io.Reader, result inte
 	start := time.Now()
 	req, err := http.NewRequest(method, url, body)
 	if err != nil {
-		return errors.E(err, errors.TypePlatformRequest, errors.Params{"url": url, "method": method})
+		return errors.E(err, errors.TypePlatformRequest, errors.Params{"url": url, "method": method}).PushToSentry()
 	}
 
 	for key, value := range r.Headers {
@@ -69,22 +69,22 @@ func (r *Request) Execute(method string, url string, body io.Reader, result inte
 
 	res, err := r.HttpClient.Do(req)
 	if err != nil {
-		return errors.E(err, errors.TypePlatformRequest, errors.Params{"url": url, "method": method})
+		return errors.E(err, errors.TypePlatformRequest, errors.Params{"url": url, "method": method}).PushToSentry()
 	}
 	go metrics.GetMetrics(res.Status, url, method, start)
 
 	err = r.ErrorHandler(res, url)
 	if err != nil {
-		return errors.E(err, errors.TypePlatformError, errors.Params{"url": url, "method": method})
+		return errors.E(err, errors.TypePlatformError, errors.Params{"url": url, "method": method}).PushToSentry()
 	}
 	defer res.Body.Close()
 	b, err := ioutil.ReadAll(res.Body)
 	if err != nil {
-		return errors.E(err, errors.TypePlatformUnmarshal, errors.Params{"url": url, "method": method})
+		return errors.E(err, errors.TypePlatformUnmarshal, errors.Params{"url": url, "method": method}).PushToSentry()
 	}
 	err = json.Unmarshal(b, result)
 	if err != nil {
-		return errors.E(err, errors.TypePlatformUnmarshal, errors.Params{"url": url, "method": method})
+		return errors.E(err, errors.TypePlatformUnmarshal, errors.Params{"url": url, "method": method}).PushToSentry()
 	}
 	return err
 }

--- a/pkg/blockatlas/jsonrpc.go
+++ b/pkg/blockatlas/jsonrpc.go
@@ -49,7 +49,10 @@ func (r *Request) RpcCall(result interface{}, method string, params []string) er
 		return err
 	}
 	if resp.Error != nil {
-		return errors.E("RPC Call error", errors.Params{"method": method, "error_code": resp.Error.Code, "error_message": resp.Error.Message}).PushToSentry()
+		return errors.E("RPC Call error", errors.Params{
+			"method":        method,
+			"error_code":    resp.Error.Code,
+			"error_message": resp.Error.Message}).PushToSentry()
 	}
 	return resp.GetObject(result)
 }

--- a/pkg/blockatlas/jsonrpc.go
+++ b/pkg/blockatlas/jsonrpc.go
@@ -31,12 +31,12 @@ type RpcError struct {
 func (r *RpcResponse) GetObject(toType interface{}) error {
 	js, err := json.Marshal(r.Result)
 	if err != nil {
-		return errors.E(err, "json-rpc GetObject Marshal error", errors.Params{"obj": toType})
+		return errors.E(err, "json-rpc GetObject Marshal error", errors.Params{"obj": toType}).PushToSentry()
 	}
 
 	err = json.Unmarshal(js, toType)
 	if err != nil {
-		return errors.E(err, "json-rpc GetObject Unmarshal error", errors.Params{"obj": toType, "string": string(js)})
+		return errors.E(err, "json-rpc GetObject Unmarshal error", errors.Params{"obj": toType, "string": string(js)}).PushToSentry()
 	}
 	return nil
 }
@@ -49,7 +49,7 @@ func (r *Request) RpcCall(result interface{}, method string, params []string) er
 		return err
 	}
 	if resp.Error != nil {
-		return errors.E("RPC Call error", errors.Params{"method": method, "error_code": resp.Error.Code, "error_message": resp.Error.Message})
+		return errors.E("RPC Call error", errors.Params{"method": method, "error_code": resp.Error.Code, "error_message": resp.Error.Message}).PushToSentry()
 	}
 	return resp.GetObject(result)
 }

--- a/pkg/blockatlas/marshal.go
+++ b/pkg/blockatlas/marshal.go
@@ -45,7 +45,7 @@ func (t *Tx) UnmarshalJSON(data []byte) error {
 	case TxAnyAction:
 		t.Meta = new(AnyAction)
 	default:
-		return errors.E("unsupported tx type", errors.Params{"type": t.Type})
+		return errors.E("unsupported tx type", errors.Params{"type": t.Type}).PushToSentry()
 	}
 	if err := json.Unmarshal(raw, t.Meta); err != nil {
 		return err
@@ -73,7 +73,7 @@ func (t *Tx) MarshalJSON() ([]byte, error) {
 	case AnyAction, *AnyAction:
 		t.Type = TxAnyAction
 	default:
-		return nil, errors.E("unsupported tx metadata", errors.Params{"meta": t.Meta})
+		return nil, errors.E("unsupported tx metadata", errors.Params{"meta": t.Meta}).PushToSentry()
 	}
 
 	// Set status to completed by default
@@ -95,7 +95,7 @@ func (a *Amount) UnmarshalJSON(data []byte) error {
 	}
 	str := string(n)
 	if !matchNumber.MatchString(str) {
-		return errors.E("not a regular decimal number", errors.Params{"str": str})
+		return errors.E("not a regular decimal number", errors.Params{"str": str}).PushToSentry()
 	}
 	if strings.ContainsRune(str, '.') {
 		str, _ = util.DecimalToSatoshis(str)

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -85,6 +85,11 @@ func (e *Error) MarshalJSON() ([]byte, error) {
 	return json.Marshal(e.JSON())
 }
 
+func (e *Error) PushToSentry() *Error {
+	SendError(e)
+	return e
+}
+
 // T create a new error with runtime stack trace.
 func T(args ...interface{}) *Error {
 	e := E(args...)
@@ -123,6 +128,5 @@ func E(args ...interface{}) *Error {
 		msg := strings.Join(message[:], ": ")
 		e.Err = errors.New(msg)
 	}
-	SendError(e)
 	return e
 }

--- a/pkg/storage/redis/hmap.go
+++ b/pkg/storage/redis/hmap.go
@@ -9,15 +9,15 @@ import (
 func (db *Redis) GetHMValue(entity, key string, value interface{}) error {
 	cmd := db.client.HMGet(entity, key)
 	if cmd.Err() != nil {
-		return errors.E(cmd.Err(), util.ErrNotFound)
+		return errors.E(cmd.Err(), util.ErrNotFound).PushToSentry()
 	}
 	val, ok := cmd.Val()[0].(string)
 	if !ok {
-		return errors.E(util.ErrNotFound)
+		return errors.E(util.ErrNotFound).PushToSentry()
 	}
 	err := json.Unmarshal([]byte(val), value)
 	if err != nil {
-		return errors.E(err, util.ErrNotFound)
+		return errors.E(err, util.ErrNotFound).PushToSentry()
 	}
 	return nil
 }
@@ -25,11 +25,11 @@ func (db *Redis) GetHMValue(entity, key string, value interface{}) error {
 func (db *Redis) AddHM(entity, key string, value interface{}) error {
 	j, err := json.Marshal(value)
 	if err != nil {
-		return errors.E(err, errors.Params{"value": value})
+		return errors.E(err, errors.Params{"value": value}).PushToSentry()
 	}
 	cmd := db.client.HMSet(entity, map[string]interface{}{key: j})
 	if cmd.Err() != nil {
-		return errors.E(cmd.Err(), util.ErrNotStored)
+		return errors.E(cmd.Err(), util.ErrNotStored).PushToSentry().PushToSentry()
 	}
 	return nil
 }
@@ -37,7 +37,7 @@ func (db *Redis) AddHM(entity, key string, value interface{}) error {
 func (db *Redis) DeleteHM(entity, key string) error {
 	cmd := db.client.HDel(entity, key)
 	if cmd.Err() != nil {
-		return errors.E(cmd.Err(), util.ErrNotDeleted)
+		return errors.E(cmd.Err(), util.ErrNotDeleted).PushToSentry()
 	}
 	return nil
 }

--- a/pkg/storage/redis/redis.go
+++ b/pkg/storage/redis/redis.go
@@ -14,11 +14,11 @@ type Redis struct {
 func (db *Redis) Init(host string) error {
 	options, err := redis.ParseURL(host)
 	if err != nil {
-		return errors.E(err, "Cannot connect to Redis")
+		return errors.E(err, "Cannot connect to Redis").PushToSentry()
 	}
 	client := redis.NewClient(options)
 	if err := client.Ping().Err(); err != nil {
-		return errors.E(err, "Redis connection test failed")
+		return errors.E(err, "Redis connection test failed").PushToSentry()
 	}
 	db.client = client
 	return nil
@@ -27,11 +27,11 @@ func (db *Redis) Init(host string) error {
 func (db *Redis) GetValue(key string, value interface{}) error {
 	cmd := db.client.Get(key)
 	if cmd.Err() != nil {
-		return errors.E(cmd.Err(), util.ErrNotFound)
+		return errors.E(cmd.Err(), util.ErrNotFound).PushToSentry()
 	}
 	err := json.Unmarshal([]byte(cmd.Val()), value)
 	if err != nil {
-		return errors.E(err, util.ErrNotFound)
+		return errors.E(err, util.ErrNotFound).PushToSentry()
 	}
 	return nil
 }
@@ -39,11 +39,11 @@ func (db *Redis) GetValue(key string, value interface{}) error {
 func (db *Redis) Add(key string, value interface{}) error {
 	j, err := json.Marshal(value)
 	if err != nil {
-		return errors.E(err, errors.Params{"value": value})
+		return errors.E(err, errors.Params{"value": value}).PushToSentry()
 	}
 	cmd := db.client.Set(key, j, 0)
 	if cmd.Err() != nil {
-		return errors.E(cmd.Err(), util.ErrNotStored)
+		return errors.E(cmd.Err(), util.ErrNotStored).PushToSentry()
 	}
 	return nil
 }
@@ -51,7 +51,7 @@ func (db *Redis) Add(key string, value interface{}) error {
 func (db *Redis) Delete(key string) error {
 	cmd := db.client.Del(key)
 	if cmd.Err() != nil {
-		return errors.E(cmd.Err(), util.ErrNotDeleted)
+		return errors.E(cmd.Err(), util.ErrNotDeleted).PushToSentry()
 	}
 	return nil
 }

--- a/pkg/storage/sql/postgres.go
+++ b/pkg/storage/sql/postgres.go
@@ -13,7 +13,7 @@ type PgSql struct {
 func (db *PgSql) Init(host string) error {
 	client, err := gorm.Open("postgres", host)
 	if err != nil {
-		return errors.E(err, "postgress connection failed")
+		return errors.E(err, "postgress connection failed").PushToSentry()
 	}
 	db.Client = client
 	return nil

--- a/pkg/storage/sql/sql.go
+++ b/pkg/storage/sql/sql.go
@@ -15,7 +15,7 @@ type Handler func(value interface{}) error
 func (db *sql) Get(value interface{}) error {
 	err := db.Client.Last(value).Error
 	if err != nil {
-		return errors.E(err, util.ErrNotFound)
+		return errors.E(err, util.ErrNotFound).PushToSentry()
 	}
 	return nil
 }
@@ -23,7 +23,7 @@ func (db *sql) Get(value interface{}) error {
 func (db *sql) Find(out interface{}, where ...interface{}) error {
 	err := db.Client.Find(out, where...).Error
 	if err != nil {
-		return errors.E(err, util.ErrNotFound)
+		return errors.E(err, util.ErrNotFound).PushToSentry()
 	}
 	return nil
 }
@@ -41,7 +41,7 @@ func (db *sql) Update(value interface{}) error {
 	}
 	err := db.Client.Save(value).Error
 	if err != nil {
-		return errors.E(err, util.ErrNotUpdated)
+		return errors.E(err, util.ErrNotUpdated).PushToSentry()
 	}
 	return nil
 }
@@ -53,7 +53,7 @@ func (db *sql) UpdateMany(values ...interface{}) error {
 func (db *sql) Add(value interface{}) error {
 	err := db.Client.Create(value).Error
 	if err != nil {
-		return errors.E(err, util.ErrNotStored)
+		return errors.E(err, util.ErrNotStored).PushToSentry()
 	}
 	return nil
 }
@@ -65,7 +65,7 @@ func (db *sql) AddMany(values ...interface{}) error {
 func (db *sql) Delete(value interface{}) error {
 	err := db.Client.Delete(value).Error
 	if err != nil {
-		return errors.E(err, util.ErrNotDeleted)
+		return errors.E(err, util.ErrNotDeleted).PushToSentry()
 	}
 	return nil
 }

--- a/platform/binance/api.go
+++ b/platform/binance/api.go
@@ -42,7 +42,7 @@ func (p *Platform) CurrentBlockNumber() (int64, error) {
 		return 0, err
 	}
 	if len(list.BlockArray) == 0 {
-		return 0, errors.E("no block descriptor found", errors.TypePlatformApi)
+		return 0, errors.E("no block descriptor found", errors.TypePlatformApi).PushToSentry()
 	}
 	return list.BlockArray[0].BlockHeight, nil
 }

--- a/platform/binance/client.go
+++ b/platform/binance/client.go
@@ -52,7 +52,7 @@ func getHTTPError(res *http.Response, desc string) error {
 	case http.StatusOK:
 		return nil
 	default:
-		return errors.E("getHTTPError error", errors.Params{"status": res.Status})
+		return errors.E("getHTTPError error", errors.Params{"status": res.Status}).PushToSentry()
 	}
 }
 
@@ -60,7 +60,7 @@ func getAPIError(res *http.Response, desc string) error {
 	var sErr Error
 	err := json.NewDecoder(res.Body).Decode(&sErr)
 	if err != nil {
-		err = errors.E(err, errors.TypePlatformUnmarshal, errors.Params{"desc": desc})
+		err = errors.E(err, errors.TypePlatformUnmarshal, errors.Params{"desc": desc}).PushToSentry()
 		logger.Error(err, "Binance: Failed to decode error response")
 		return blockatlas.ErrSourceConn
 	}

--- a/platform/cosmos/client.go
+++ b/platform/cosmos/client.go
@@ -57,7 +57,7 @@ func (c *Client) CurrentBlockNumber() (num int64, err error) {
 
 	num, err = strconv.ParseInt(block.Meta.Header.Height, 10, 64)
 	if err != nil {
-		return num, errors.E("error to ParseInt", errors.TypePlatformUnmarshal)
+		return num, errors.E("error to ParseInt", errors.TypePlatformUnmarshal).PushToSentry()
 	}
 
 	return num, nil
@@ -77,7 +77,7 @@ func (c *Client) GetInflation() (float64, error) {
 
 	s, err := strconv.ParseFloat(result, 32)
 	if err != nil {
-		return 0, errors.E("error to ParseFloat", errors.TypePlatformUnmarshal)
+		return 0, errors.E("error to ParseFloat", errors.TypePlatformUnmarshal).PushToSentry()
 	}
 	return s, nil
 }

--- a/platform/ethereum/collections_client.go
+++ b/platform/ethereum/collections_client.go
@@ -29,7 +29,7 @@ func (c CollectionsClient) GetCollectibles(owner string, collectibleID string) (
 	collection := searchCollection(collections, id)
 	if collection == nil {
 		return nil, nil, errors.E("collectible not found", errors.TypePlatformClient,
-			errors.Params{"collectibleID": collectibleID})
+			errors.Params{"collectibleID": collectibleID}).PushToSentry()
 	}
 
 	query := url.Values{

--- a/platform/icon/api.go
+++ b/platform/icon/api.go
@@ -45,7 +45,7 @@ func (p *Platform) GetTxsByAddress(address string) (blockatlas.TxPage, error) {
 func Normalize(trx *Tx) (tx blockatlas.Tx, b bool) {
 	date, err := time.Parse("2006-01-02T15:04:05.999Z0700", trx.CreateDate)
 	if err != nil {
-		err = errors.E(err, errors.TypePlatformUnmarshal)
+		err = errors.E(err, errors.TypePlatformUnmarshal).PushToSentry()
 		logger.Error(err)
 		return tx, false
 	}

--- a/platform/iotex/client.go
+++ b/platform/iotex/client.go
@@ -21,7 +21,7 @@ func (c *Client) GetLatestBlock() (int64, error) {
 	}
 	b, err := strconv.ParseInt(chainMeta.Height, 10, 64)
 	if err != nil {
-		return 0, errors.E(err, "ParseInt failed", errors.TypePlatformUnmarshal)
+		return 0, errors.E(err, "ParseInt failed", errors.TypePlatformUnmarshal).PushToSentry()
 	}
 	return b, nil
 }

--- a/platform/stellar/client.go
+++ b/platform/stellar/client.go
@@ -38,7 +38,7 @@ func (c *Client) CurrentBlockNumber() (int64, error) {
 	}
 
 	if len(ledgers.Embedded.Records) == 0 {
-		return 0, errors.E("CurrentBlockNumber: Records is empty", errors.TypePlatformUnmarshal)
+		return 0, errors.E("CurrentBlockNumber: Records is empty", errors.TypePlatformUnmarshal).PushToSentry()
 	}
 	return ledgers.Embedded.Records[0].Sequence, nil
 }

--- a/platform/tron/api.go
+++ b/platform/tron/api.go
@@ -78,7 +78,7 @@ func (p *Platform) GetTokenTxsByAddress(address, token string) (blockatlas.TxPag
 func NormalizeTokenTransfer(srcTx *Tx, tokenInfo AssetInfo) (tx blockatlas.Tx, e error) {
 	if len(srcTx.Data.Contracts) == 0 {
 		return tx, errors.E("token transfer without contract", errors.TypePlatformApi,
-			errors.Params{"tokenInfo": tokenInfo, "tx": tx})
+			errors.Params{"tokenInfo": tokenInfo, "tx": tx}).PushToSentry()
 	}
 	contract := &srcTx.Data.Contracts[0]
 

--- a/platform/tron/util.go
+++ b/platform/tron/util.go
@@ -13,7 +13,7 @@ func HexToAddress(hexAddr string) (b58 string, err error) {
 	bytes, err := hex.DecodeString(hexAddr)
 	if err != nil {
 		return "", errors.E(err, errors.TypePlatformUnmarshal,
-			errors.Params{"hexAddr": hexAddr})
+			errors.Params{"hexAddr": hexAddr}).PushToSentry()
 	}
 	var checksum [32]byte
 	checksum = sha256.Sum256(bytes)

--- a/platform/vechain/api.go
+++ b/platform/vechain/api.go
@@ -70,7 +70,7 @@ func (p *Platform) GetTokenTxsByAddress(address string, token string) (blockatla
 		return p.getThorTxsByAddress(address)
 	} else {
 		return nil, errors.E("vechain invalid token", errors.TypePlatformUnmarshal,
-			errors.Params{"token": token})
+			errors.Params{"token": token}).PushToSentry()
 	}
 }
 
@@ -103,7 +103,7 @@ func (p *Platform) getThorTxsByAddress(address string) ([]blockatlas.Tx, error) 
 		tx, err := NormalizeTokenTransfer(&t, receipt)
 		if err != nil {
 			p := logger.Params{"receipt": receipt, "transfer": t}
-			err = errors.E(err, "invalid token", errors.TypePlatformUnmarshal, p)
+			err = errors.E(err, "invalid token", errors.TypePlatformUnmarshal, p).PushToSentry()
 			logger.Error(err, "getTxsByAddress clause error", p)
 			continue
 		}
@@ -126,7 +126,7 @@ func (p *Platform) getTransactionReceipt(ids []string) chan *TransferReceipt {
 			receipt, err := p.client.GetTransactionReceipt(id)
 			if err != nil {
 				err = errors.E(err, "Failed to get tx receipt", errors.TypePlatformUnmarshal,
-					errors.Params{"id": id})
+					errors.Params{"id": id}).PushToSentry()
 				logger.Error(err, logger.Params{"id": id})
 				return
 			}
@@ -153,7 +153,7 @@ func (p *Platform) getTransactions(ids []string) chan *NativeTransaction {
 			receipt, err := p.client.GetTransactionByID(id)
 			if err != nil {
 				err = errors.E(err, "Failed to get tx transaction", errors.TypePlatformUnmarshal,
-					errors.Params{"id": id})
+					errors.Params{"id": id}).PushToSentry()
 				logger.Error(err, logger.Params{"id": id})
 				return
 			}
@@ -194,7 +194,7 @@ func (p *Platform) getTxsByAddress(address string) ([]blockatlas.Tx, error) {
 			tx, err := NormalizeTransfer(receipt, &clause)
 			if err != nil {
 				p := logger.Params{"receipt": receipt, "clause": clause}
-				err = errors.E(err, errors.TypePlatformUnmarshal, p)
+				err = errors.E(err, errors.TypePlatformUnmarshal, p).PushToSentry()
 				logger.Error(err, "getTxsByAddress clause error", p)
 				continue
 			}
@@ -207,7 +207,7 @@ func (p *Platform) getTxsByAddress(address string) ([]blockatlas.Tx, error) {
 
 func NormalizeTransfer(receipt *TransferReceipt, clause *Clause) (blockatlas.Tx, error) {
 	if receipt.Receipt == nil || clause == nil {
-		return blockatlas.Tx{}, errors.E("invalid parameters", errors.Params{"receipt": receipt, "clause": clause})
+		return blockatlas.Tx{}, errors.E("invalid parameters", errors.Params{"receipt": receipt, "clause": clause}).PushToSentry()
 	}
 	feeBase10, err := util.HexToDecimal(receipt.Receipt.Paid)
 	if err != nil {

--- a/services/assets/client.go
+++ b/services/assets/client.go
@@ -14,7 +14,7 @@ const (
 func GetValidators(api blockatlas.StakeAPI) ([]blockatlas.StakeValidator, error) {
 	assetsValidators, err := GetValidatorsInfo(api.Coin())
 	if err != nil {
-		return nil, errors.E(err, "unable to fetch validators list from the registry")
+		return nil, errors.E(err, "unable to fetch validators list from the registry").PushToSentry()
 	}
 
 	validators, err := api.GetValidators()
@@ -34,7 +34,7 @@ func GetValidatorsInfo(coin coin.Coin) ([]AssetValidator, error) {
 	}
 	err := request.Get(&results, "validators/list.json", nil)
 	if err != nil {
-		return nil, errors.E(err, errors.Params{"coin": coin.Handle})
+		return nil, errors.E(err, errors.Params{"coin": coin.Handle}).PushToSentry()
 	}
 	return results, nil
 }

--- a/util/decimal.go
+++ b/util/decimal.go
@@ -15,7 +15,7 @@ func DecimalToSatoshis(dec string) (string, error) {
 	out = strings.TrimLeft(out, "0")
 	for _, c := range out {
 		if !unicode.IsNumber(c) {
-			return "", errors.E("not a number", errors.Params{"dec": dec, "c": c})
+			return "", errors.E("not a number", errors.Params{"dec": dec, "c": c}).PushToSentry()
 		}
 	}
 	return out, nil
@@ -63,7 +63,7 @@ func DecimalExp(dec string, exp int) string {
 func HexToDecimal(hex string) (string, error) {
 	var i big.Int
 	if _, ok := i.SetString(hex, 0); !ok {
-		return "", errors.E("invalid hex", errors.Params{"hex": hex})
+		return "", errors.E("invalid hex", errors.Params{"hex": hex}).PushToSentry()
 	}
 	return i.String(), nil
 }


### PR DESCRIPTION
# Headline
Change the way to send errors to Sentry

## Problem
If you create a new custom error, the error automatically going to send to Sentry, sometimes we don't want to send that to Sentry

## Solution
Create a method to send an error to Sentry: `.PushToSentry()`
