### PR TITLE
Fix nano transactions history

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -214,7 +214,7 @@ algorand:
 #  key: YOUR_API_KEY
 
 nano:
-  # api: https://mynano.ninja/api
+  api: https://nanoverse.io/api/node
 
 digibyte:
   api: https://dgb1.trezor.io/api

--- a/pkg/blockatlas/client.go
+++ b/pkg/blockatlas/client.go
@@ -90,6 +90,9 @@ func (r *Request) Execute(method string, url string, body io.Reader, result inte
 }
 
 func (r *Request) getBase(path string) string {
+	if path == "" {
+		return fmt.Sprintf("%s", r.BaseUrl)
+	}
 	return fmt.Sprintf("%s/%s", r.BaseUrl, path)
 }
 

--- a/platform/nano/api.go
+++ b/platform/nano/api.go
@@ -1,7 +1,6 @@
 package nano
 
 import (
-	"encoding/json"
 	"strconv"
 
 	"github.com/trustwallet/blockatlas/coin"
@@ -16,7 +15,6 @@ type Platform struct {
 
 func (p *Platform) Init() error {
 	p.client = Client{blockatlas.InitClient(viper.GetString("nano.api"))}
-	p.client.Headers["Content-Type"] = "application/json"
 	return nil
 }
 
@@ -31,17 +29,7 @@ func (p *Platform) GetTxsByAddress(address string) (blockatlas.TxPage, error) {
 		return nil, err
 	}
 
-	b, err := json.Marshal(history.History)
-	if err != nil {
-		return normalized, nil
-	}
-
-	var txs []Transaction
-	err = json.Unmarshal(b, &txs)
-	if err != nil {
-		return normalized, nil
-	}
-	for _, srcTx := range txs {
+	for _, srcTx := range history.History {
 		tx := p.Normalize(&srcTx, history.Account)
 		normalized = append(normalized, tx)
 	}

--- a/platform/nano/api.go
+++ b/platform/nano/api.go
@@ -64,6 +64,7 @@ func (p *Platform) Normalize(srcTx *Transaction, account string) (tx blockatlas.
 		To:     to,
 		Block:  height,
 		Status: status,
+		Fee:    "0",
 		Meta: blockatlas.Transfer{
 			Value:    blockatlas.Amount(srcTx.Amount),
 			Symbol:   p.Coin().Symbol,

--- a/platform/nano/api.go
+++ b/platform/nano/api.go
@@ -1,6 +1,7 @@
 package nano
 
 import (
+	"encoding/json"
 	"strconv"
 
 	"github.com/trustwallet/blockatlas/coin"
@@ -26,10 +27,19 @@ func (p *Platform) GetTxsByAddress(address string) (blockatlas.TxPage, error) {
 	normalized := make([]blockatlas.Tx, 0)
 	history, err := p.client.GetAccountHistory(address)
 	if err != nil {
-		return nil, err
+		return normalized, err
+	}
+	b, err := json.Marshal(history.History)
+	if err != nil {
+		return normalized, nil
+	}
+	var txs []Transaction
+	err = json.Unmarshal(b, &txs)
+	if err != nil {
+		return normalized, nil
 	}
 
-	for _, srcTx := range history.History {
+	for _, srcTx := range txs {
 		tx := p.Normalize(&srcTx, history.Account)
 		normalized = append(normalized, tx)
 	}

--- a/platform/nano/api.go
+++ b/platform/nano/api.go
@@ -16,6 +16,7 @@ type Platform struct {
 
 func (p *Platform) Init() error {
 	p.client = Client{blockatlas.InitClient(viper.GetString("nano.api"))}
+	p.client.Headers["Content-Type"] = "application/json"
 	return nil
 }
 

--- a/platform/nano/api_test.go
+++ b/platform/nano/api_test.go
@@ -39,6 +39,7 @@ func TestNormalize(t *testing.T) {
 				To:     "nano_1trqphog5noig7z888asnjejcie8z1iopxyepcjdo1atps8whxiuwd51ehbw",
 				Block:  4,
 				Status: "completed",
+				Fee:    "0",
 				Meta: blockatlas.Transfer{
 					Value:    blockatlas.Amount("45000000000000000000000000000"),
 					Symbol:   "NANO",
@@ -67,6 +68,7 @@ func TestNormalize(t *testing.T) {
 				To:     "nano_3ifzdoxn7keh7tn8zuwty1yr8k5pmaxoq6jpp3jidbjbfnz6hyanh89x6rwj",
 				Block:  1,
 				Status: "completed",
+				Fee:    "0",
 				Meta: blockatlas.Transfer{
 					Value:    blockatlas.Amount("90000000000000000000000000000"),
 					Symbol:   "NANO",

--- a/platform/nano/model.go
+++ b/platform/nano/model.go
@@ -14,8 +14,8 @@ type AccountHistoryRequest struct {
 }
 
 type AccountHistory struct {
-	Account string        `json:"account"`
-	History []Transaction `json:"history"`
+	Account string `json:"account"`
+	History interface{} // NANO RPC returns string for address with 0 transactions
 }
 
 type Transaction struct {

--- a/platform/nano/model.go
+++ b/platform/nano/model.go
@@ -11,12 +11,11 @@ type AccountHistoryRequest struct {
 	Action  string `json:"action"`
 	Account string `json:"account"`
 	Count   string `json:"count"`
-	Raw     bool   `json:"raw,omitempty"`
 }
 
 type AccountHistory struct {
-	Account string      `json:"account"`
-	History interface{} `json:"history"`
+	Account string        `json:"account"`
+	History []Transaction `json:"history"`
 }
 
 type Transaction struct {


### PR DESCRIPTION
Root issues fixed in this commit https://github.com/trustwallet/blockatlas/commit/e8b70a8616d1257be32aaad61d0d43eb5a16d0ec
I believe @hewigovens implemented logic to work with rpc 
https://github.com/trustwallet/blockatlas/commit/481c807babbac01a9087a3f3bc728771d637e2ee#diff-0f1be8eec416e71c28b41efb0544df26 but in current implementation transactions never returned
And current rpc expecting `/node` to be added: soruce https://mynano.ninja/api and new rpc https://nanoverse.io/api/#account_history
```curl
  https://nanoverse.io/api/node/
-d '{
  "action": "account_history",
  "account": "nano_3jwrszth46rk1mu7rmb4rhm54us8yg1gw3ipodftqtikf5yqdyr7471nsg1k",
  "count": "5"
}'
```
But should be 
```curl
  https://nanoverse.io/api/node
-d '{
  "action": "account_history",
  "account": "nano_3jwrszth46rk1mu7rmb4rhm54us8yg1gw3ipodftqtikf5yqdyr7471nsg1k",
  "count": "5"
}'
```