### PR TITLE
VET: Remove nonce

### DIFF
--- a/platform/vechain/api.go
+++ b/platform/vechain/api.go
@@ -112,10 +112,6 @@ func NormalizeTokenTransaction(srcTx Tx, receipt TxReceipt) (blockatlas.TxPage, 
 		return blockatlas.TxPage{}, errors.E("NormalizeBlockTransaction: Clauses not found", errors.Params{"tx": srcTx}).PushToSentry()
 	}
 
-	nonce, err := hexToInt(srcTx.Nonce)
-	if err != nil {
-		return blockatlas.TxPage{}, err
-	}
 	origin := util.GetValidParameter(srcTx.Origin, srcTx.Meta.TxOrigin)
 
 	fee, err := util.HexToDecimal(receipt.Paid)
@@ -143,7 +139,6 @@ func NormalizeTokenTransaction(srcTx Tx, receipt TxReceipt) (blockatlas.TxPage, 
 			Date:     srcTx.Meta.BlockTimestamp,
 			Type:     blockatlas.TxTokenTransfer,
 			Block:    srcTx.Meta.BlockNumber,
-			Sequence: nonce,
 			Status:   blockatlas.StatusCompleted,
 			Meta: blockatlas.TokenTransfer{
 				Name:     "",
@@ -187,10 +182,6 @@ func NormalizeTransaction(srcTx LogTransfer, trxId Tx) (blockatlas.Tx, error) {
 		return blockatlas.Tx{}, err
 	}
 
-	nonce, err := hexToInt(trxId.Nonce)
-	if err != nil {
-		return blockatlas.Tx{}, err
-	}
 	fee := strconv.Itoa(trxId.Gas)
 
 	return blockatlas.Tx{
@@ -203,7 +194,6 @@ func NormalizeTransaction(srcTx LogTransfer, trxId Tx) (blockatlas.Tx, error) {
 		Type:     blockatlas.TxTransfer,
 		Block:    srcTx.Meta.BlockNumber,
 		Status:   blockatlas.StatusCompleted,
-		Sequence: nonce,
 		Meta: blockatlas.Transfer{
 			Value:    blockatlas.Amount(value),
 			Symbol:   coin.Coins[coin.VET].Symbol,

--- a/platform/vechain/api_test.go
+++ b/platform/vechain/api_test.go
@@ -36,7 +36,6 @@ var expectedTransfer = blockatlas.Tx{
 	Fee:      blockatlas.Amount("21000"),
 	Status:   blockatlas.StatusCompleted,
 	Block:    4395940,
-	Sequence: 10159885323814049016,
 	Meta: blockatlas.Transfer{
 		Value:    blockatlas.Amount("1347000000000000000"),
 		Decimals: 18,
@@ -137,7 +136,6 @@ var expectedTransferLog = blockatlas.TxPage{
 		Type:     blockatlas.TxTokenTransfer,
 		Fee:      blockatlas.Amount("36582000000000000000"),
 		Status:   blockatlas.StatusCompleted,
-		Sequence: 78141085,
 		Block:    4382764,
 		Meta: blockatlas.TokenTransfer{
 			Name:     "",


### PR DESCRIPTION
We don't actually use nonce on a client compare to ETH chains + VET nonce can be too long to handle on a client.
Fix issue with non displaying transactions on a client