### PR TITLE
Fix Nano platform

### DIFF
--- a/platform/nano/api.go
+++ b/platform/nano/api.go
@@ -1,6 +1,7 @@
 package nano
 
 import (
+	"encoding/json"
 	"strconv"
 
 	"github.com/trustwallet/blockatlas/coin"
@@ -25,12 +26,21 @@ func (p *Platform) Coin() coin.Coin {
 func (p *Platform) GetTxsByAddress(address string) (blockatlas.TxPage, error) {
 	normalized := make([]blockatlas.Tx, 0)
 	history, err := p.client.GetAccountHistory(address)
-
 	if err != nil {
 		return nil, err
 	}
 
-	for _, srcTx := range history.History {
+	b, err := json.Marshal(history.History)
+	if err != nil {
+		return nil, err
+	}
+
+	var txs []Transaction
+	err = json.Unmarshal(b, &txs)
+	if err != nil {
+		return normalized, nil
+	}
+	for _, srcTx := range txs {
 		tx := p.Normalize(&srcTx, history.Account)
 		normalized = append(normalized, tx)
 	}

--- a/platform/nano/client.go
+++ b/platform/nano/client.go
@@ -12,6 +12,6 @@ type Client struct {
 
 func (c *Client) GetAccountHistory(address string) (history AccountHistory, err error) {
 	count := strconv.Itoa(blockatlas.TxPerPage)
-	err = c.Post(&history, "/", AccountHistoryRequest{Action: "account_history", Account: address, Count: count})
-	return history, err
+	err = c.Post(&history, "", AccountHistoryRequest{Action: "account_history", Account: address, Count: count})
+	return
 }

--- a/platform/nano/model.go
+++ b/platform/nano/model.go
@@ -1,11 +1,11 @@
 package nano
 
 const (
-	BlockTypeSend    = "send"
-	BlockTypeReceive = "receive"
+	BlockTypeSend    BlockType = "send"
+	BlockTypeReceive BlockType = "receive"
 )
 
-type BLockType string
+type BlockType string
 
 type AccountHistoryRequest struct {
 	Action  string `json:"action"`
@@ -15,12 +15,12 @@ type AccountHistoryRequest struct {
 }
 
 type AccountHistory struct {
-	Account string        `json:"account"`
-	History []Transaction `json:"history"`
+	Account string      `json:"account"`
+	History interface{} `json:"history"`
 }
 
 type Transaction struct {
-	Type           BLockType `json:"type"`
+	Type           BlockType `json:"type"`
 	Account        string    `json:"account"`
 	Amount         string    `json:"amount"`
 	LocalTimestamp string    `json:"local_timestamp"`


### PR DESCRIPTION
# Headline
Fix Nano platform

## Problem
When the account doesn't have a transaction, the field history returns an empty string instead of a array. 
``{
    "account": "nano_3rhb35hby858uwb6p7qauwa3ax6z7j6ozt5t6ber1mag89ia8en6ind9qqfs",
    "history": ""
}``

## Solution
Use the param `history` as an interface and unmarshal them

## Changes
- Fix empty history
- Fix `BlockType` typo
- Fix `BlockType` enum
- Remove redundancy return for `GetAccountHistory` method