### PR TITLE
add default block number for Tron

### DIFF
--- a/platform/tron/api.go
+++ b/platform/tron/api.go
@@ -95,12 +95,13 @@ func NormalizeTokenTransfer(srcTx *Tx, tokenInfo AssetInfo) (tx blockatlas.Tx, e
 		}
 
 		return blockatlas.Tx{
-			ID:   srcTx.ID,
-			Coin: coin.TRX,
-			Date: srcTx.BlockTime / 1000,
-			Fee:  "0",
-			From: from,
-			To:   to,
+			ID:    srcTx.ID,
+			Coin:  coin.TRX,
+			Date:  srcTx.BlockTime / 1000,
+			Fee:   "0",
+			Block: 0,
+			From:  from,
+			To:    to,
 			Meta: blockatlas.TokenTransfer{
 				Name:     tokenInfo.Name,
 				Symbol:   tokenInfo.Symbol,


### PR DESCRIPTION
We don't have the block number, so, use the zero number as a default

closes https://github.com/trustwallet/blockatlas/issues/197