### PR TITLE
Use url.Path + url.RawQueryas unique identifier for the request

### DIFF
--- a/pkg/ginutils/gincache/cache.go
+++ b/pkg/ginutils/gincache/cache.go
@@ -97,22 +97,22 @@ func (w *cachedWriter) WriteString(data string) (n int, err error) {
 	return ret, err
 }
 
-func generateKey(path string, c *gin.Context) string {
+func generateKey(c *gin.Context) string {
+	url := c.Request.URL.String()
 	var b []byte
 	if c.Request.Body != nil {
 		b, _ = ioutil.ReadAll(c.Request.Body)
 		// Restore the io.ReadCloser to its original state
 		c.Request.Body = ioutil.NopCloser(bytes.NewBuffer(b))
 	}
-	hash := sha1.Sum(append([]byte(path), b...))
+	hash := sha1.Sum(append([]byte(url), b...))
 	return base64.URLEncoding.EncodeToString(hash[:])
 }
 
 // CacheMiddleware encapsulates a gin handler function and caches the response with an expiration time.
 func CacheMiddleware(expiration time.Duration, handle gin.HandlerFunc) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		url := c.Request.URL.String()
-		key := generateKey(url, c)c.Request.URL.String()
+		key := generateKey(c)
 		mc, err := getCacheResponse(key)
 		if err != nil || mc.Data == nil {
 			writer := newCachedWriter(expiration, c.Writer, key)

--- a/pkg/ginutils/gincache/cache.go
+++ b/pkg/ginutils/gincache/cache.go
@@ -112,7 +112,8 @@ func generateKey(path string, c *gin.Context) string {
 func CacheMiddleware(expiration time.Duration, handle gin.HandlerFunc) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		url := c.Request.URL
-		key := generateKey(url.RawQuery, c)
+		urlPath := url.Path + "?" + url.RawQuery
+		key := generateKey(urlPath, c)
 		mc, err := getCacheResponse(key)
 		if err != nil || mc.Data == nil {
 			writer := newCachedWriter(expiration, c.Writer, key)

--- a/pkg/ginutils/gincache/cache.go
+++ b/pkg/ginutils/gincache/cache.go
@@ -111,9 +111,8 @@ func generateKey(path string, c *gin.Context) string {
 // CacheMiddleware encapsulates a gin handler function and caches the response with an expiration time.
 func CacheMiddleware(expiration time.Duration, handle gin.HandlerFunc) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		url := c.Request.URL
-		urlPath := url.Path + "?" + url.RawQuery
-		key := generateKey(urlPath, c)
+		url := fmt.Sprintf("%s", c.Request.URL)
+		key := generateKey(url, c)
 		mc, err := getCacheResponse(key)
 		if err != nil || mc.Data == nil {
 			writer := newCachedWriter(expiration, c.Writer, key)

--- a/pkg/ginutils/gincache/cache.go
+++ b/pkg/ginutils/gincache/cache.go
@@ -112,7 +112,7 @@ func generateKey(path string, c *gin.Context) string {
 func CacheMiddleware(expiration time.Duration, handle gin.HandlerFunc) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		url := c.Request.URL
-		key := generateKey(url.Path, c)
+		key := generateKey(url.RawQuery, c)
 		mc, err := getCacheResponse(key)
 		if err != nil || mc.Data == nil {
 			writer := newCachedWriter(expiration, c.Writer, key)

--- a/pkg/ginutils/gincache/cache.go
+++ b/pkg/ginutils/gincache/cache.go
@@ -111,8 +111,8 @@ func generateKey(path string, c *gin.Context) string {
 // CacheMiddleware encapsulates a gin handler function and caches the response with an expiration time.
 func CacheMiddleware(expiration time.Duration, handle gin.HandlerFunc) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		url := fmt.Sprintf("%s", c.Request.URL)
-		key := generateKey(url, c)
+		url := c.Request.URL.String()
+		key := generateKey(url, c)c.Request.URL.String()
 		mc, err := getCacheResponse(key)
 		if err != nil || mc.Data == nil {
 			writer := newCachedWriter(expiration, c.Writer, key)


### PR DESCRIPTION
If you pass `/test?value=1` it would treat key as `/test`. `RawQuery` will allow us to cache for any request params separately 

Example: `/test?value=1`
Path: `/test`
RawQuery: `/test?value=1`