### PR TITLE
use float instead string for market response

### DIFF
--- a/api/maketdata.go
+++ b/api/maketdata.go
@@ -53,7 +53,7 @@ func getTickerHandler(storage storage.Market) func(c *gin.Context) {
 		}
 		token := c.Query("token")
 
-		currency := c.DefaultQuery("currency", "USD")
+		currency := c.DefaultQuery("currency", blockatlas.DefaultCurrency)
 		rate, err := storage.GetRate(strings.ToUpper(currency))
 		if err != nil {
 			ginutils.RenderError(c, http.StatusInternalServerError, "Invalid currency")
@@ -85,7 +85,7 @@ func getTickersHandler(storage storage.Market) func(c *gin.Context) {
 		return nil
 	}
 	return func(c *gin.Context) {
-		md := TickerRequest{Currency: "USD"}
+		md := TickerRequest{Currency: blockatlas.DefaultCurrency}
 		if err := c.BindJSON(&md); err != nil {
 			ginutils.ErrorResponse(c).Message(err.Error()).Render()
 			return

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/trustwallet/blockatlas/marketdata"
+	"github.com/trustwallet/blockatlas/pkg/logger"
 )
 
 var syncCmd = &cobra.Command{
@@ -13,6 +15,10 @@ var syncCmd = &cobra.Command{
 }
 
 func syncMarketData(cmd *cobra.Command, args []string) {
+	if !viper.GetBool("market.enabled") {
+		logger.Fatal("Market is not enabled")
+	}
+
 	marketdata.InitRates(Storage)
 	marketdata.InitMarkets(Storage)
 	<-make(chan bool)

--- a/marketdata/market/coinmarketcap/cmc.go
+++ b/marketdata/market/coinmarketcap/cmc.go
@@ -6,7 +6,6 @@ import (
 	"github.com/trustwallet/blockatlas/marketdata/market"
 	"github.com/trustwallet/blockatlas/pkg/blockatlas"
 	"github.com/trustwallet/blockatlas/pkg/logger"
-	"math/big"
 	"net/url"
 )
 
@@ -61,8 +60,8 @@ func normalizeTicker(price Data, provider string, cmap cmcmap.CmcMapping) (block
 		CoinType: coinType,
 		TokenId:  tokenId,
 		Price: blockatlas.TickerPrice{
-			Value:     big.NewFloat(price.Quote.USD.Price),
-			Change24h: big.NewFloat(price.Quote.USD.PercentChange24h),
+			Value:     price.Quote.USD.Price,
+			Change24h: price.Quote.USD.PercentChange24h,
 			Currency:  "USD",
 			Provider:  provider,
 		},

--- a/marketdata/market/coinmarketcap/cmc.go
+++ b/marketdata/market/coinmarketcap/cmc.go
@@ -31,7 +31,7 @@ func (m *Market) GetData() (blockatlas.Tickers, error) {
 		return nil, err
 	}
 	var prices CoinPrices
-	err = m.Get(&prices, "v1/cryptocurrency/listings/latest", url.Values{"limit": {"5000"}, "convert": {"USD"}})
+	err = m.Get(&prices, "v1/cryptocurrency/listings/latest", url.Values{"limit": {"5000"}, "convert": {blockatlas.DefaultCurrency}})
 	if err != nil {
 		return nil, err
 	}
@@ -62,7 +62,7 @@ func normalizeTicker(price Data, provider string, cmap cmcmap.CmcMapping) (block
 		Price: blockatlas.TickerPrice{
 			Value:     price.Quote.USD.Price,
 			Change24h: price.Quote.USD.PercentChange24h,
-			Currency:  "USD",
+			Currency:  blockatlas.DefaultCurrency,
 			Provider:  provider,
 		},
 		LastUpdate: price.LastUpdated,

--- a/marketdata/market/coinmarketcap/cmc_test.go
+++ b/marketdata/market/coinmarketcap/cmc_test.go
@@ -4,7 +4,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/trustwallet/blockatlas/marketdata/cmcmap"
 	"github.com/trustwallet/blockatlas/pkg/blockatlas"
-	"math/big"
 	"sort"
 	"testing"
 	"time"
@@ -34,24 +33,24 @@ func Test_normalizeTickers(t *testing.T) {
 			blockatlas.Tickers{
 				blockatlas.Ticker{CoinName: "BTC", CoinType: blockatlas.TypeCoin, LastUpdate: time.Unix(111, 0),
 					Price: blockatlas.TickerPrice{
-						Value:     big.NewFloat(223.55),
-						Change24h: big.NewFloat(10),
+						Value:     223.55,
+						Change24h: 10,
 						Currency:  "USD",
 						Provider:  "cmc",
 					},
 				},
 				blockatlas.Ticker{CoinName: "ETH", CoinType: blockatlas.TypeCoin, LastUpdate: time.Unix(333, 0),
 					Price: blockatlas.TickerPrice{
-						Value:     big.NewFloat(11.11),
-						Change24h: big.NewFloat(20),
+						Value:     11.11,
+						Change24h: 20,
 						Currency:  "USD",
 						Provider:  "cmc",
 					},
 				},
 				blockatlas.Ticker{CoinName: "ETH", TokenId: "0x8ce9137d39326ad0cd6491fb5cc0cba0e089b6a9", CoinType: blockatlas.TypeToken, LastUpdate: time.Unix(444, 0),
 					Price: blockatlas.TickerPrice{
-						Value:     big.NewFloat(463.22),
-						Change24h: big.NewFloat(-3),
+						Value:     463.22,
+						Change24h: -3,
 						Currency:  "USD",
 						Provider:  "cmc",
 					},

--- a/marketdata/market/coinmarketcap/cmc_test.go
+++ b/marketdata/market/coinmarketcap/cmc_test.go
@@ -35,7 +35,7 @@ func Test_normalizeTickers(t *testing.T) {
 					Price: blockatlas.TickerPrice{
 						Value:     223.55,
 						Change24h: 10,
-						Currency:  "USD",
+						Currency:  blockatlas.DefaultCurrency,
 						Provider:  "cmc",
 					},
 				},
@@ -43,7 +43,7 @@ func Test_normalizeTickers(t *testing.T) {
 					Price: blockatlas.TickerPrice{
 						Value:     11.11,
 						Change24h: 20,
-						Currency:  "USD",
+						Currency:  blockatlas.DefaultCurrency,
 						Provider:  "cmc",
 					},
 				},
@@ -51,7 +51,7 @@ func Test_normalizeTickers(t *testing.T) {
 					Price: blockatlas.TickerPrice{
 						Value:     463.22,
 						Change24h: -3,
-						Currency:  "USD",
+						Currency:  blockatlas.DefaultCurrency,
 						Provider:  "cmc",
 					},
 				},

--- a/marketdata/market/dex/dex.go
+++ b/marketdata/market/dex/dex.go
@@ -40,7 +40,7 @@ func (m *Market) GetData() (blockatlas.Tickers, error) {
 		return nil, errors.E(err, "rate not found", errors.Params{"asset": BNBAsset})
 	}
 	result := normalizeTickers(prices, m.GetId())
-	result.ApplyRate(1/rate.Rate, "USD")
+	result.ApplyRate(1/rate.Rate, blockatlas.DefaultCurrency)
 	return result, nil
 }
 

--- a/marketdata/market/dex/dex.go
+++ b/marketdata/market/dex/dex.go
@@ -5,7 +5,6 @@ import (
 	"github.com/trustwallet/blockatlas/marketdata/market"
 	"github.com/trustwallet/blockatlas/pkg/blockatlas"
 	"github.com/trustwallet/blockatlas/pkg/errors"
-	"math/big"
 	"net/url"
 	"strconv"
 	"time"
@@ -41,7 +40,7 @@ func (m *Market) GetData() (blockatlas.Tickers, error) {
 		return nil, errors.E(err, "rate not found", errors.Params{"asset": BNBAsset})
 	}
 	result := normalizeTickers(prices, m.GetId())
-	result.ApplyRate(rate.Rate.Quo(big.NewFloat(1), rate.Rate), "USD")
+	result.ApplyRate(1/rate.Rate, "USD")
 	return result, nil
 }
 
@@ -70,8 +69,8 @@ func normalizeTicker(price CoinPrice, provider string) (blockatlas.Ticker, error
 		CoinType: blockatlas.TypeToken,
 		TokenId:  tokenId,
 		Price: blockatlas.TickerPrice{
-			Value:     big.NewFloat(value),
-			Change24h: big.NewFloat(value24h),
+			Value:     value,
+			Change24h: value24h,
 			Currency:  "BNB",
 			Provider:  provider,
 		},

--- a/marketdata/market/dex/dex_test.go
+++ b/marketdata/market/dex/dex_test.go
@@ -2,7 +2,6 @@ package dex
 
 import (
 	"github.com/trustwallet/blockatlas/pkg/blockatlas"
-	"math/big"
 	"reflect"
 	"testing"
 	"time"
@@ -44,16 +43,16 @@ func Test_normalizeTickers(t *testing.T) {
 			blockatlas.Tickers{
 				blockatlas.Ticker{CoinName: "BNB", TokenId: "RAVEN-F66", CoinType: blockatlas.TypeToken, LastUpdate: time.Now(),
 					Price: blockatlas.TickerPrice{
-						Value:     big.NewFloat(0.00001082),
-						Change24h: big.NewFloat(-2.2500),
+						Value:     0.00001082,
+						Change24h: -2.2500,
 						Currency:  "BNB",
 						Provider:  "dex",
 					},
 				},
 				blockatlas.Ticker{CoinName: "BNB", TokenId: "SLV-986", CoinType: blockatlas.TypeToken, LastUpdate: time.Now(),
 					Price: blockatlas.TickerPrice{
-						Value:     big.NewFloat(0.0449451),
-						Change24h: big.NewFloat(-5.3700),
+						Value:     0.0449451,
+						Change24h: -5.3700,
 						Currency:  "BNB",
 						Provider:  "dex",
 					},

--- a/marketdata/rate/coinmarketcap/cmc.go
+++ b/marketdata/rate/coinmarketcap/cmc.go
@@ -5,7 +5,6 @@ import (
 	"github.com/trustwallet/blockatlas/marketdata/cmcmap"
 	"github.com/trustwallet/blockatlas/marketdata/rate"
 	"github.com/trustwallet/blockatlas/pkg/blockatlas"
-	"math/big"
 	"net/url"
 )
 
@@ -49,10 +48,9 @@ func normalizeRates(prices CoinPrices, cmap cmcmap.CmcMapping) (rates blockatlas
 		if err == nil {
 			currency = cmcCoin.Symbol
 		}
-		rate := new(big.Float).Quo(big.NewFloat(1), big.NewFloat(price.Quote.USD.Price))
 		rates = append(rates, blockatlas.Rate{
 			Currency:  currency,
-			Rate:      rate,
+			Rate:      1.0 / price.Quote.USD.Price,
 			Timestamp: price.LastUpdated.Unix(),
 		})
 	}

--- a/marketdata/rate/coinmarketcap/cmc_test.go
+++ b/marketdata/rate/coinmarketcap/cmc_test.go
@@ -4,7 +4,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/trustwallet/blockatlas/marketdata/cmcmap"
 	"github.com/trustwallet/blockatlas/pkg/blockatlas"
-	"math/big"
 	"sort"
 	"testing"
 	"time"
@@ -26,7 +25,7 @@ func Test_normalizeRates(t *testing.T) {
 						},
 						Quote: Quote{
 							USD: USD{
-								Price: 223.55,
+								Price: 223.5,
 							},
 						},
 						LastUpdated: time.Unix(333, 0),
@@ -45,8 +44,8 @@ func Test_normalizeRates(t *testing.T) {
 				},
 			},
 			blockatlas.Rates{
-				blockatlas.Rate{Currency: "BTC", Rate: new(big.Float).Quo(big.NewFloat(1), big.NewFloat(223.55)), Timestamp: 333},
-				blockatlas.Rate{Currency: "ETH", Rate: new(big.Float).Quo(big.NewFloat(1), big.NewFloat(11.11)), Timestamp: 333},
+				blockatlas.Rate{Currency: "BTC", Rate: 1 / 223.5, Timestamp: 333},
+				blockatlas.Rate{Currency: "ETH", Rate: 1 / 11.11, Timestamp: 333},
 			},
 		},
 		{
@@ -78,8 +77,8 @@ func Test_normalizeRates(t *testing.T) {
 				},
 			},
 			blockatlas.Rates{
-				blockatlas.Rate{Currency: "BNB", Rate: new(big.Float).Quo(big.NewFloat(1), big.NewFloat(30.333)), Timestamp: 123},
-				blockatlas.Rate{Currency: "XRP", Rate: new(big.Float).Quo(big.NewFloat(1), big.NewFloat(0.4687)), Timestamp: 123},
+				blockatlas.Rate{Currency: "BNB", Rate: 1 / 30.333, Timestamp: 123},
+				blockatlas.Rate{Currency: "XRP", Rate: 1 / 0.4687, Timestamp: 123},
 			},
 		},
 	}
@@ -87,8 +86,7 @@ func Test_normalizeRates(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			gotRates := normalizeRates(tt.prices, cmcmap.CmcMapping{})
 			sort.SliceStable(gotRates, func(i, j int) bool {
-				y := gotRates[i].Rate.Cmp(gotRates[j].Rate)
-				return y <= 0
+				return gotRates[i].Rate < gotRates[j].Rate
 			})
 			if !assert.ObjectsAreEqualValues(gotRates, tt.wantRates) {
 				t.Errorf("normalizeRates() = %v, want %v", gotRates, tt.wantRates)

--- a/marketdata/rate/fixer/fixer.go
+++ b/marketdata/rate/fixer/fixer.go
@@ -26,7 +26,7 @@ func InitRate() rate.Provider {
 func (f *Fixer) FetchLatestRates() (rates blockatlas.Rates, err error) {
 	values := url.Values{
 		"access_key": {f.APIKey},
-		"base":       {"USD"}, // Base USD supported only in paid api
+		"base":       {blockatlas.DefaultCurrency}, // Base USD supported only in paid api
 	}
 	var latest Latest
 	err = f.Get(&latest, "latest", values)

--- a/marketdata/rate/fixer/fixer.go
+++ b/marketdata/rate/fixer/fixer.go
@@ -4,7 +4,6 @@ import (
 	"github.com/spf13/viper"
 	"github.com/trustwallet/blockatlas/marketdata/rate"
 	"github.com/trustwallet/blockatlas/pkg/blockatlas"
-	"math/big"
 	"net/url"
 )
 
@@ -40,7 +39,7 @@ func (f *Fixer) FetchLatestRates() (rates blockatlas.Rates, err error) {
 
 func normalizeRates(latest Latest) (rates blockatlas.Rates) {
 	for currency, rate := range latest.Rates {
-		rates = append(rates, blockatlas.Rate{Currency: currency, Rate: big.NewFloat(rate), Timestamp: latest.Timestamp})
+		rates = append(rates, blockatlas.Rate{Currency: currency, Rate: rate, Timestamp: latest.Timestamp})
 	}
 	return
 }

--- a/marketdata/rate/fixer/fixer_test.go
+++ b/marketdata/rate/fixer/fixer_test.go
@@ -3,7 +3,6 @@ package fixer
 import (
 	"github.com/stretchr/testify/assert"
 	"github.com/trustwallet/blockatlas/pkg/blockatlas"
-	"math/big"
 	"sort"
 	"testing"
 	"time"
@@ -23,9 +22,9 @@ func Test_normalizeRates(t *testing.T) {
 				UpdatedAt: time.Now(),
 			},
 			blockatlas.Rates{
-				blockatlas.Rate{Currency: "USD", Rate: big.NewFloat(22.111), Timestamp: 123},
-				blockatlas.Rate{Currency: "BRL", Rate: big.NewFloat(33.2), Timestamp: 123},
-				blockatlas.Rate{Currency: "BTC", Rate: big.NewFloat(44.99), Timestamp: 123},
+				blockatlas.Rate{Currency: "USD", Rate: 22.111, Timestamp: 123},
+				blockatlas.Rate{Currency: "BRL", Rate: 33.2, Timestamp: 123},
+				blockatlas.Rate{Currency: "BTC", Rate: 44.99, Timestamp: 123},
 			},
 		},
 		{
@@ -36,9 +35,9 @@ func Test_normalizeRates(t *testing.T) {
 				UpdatedAt: time.Now(),
 			},
 			blockatlas.Rates{
-				blockatlas.Rate{Currency: "IFC", Rate: big.NewFloat(34.973), Timestamp: 333},
-				blockatlas.Rate{Currency: "LSK", Rate: big.NewFloat(123.321), Timestamp: 333},
-				blockatlas.Rate{Currency: "DUO", Rate: big.NewFloat(998.3), Timestamp: 333},
+				blockatlas.Rate{Currency: "IFC", Rate: 34.973, Timestamp: 333},
+				blockatlas.Rate{Currency: "LSK", Rate: 123.321, Timestamp: 333},
+				blockatlas.Rate{Currency: "DUO", Rate: 998.3, Timestamp: 333},
 			},
 		},
 	}
@@ -46,8 +45,7 @@ func Test_normalizeRates(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			gotRates := normalizeRates(tt.latest)
 			sort.SliceStable(gotRates, func(i, j int) bool {
-				y := gotRates[i].Rate.Cmp(gotRates[j].Rate)
-				return y <= 0
+				return gotRates[i].Rate < gotRates[j].Rate
 			})
 			if !assert.ObjectsAreEqualValues(gotRates, tt.wantRates) {
 				t.Errorf("normalizeRates() = %v, want %v", gotRates, tt.wantRates)

--- a/pkg/blockatlas/marketdata.go
+++ b/pkg/blockatlas/marketdata.go
@@ -1,7 +1,6 @@
 package blockatlas
 
 import (
-	"math/big"
 	"time"
 )
 
@@ -35,31 +34,31 @@ func (t *Ticker) SetCoinId(coinId uint) {
 }
 
 type TickerPrice struct {
-	Value     *big.Float `json:"value,omitempty"`
-	Change24h *big.Float `json:"change_24h,omitempty"`
-	Currency  string     `json:"currency,omitempty"`
-	Provider  string     `json:"provider,omitempty"`
+	Value     float64 `json:"value,omitempty"`
+	Change24h float64 `json:"change_24h,omitempty"`
+	Currency  string  `json:"currency,omitempty"`
+	Provider  string  `json:"provider,omitempty"`
 }
 
 type Rate struct {
-	Currency  string     `json:"currency"`
-	Rate      *big.Float `json:"rate"`
-	Timestamp int64      `json:"timestamp"`
+	Currency  string  `json:"currency"`
+	Rate      float64 `json:"rate"`
+	Timestamp int64   `json:"timestamp"`
 }
 
 type Rates []Rate
 type Tickers []Ticker
 
-func (ts Tickers) ApplyRate(rate *big.Float, currency string) {
+func (ts Tickers) ApplyRate(rate float64, currency string) {
 	for _, t := range ts {
 		t.ApplyRate(rate, currency)
 	}
 }
 
-func (t *Ticker) ApplyRate(rate *big.Float, currency string) {
+func (t *Ticker) ApplyRate(rate float64, currency string) {
 	if t.Price.Currency == currency {
 		return
 	}
-	t.Price.Value.Mul(t.Price.Value, rate)
+	t.Price.Value *= rate
 	t.Price.Currency = currency
 }

--- a/pkg/blockatlas/marketdata.go
+++ b/pkg/blockatlas/marketdata.go
@@ -7,6 +7,8 @@ import (
 const (
 	TypeCoin  CoinType = "coin"
 	TypeToken CoinType = "token"
+
+	DefaultCurrency = "USD"
 )
 
 type CoinType string


### PR DESCRIPTION
# Headline
Use float instead of string for market response

# Problem
We cannot serialize a `big.Float`  into a number, only into a string

# Solution
Change `big.Float` to `float64`