### PR TITLE
Add direction for non-UTXO's blockchain

### DIFF
--- a/observer/observer.go
+++ b/observer/observer.go
@@ -75,6 +75,11 @@ func (o *Observer) processBlock(events chan<- Event, block *blockatlas.Block) {
 		// Verify the tx is for xpub
 		xpubAddresses, ok := xpubs[sub.Address]
 		for _, tx := range tx.Txs() {
+			if sub.Address == tx.To {
+				tx.Direction = blockatlas.DirectionIncoming
+			} else if sub.Address == tx.From {
+				tx.Direction = blockatlas.DirectionOutgoing
+			}
 			if ok {
 				// Create a mapset for xpub addresses
 				addressSet := mapset.NewSet()


### PR DESCRIPTION
# Headline
Add direction for non-UTXO's blockchains

## Problem
If you send a transaction for another wallet inside your app, you going two receive 2 push notifications with `received` title

https://github.com/trustwallet/backend/blob/master/services/notifications/message.go#L76

## Solution
Infer the direction for non-UTXO's blockchains, and parse inside the backend