### PR TITLE
fix unit tests for array assertion

### DIFF
--- a/api/observer_test.go
+++ b/api/observer_test.go
@@ -56,7 +56,9 @@ func Test_parseSubscriptions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gotSubs := parseSubscriptions(tt.subscriptions, tt.webhook)
-			assert.EqualValues(t, tt.wantSubs, gotSubs)
+			if !assert.ObjectsAreEqual(tt.wantSubs, gotSubs) {
+				t.Errorf("parseSubscriptions() = %v, want %v", gotSubs, tt.wantSubs)
+			}
 		})
 	}
 }

--- a/api/observer_test.go
+++ b/api/observer_test.go
@@ -56,7 +56,7 @@ func Test_parseSubscriptions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gotSubs := parseSubscriptions(tt.subscriptions, tt.webhook)
-			if !assert.ObjectsAreEqual(tt.wantSubs, gotSubs) {
+			if !assert.ObjectsAreEqualValues(tt.wantSubs, gotSubs) {
 				t.Errorf("parseSubscriptions() = %v, want %v", gotSubs, tt.wantSubs)
 			}
 		})

--- a/marketdata/market/coinmarketcap/cmc_test.go
+++ b/marketdata/market/coinmarketcap/cmc_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/trustwallet/blockatlas/pkg/blockatlas"
 	"math/big"
+	"sort"
 	"testing"
 	"time"
 )
@@ -21,13 +22,13 @@ func Test_normalizeTickers(t *testing.T) {
 		{
 			"test normalize cmc quote",
 			args{prices: CoinPrices{Data: []Data{
-				{Coin: Coin{Symbol: "BTC"}, LastUpdated: time.Unix(333, 0), Quote: Quote{
+				{Coin: Coin{Symbol: "BTC"}, LastUpdated: time.Unix(111, 0), Quote: Quote{
 					USD: USD{Price: 223.55, PercentChange24h: 10}}},
 				{Coin: Coin{Symbol: "ETH"}, LastUpdated: time.Unix(333, 0), Quote: Quote{
 					USD: USD{Price: 11.11, PercentChange24h: 20}}}}},
 				provider: "cmc"},
 			blockatlas.Tickers{
-				blockatlas.Ticker{CoinName: "BTC", CoinType: blockatlas.TypeCoin, LastUpdate: time.Unix(333, 0),
+				blockatlas.Ticker{CoinName: "BTC", CoinType: blockatlas.TypeCoin, LastUpdate: time.Unix(111, 0),
 					Price: blockatlas.TickerPrice{
 						Value:     big.NewFloat(223.55),
 						Change24h: big.NewFloat(10),
@@ -49,6 +50,9 @@ func Test_normalizeTickers(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gotTickers := normalizeTickers(tt.args.prices, tt.args.provider)
+			sort.SliceStable(gotTickers, func(i, j int) bool {
+				return gotTickers[i].LastUpdate.Unix() < gotTickers[j].LastUpdate.Unix()
+			})
 			if !assert.ObjectsAreEqualValues(gotTickers, tt.wantTickers) {
 				t.Errorf("normalizeTickers() = %v, want %v", gotTickers, tt.wantTickers)
 			}

--- a/marketdata/market/coinmarketcap/cmc_test.go
+++ b/marketdata/market/coinmarketcap/cmc_test.go
@@ -1,9 +1,9 @@
 package cmc
 
 import (
+	"github.com/stretchr/testify/assert"
 	"github.com/trustwallet/blockatlas/pkg/blockatlas"
 	"math/big"
-	"reflect"
 	"testing"
 	"time"
 )
@@ -48,7 +48,8 @@ func Test_normalizeTickers(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if gotTickers := normalizeTickers(tt.args.prices, tt.args.provider); !reflect.DeepEqual(gotTickers, tt.wantTickers) {
+			gotTickers := normalizeTickers(tt.args.prices, tt.args.provider)
+			if !assert.ObjectsAreEqualValues(gotTickers, tt.wantTickers) {
 				t.Errorf("normalizeTickers() = %v, want %v", gotTickers, tt.wantTickers)
 			}
 		})

--- a/marketdata/rate/coinmarketcap/cmc_test.go
+++ b/marketdata/rate/coinmarketcap/cmc_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/trustwallet/blockatlas/pkg/blockatlas"
 	"math/big"
+	"sort"
 	"testing"
 	"time"
 )
@@ -84,6 +85,10 @@ func Test_normalizeRates(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gotRates := normalizeRates(tt.prices)
+			sort.SliceStable(gotRates, func(i, j int) bool {
+				y := gotRates[i].Rate.Cmp(gotRates[j].Rate)
+				return y <= 0
+			})
 			if !assert.ObjectsAreEqualValues(gotRates, tt.wantRates) {
 				t.Errorf("normalizeRates() = %v, want %v", gotRates, tt.wantRates)
 			}

--- a/marketdata/rate/coinmarketcap/cmc_test.go
+++ b/marketdata/rate/coinmarketcap/cmc_test.go
@@ -1,9 +1,9 @@
 package cmc
 
 import (
+	"github.com/stretchr/testify/assert"
 	"github.com/trustwallet/blockatlas/pkg/blockatlas"
 	"math/big"
-	"reflect"
 	"testing"
 	"time"
 )
@@ -83,7 +83,8 @@ func Test_normalizeRates(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if gotRates := normalizeRates(tt.prices); !reflect.DeepEqual(gotRates, tt.wantRates) {
+			gotRates := normalizeRates(tt.prices)
+			if !assert.ObjectsAreEqualValues(gotRates, tt.wantRates) {
 				t.Errorf("normalizeRates() = %v, want %v", gotRates, tt.wantRates)
 			}
 		})

--- a/marketdata/rate/fixer/fixer_test.go
+++ b/marketdata/rate/fixer/fixer_test.go
@@ -1,9 +1,9 @@
 package fixer
 
 import (
+	"github.com/stretchr/testify/assert"
 	"github.com/trustwallet/blockatlas/pkg/blockatlas"
 	"math/big"
-	"reflect"
 	"testing"
 	"time"
 )
@@ -43,7 +43,8 @@ func Test_normalizeRates(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if gotRates := normalizeRates(tt.latest); !reflect.DeepEqual(gotRates, tt.wantRates) {
+			gotRates := normalizeRates(tt.latest)
+			if !assert.ObjectsAreEqualValues(gotRates, tt.wantRates) {
 				t.Errorf("normalizeRates() = %v, want %v", gotRates, tt.wantRates)
 			}
 		})

--- a/marketdata/rate/fixer/fixer_test.go
+++ b/marketdata/rate/fixer/fixer_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/trustwallet/blockatlas/pkg/blockatlas"
 	"math/big"
+	"sort"
 	"testing"
 	"time"
 )
@@ -35,8 +36,8 @@ func Test_normalizeRates(t *testing.T) {
 				UpdatedAt: time.Now(),
 			},
 			blockatlas.Rates{
-				blockatlas.Rate{Currency: "LSK", Rate: big.NewFloat(123.321), Timestamp: 333},
 				blockatlas.Rate{Currency: "IFC", Rate: big.NewFloat(34.973), Timestamp: 333},
+				blockatlas.Rate{Currency: "LSK", Rate: big.NewFloat(123.321), Timestamp: 333},
 				blockatlas.Rate{Currency: "DUO", Rate: big.NewFloat(998.3), Timestamp: 333},
 			},
 		},
@@ -44,6 +45,10 @@ func Test_normalizeRates(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			gotRates := normalizeRates(tt.latest)
+			sort.SliceStable(gotRates, func(i, j int) bool {
+				y := gotRates[i].Rate.Cmp(gotRates[j].Rate)
+				return y <= 0
+			})
 			if !assert.ObjectsAreEqualValues(gotRates, tt.wantRates) {
 				t.Errorf("normalizeRates() = %v, want %v", gotRates, tt.wantRates)
 			}


### PR DESCRIPTION
fix unit test because sometimes array is not sorted in the same way

```
--- FAIL: Test_parseSubscriptions (0.00s)
    --- FAIL: Test_parseSubscriptions/webhook_with_2_coins (0.00s)
        observer_test.go:59: 
            	Error Trace:	observer_test.go:59
            	Error:      	Not equal: 
            	            	expected: []blockatlas.Subscription{blockatlas.Subscription{Coin:0x2, Address:"zpub6rH4MwgyTmuexAX6HAraks5cKv5BbtmwdLirvnU5845ovUJb4abgjt9DtXK4ZEaToRrNj8dQznuLC6Nka4eMviGMinCVMUxKLpuyddcG9Vc", Webhook:"http://127.0.0.1:8080"}, blockatlas.Subscription{Coin:0x0, Address:"xpub6BpYi6J1GZzfY3yY7DbhLLccF3efQa18nQngM3jaehgtNSoEgk6UtPULpC3oK5oA3trczY8Ld34LFw1USMPfGHwTEizdD5QyGcMyuh2UoBA", Webhook:"http://127.0.0.1:8080"}, blockatlas.Subscription{Coin:0x0, Address:"xpub6CYwPfnPJLPquufPkb98coSb3mdy1CgaZrWUtYWGJTJ4VWZUbzH9HLGy7nHpP7DG4UdTkYYpirkTWQSP7pWHsrk24Nos5oYNHpfr4BgPVTL", Webhook:"http://127.0.0.1:8080"}}
            	            	actual  : []blockatlas.Subscription{blockatlas.Subscription{Coin:0x0, Address:"xpub6BpYi6J1GZzfY3yY7DbhLLccF3efQa18nQngM3jaehgtNSoEgk6UtPULpC3oK5oA3trczY8Ld34LFw1USMPfGHwTEizdD5QyGcMyuh2UoBA", Webhook:"http://127.0.0.1:8080"}, blockatlas.Subscription{Coin:0x0, Address:"xpub6CYwPfnPJLPquufPkb98coSb3mdy1CgaZrWUtYWGJTJ4VWZUbzH9HLGy7nHpP7DG4UdTkYYpirkTWQSP7pWHsrk24Nos5oYNHpfr4BgPVTL", Webhook:"http://127.0.0.1:8080"}, blockatlas.Subscription{Coin:0x2, Address:"zpub6rH4MwgyTmuexAX6HAraks5cKv5BbtmwdLirvnU5845ovUJb4abgjt9DtXK4ZEaToRrNj8dQznuLC6Nka4eMviGMinCVMUxKLpuyddcG9Vc", Webhook:"http://127.0.0.1:8080"}}
            	            	
            	            	Diff:
            	            	--- Expected
            	            	+++ Actual
            	            	@@ -1,7 +1,2 @@
            	            	 ([]blockatlas.Subscription) (len=3) {
            	            	- (blockatlas.Subscription) {
            	            	-  Coin: (uint) 2,
            	            	-  Address: (string) (len=111) "zpub6rH4MwgyTmuexAX6HAraks5cKv5BbtmwdLirvnU5845ovUJb4abgjt9DtXK4ZEaToRrNj8dQznuLC6Nka4eMviGMinCVMUxKLpuyddcG9Vc",
            	            	-  Webhook: (string) (len=21) "http://127.0.0.1:8080"
            	            	- },
            	            	  (blockatlas.Subscription) {
            	            	@@ -15,2 +10,7 @@
            	            	   Webhook: (string) (len=21) "http://127.0.0.1:8080"
            	            	+ },
            	            	+ (blockatlas.Subscription) {
            	            	+  Coin: (uint) 2,
            	            	+  Address: (string) (len=111) "zpub6rH4MwgyTmuexAX6HAraks5cKv5BbtmwdLirvnU5845ovUJb4abgjt9DtXK4ZEaToRrNj8dQznuLC6Nka4eMviGMinCVMUxKLpuyddcG9Vc",
            	            	+  Webhook: (string) (len=21) "http://127.0.0.1:8080"
            	            	  }
            	Test:       	Test_parseSubscriptions/webhook_with_2_coins
    --- PASS: Test_parseSubscriptions/webhook_with_1_coin (0.00s)
FAIL
```