### PR TITLE
Return empty result instead of 400/500 errors

### DIFF
--- a/api/naming_service.go
+++ b/api/naming_service.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	CoinType "github.com/trustwallet/blockatlas/coin"
+	"github.com/trustwallet/blockatlas/pkg/blockatlas"
 	"github.com/trustwallet/blockatlas/platform"
 )
 
@@ -58,6 +59,5 @@ func handleLookup(c *gin.Context) {
 			}
 		}
 	}
-
-	RenderError(c, http.StatusBadRequest, "not supported domain")
+	RenderSuccess(c, blockatlas.Resolved{Result: "", Coin: coin})
 }

--- a/platform/ethereum/ens.go
+++ b/platform/ethereum/ens.go
@@ -25,7 +25,11 @@ func (p *Platform) Lookup(coin uint64, name string) (*blockatlas.Resolved, error
 
 	ensName, err := ens.NewName(client, name)
 	if err != nil {
-		return nil, errors.E(http.StatusInternalServerError, err.Error())
+		logger.Error("Query ens failed", err, logger.Params{
+			"name": name,
+			"coin": coin,
+		})
+		return &result, nil
 	}
 
 	address, err := ensName.Address(coin)


### PR DESCRIPTION
suppress errors

- 500 "name is not valid according to the rules of the registrar (too short, invalid characters, etc.)
- 400 not supported domains