### PR TITLE
fix vechain token normalize

### DIFF
--- a/platform/vechain/api.go
+++ b/platform/vechain/api.go
@@ -125,10 +125,13 @@ func NormalizeTokenTransaction(srcTx Tx, receipt TxReceipt) (blockatlas.TxPage, 
 
 	txs := make(blockatlas.TxPage, 0)
 	for _, output := range receipt.Outputs {
+		if len(output.Events) == 0 || len(output.Events[0].Topics) < 3 {
+			continue
+		}
 		event := output.Events[0] // TODO add support for multisend
 		value, err := util.HexToDecimal(event.Data)
 		if err != nil {
-			return blockatlas.TxPage{}, err
+			continue
 		}
 
 		txs = append(txs, blockatlas.Tx{
@@ -143,13 +146,13 @@ func NormalizeTokenTransaction(srcTx Tx, receipt TxReceipt) (blockatlas.TxPage, 
 			Sequence: nonce,
 			Status:   blockatlas.StatusCompleted,
 			Meta: blockatlas.TokenTransfer{
-				Name: "",
-				TokenID: "",
+				Name:     "",
+				TokenID:  "",
 				Value:    blockatlas.Amount(value),
 				Symbol:   "VTHO", // TODO replace with real name for other coins
-				Decimals: 18, // TODO Not all tokens have decimal 18 https://github.com/vechain/token-registry/tree/master/tokens/main
-				From: origin,
-				To: getRecipientAddress(event.Topics[2]),
+				Decimals: 18,     // TODO Not all tokens have decimal 18 https://github.com/vechain/token-registry/tree/master/tokens/main
+				From:     origin,
+				To:       getRecipientAddress(event.Topics[2]),
 			},
 		})
 	}
@@ -191,15 +194,15 @@ func NormalizeTransaction(srcTx LogTransfer, trxId Tx) (blockatlas.Tx, error) {
 	fee := strconv.Itoa(trxId.Gas)
 
 	return blockatlas.Tx{
-		ID:     srcTx.Meta.TxId,
-		Coin:   coin.VET,
-		From:   srcTx.Sender,
-		To:     srcTx.Recipient,
-		Fee:    blockatlas.Amount(fee),
-		Date:   srcTx.Meta.BlockTimestamp,
-		Type:   blockatlas.TxTransfer,
-		Block:  srcTx.Meta.BlockNumber,
-		Status: blockatlas.StatusCompleted,
+		ID:       srcTx.Meta.TxId,
+		Coin:     coin.VET,
+		From:     srcTx.Sender,
+		To:       srcTx.Recipient,
+		Fee:      blockatlas.Amount(fee),
+		Date:     srcTx.Meta.BlockTimestamp,
+		Type:     blockatlas.TxTransfer,
+		Block:    srcTx.Meta.BlockNumber,
+		Status:   blockatlas.StatusCompleted,
 		Sequence: nonce,
 		Meta: blockatlas.Transfer{
 			Value:    blockatlas.Amount(value),

--- a/platform/vechain/api_test.go
+++ b/platform/vechain/api_test.go
@@ -129,16 +129,16 @@ const trxReceipt = `{
 
 var expectedTransferLog = blockatlas.TxPage{
 	{
-		ID:     "0x42f5eba46ddcc458243c753545a3faa849502d078efbc5b74baddea9e6ea5b04",
-		Coin:   coin.VET,
-		From:   "0x2c7a8d5cce0d5e6a8a31233b7dc3dae9aae4b405",
-		To:     "0x0000000000000000000000000000456e65726779",
-		Date:   1574278180,
-		Type:   blockatlas.TxTokenTransfer,
-		Fee:    blockatlas.Amount("36582000000000000000"),
-		Status: blockatlas.StatusCompleted,
+		ID:       "0x42f5eba46ddcc458243c753545a3faa849502d078efbc5b74baddea9e6ea5b04",
+		Coin:     coin.VET,
+		From:     "0x2c7a8d5cce0d5e6a8a31233b7dc3dae9aae4b405",
+		To:       "0x0000000000000000000000000000456e65726779",
+		Date:     1574278180,
+		Type:     blockatlas.TxTokenTransfer,
+		Fee:      blockatlas.Amount("36582000000000000000"),
+		Status:   blockatlas.StatusCompleted,
 		Sequence: 78141085,
-		Block:  4382764,
+		Block:    4382764,
 		Meta: blockatlas.TokenTransfer{
 			Name:     "",
 			Symbol:   "VTHO",
@@ -196,6 +196,27 @@ func Test_hexToInt(t *testing.T) {
 			}
 			if got != tt.expected {
 				t.Errorf("hexToInt() got = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func Test_getRecipientAddress(t *testing.T) {
+	type args struct {
+		hex string
+	}
+	tests := []struct {
+		name string
+		hex  string
+		want string
+	}{
+		{"hex 1", "0x000000000000000000000000b5e883349e68ab59307d1604555ac890fac47128", "0xb5e883349e68ab59307d1604555ac890fac47128"},
+		{"hex 2", "0x000000000000000000000000f3586684107ce0859c44aa2b2e0fb8cd8731a15a", "0xf3586684107ce0859c44aa2b2e0fb8cd8731a15a"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getRecipientAddress(tt.hex); got != tt.want {
+				t.Errorf("getRecipientAddress() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
```
26 Nov 2019 12:10:27.740152 <190>1 2019-11-26T15:10:27.648130+00:00 app web.1 - - panic: runtime error: index out of range [0] with length 0
26 Nov 2019 12:10:27.74094 <190>1 2019-11-26T15:10:27.648134+00:00 app web.1 - -
26 Nov 2019 12:10:27.740120 <190>1 2019-11-26T15:10:27.648143+00:00 app web.1 - - goroutine 16125 [running]:
26 Nov 2019 12:10:27.740268 <190>1 2019-11-26T15:10:27.648188+00:00 app web.1 - - github.com/trustwallet/blockatlas/platform/vechain.NormalizeTokenTransaction(0xc002d3c4b0, 0x42, 0xc0032257a0, 0x2a, 0xc0012a1b80, 0x3, 0x4, 0x21ef8, 0xc001ebf040, 0x12, ...)
26 Nov 2019 12:10:27.740173 <190>1 2019-11-26T15:10:27.648192+00:00 app web.1 - - /tmp/build_bd8f045926171f7350bcbba7ce8e06fc/platform/vechain/api.go:128 +0x7e8
26 Nov 2019 12:10:27.740242 <190>1 2019-11-26T15:10:27.648231+00:00 app web.1 - - github.com/trustwallet/blockatlas/platform/vechain.(*Platform).getTransactionChannel(0x2796480, 0xc001d4fa90, 0x42, 0xc001b25d40, 0xc0025d97a0, 0x0)
```