### PR TITLE
Add unbounding Everstake validator

### DIFF
--- a/platform/cosmos/client.go
+++ b/platform/cosmos/client.go
@@ -39,6 +39,7 @@ func (c *Client) GetValidators() (validators []Validator, err error) {
 	if err != nil {
 		return validators, err
 	}
+	validators = append(validators, everstakeValidator) // Adding due to unbound status
 	return validators, err
 }
 
@@ -105,4 +106,12 @@ func (c *Client) GetUnbondingDelegations(address string) (delegations []Unbondin
 func (c *Client) GetAccount(address string) (result Account, err error) {
 	path := fmt.Sprintf("auth/accounts/%s", address)
 	return result, c.Get(&result, path, nil)
+}
+
+var everstakeValidator = Validator{
+	Status: 1,
+	Address: "cosmosvaloper1tflk30mq5vgqjdly92kkhhq3raev2hnz6eete3",
+	Commission: CosmosCommission{
+		Rate: "0.030000000000000000",
+	},
 }


### PR DESCRIPTION
Normally we query only validators with status `bonded` https://github.com/trustwallet/blockatlas/blob/master/platform/cosmos/client.go#L34 but due to recent lose of significant staking amount Everstake validator changed status to `unbonding ` and not longer present on http://platform.trustwallet.com, thus user can't unstake ATOM. Currectn Cosmos protocol implementation returns top 100 bonded validators, Evertstake on 102nd place.
This is temp solution, we need to think of long term