### PR TITLE
Fix integration tests for Algorand

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -190,4 +190,5 @@ decred:
   api: https://blockbook.decred.org:9161/api
 
 algorand:
-  api: https://algorand.node
+  api: https://mainnet-algorand.api.purestake.io/ps1
+#  key: YOUR_API_KEY

--- a/platform/algorand/api.go
+++ b/platform/algorand/api.go
@@ -13,7 +13,8 @@ type Platform struct {
 }
 
 func (p *Platform) Init() error {
-	p.client = InitClient(viper.GetString("algorand.api"))
+	p.client = Client{blockatlas.InitClient(viper.GetString("algorand.api"))}
+	p.client.Headers["x-api-key"] = viper.GetString("algorand.key")
 	return nil
 }
 


### PR DESCRIPTION
We going to start to use this provider for Algorand inside the integrations tests: `purestake.io`