### PR TITLE
Calculate the price percent change

### DIFF
--- a/api/maketdata.go
+++ b/api/maketdata.go
@@ -67,7 +67,7 @@ func getTickerHandler(storage storage.Market) func(c *gin.Context) {
 			ginutils.RenderError(c, http.StatusInternalServerError, err.Error())
 			return
 		}
-		result.ApplyRate(currency, rate.Rate, nil)
+		result.ApplyRate(currency, rate.Rate, rate.PercentChange24h)
 		ginutils.RenderSuccess(c, result)
 	}
 }

--- a/api/maketdata.go
+++ b/api/maketdata.go
@@ -67,7 +67,7 @@ func getTickerHandler(storage storage.Market) func(c *gin.Context) {
 			ginutils.RenderError(c, http.StatusInternalServerError, err.Error())
 			return
 		}
-		result.ApplyRate(rate.Rate, currency)
+		result.ApplyRate(currency, rate.Rate, nil)
 		ginutils.RenderSuccess(c, result)
 	}
 }
@@ -107,7 +107,7 @@ func getTickersHandler(storage storage.Market) func(c *gin.Context) {
 			if err != nil {
 				continue
 			}
-			r.ApplyRate(rate.Rate, md.Currency)
+			r.ApplyRate(md.Currency, rate.Rate, rate.PercentChange24h)
 			r.SetCoinId(coinRequest.Coin)
 			tickers = append(tickers, r)
 		}

--- a/marketdata/market/dex/dex.go
+++ b/marketdata/market/dex/dex.go
@@ -5,6 +5,7 @@ import (
 	"github.com/trustwallet/blockatlas/marketdata/market"
 	"github.com/trustwallet/blockatlas/pkg/blockatlas"
 	"github.com/trustwallet/blockatlas/pkg/errors"
+	"math/big"
 	"net/url"
 	"strconv"
 	"time"
@@ -42,7 +43,8 @@ func (m *Market) GetData() (blockatlas.Tickers, error) {
 		return nil, errors.E(err, "rate not found", errors.Params{"asset": BNBAsset})
 	}
 	result := normalizeTickers(prices, m.GetId())
-	result.ApplyRate(blockatlas.DefaultCurrency, 1/rate.Rate, nil)
+	rate.PercentChange24h.Mul(rate.PercentChange24h, big.NewFloat(-1))
+	result.ApplyRate(blockatlas.DefaultCurrency, 1/rate.Rate, rate.PercentChange24h)
 	return result, nil
 }
 

--- a/marketdata/market/dex/dex.go
+++ b/marketdata/market/dex/dex.go
@@ -43,7 +43,9 @@ func (m *Market) GetData() (blockatlas.Tickers, error) {
 		return nil, errors.E(err, "rate not found", errors.Params{"asset": BNBAsset})
 	}
 	result := normalizeTickers(prices, m.GetId())
-	rate.PercentChange24h.Mul(rate.PercentChange24h, big.NewFloat(-1))
+	if rate.PercentChange24h != nil {
+		rate.PercentChange24h.Mul(rate.PercentChange24h, big.NewFloat(-1))
+	}
 	result.ApplyRate(blockatlas.DefaultCurrency, 1/rate.Rate, rate.PercentChange24h)
 	return result, nil
 }

--- a/marketdata/market/dex/dex.go
+++ b/marketdata/market/dex/dex.go
@@ -42,7 +42,7 @@ func (m *Market) GetData() (blockatlas.Tickers, error) {
 		return nil, errors.E(err, "rate not found", errors.Params{"asset": BNBAsset})
 	}
 	result := normalizeTickers(prices, m.GetId())
-	result.ApplyRate(1/rate.Rate, blockatlas.DefaultCurrency)
+	result.ApplyRate(blockatlas.DefaultCurrency, 1/rate.Rate, nil)
 	return result, nil
 }
 

--- a/marketdata/rate/coinmarketcap/cmc.go
+++ b/marketdata/rate/coinmarketcap/cmc.go
@@ -4,6 +4,7 @@ import (
 	"github.com/trustwallet/blockatlas/marketdata/clients/cmc"
 	"github.com/trustwallet/blockatlas/marketdata/rate"
 	"github.com/trustwallet/blockatlas/pkg/blockatlas"
+	"math/big"
 )
 
 const (
@@ -29,28 +30,25 @@ func InitRate(api string, apiKey string, mapApi string, updateTime string) rate.
 }
 
 func (c *Cmc) FetchLatestRates() (rates blockatlas.Rates, err error) {
-	cmap, err := cmc.GetCmcMap(c.mapApi)
-	if err != nil {
-		return nil, err
-	}
 	prices, err := c.client.GetData()
 	if err != nil {
 		return
 	}
-	rates = normalizeRates(prices, cmap, c.GetId())
+	rates = normalizeRates(prices, c.GetId())
 	return
 }
 
-func normalizeRates(prices cmc.CoinPrices, cmap cmc.CmcMapping, provider string) (rates blockatlas.Rates) {
+func normalizeRates(prices cmc.CoinPrices, provider string) (rates blockatlas.Rates) {
 	for _, price := range prices.Data {
 		if price.Platform != nil {
 			continue
 		}
 		rates = append(rates, blockatlas.Rate{
-			Currency:  price.Symbol,
-			Rate:      1.0 / price.Quote.USD.Price,
-			Timestamp: price.LastUpdated.Unix(),
-			Provider:  provider,
+			Currency:         price.Symbol,
+			Rate:             1.0 / price.Quote.USD.Price,
+			Timestamp:        price.LastUpdated.Unix(),
+			PercentChange24h: big.NewFloat(price.Quote.USD.PercentChange24h),
+			Provider:         provider,
 		})
 	}
 	return

--- a/marketdata/rate/coinmarketcap/cmc_test.go
+++ b/marketdata/rate/coinmarketcap/cmc_test.go
@@ -85,7 +85,7 @@ func Test_normalizeRates(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotRates := normalizeRates(tt.prices, cmc.CmcMapping{}, provider)
+			gotRates := normalizeRates(tt.prices, provider)
 			sort.SliceStable(gotRates, func(i, j int) bool {
 				return gotRates[i].Rate < gotRates[j].Rate
 			})

--- a/marketdata/rate/coinmarketcap/cmc_test.go
+++ b/marketdata/rate/coinmarketcap/cmc_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/trustwallet/blockatlas/marketdata/clients/cmc"
 	"github.com/trustwallet/blockatlas/pkg/blockatlas"
+	"math/big"
 	"sort"
 	"testing"
 	"time"
@@ -26,7 +27,8 @@ func Test_normalizeRates(t *testing.T) {
 						},
 						Quote: cmc.Quote{
 							USD: cmc.USD{
-								Price: 223.5,
+								Price:            223.5,
+								PercentChange24h: 0.33,
 							},
 						},
 						LastUpdated: time.Unix(333, 0),
@@ -37,7 +39,8 @@ func Test_normalizeRates(t *testing.T) {
 						},
 						Quote: cmc.Quote{
 							USD: cmc.USD{
-								Price: 11.11,
+								Price:            11.11,
+								PercentChange24h: -1.22,
 							},
 						},
 						LastUpdated: time.Unix(333, 0),
@@ -45,8 +48,8 @@ func Test_normalizeRates(t *testing.T) {
 				},
 			},
 			blockatlas.Rates{
-				blockatlas.Rate{Currency: "BTC", Rate: 1 / 223.5, Timestamp: 333, Provider: provider},
-				blockatlas.Rate{Currency: "ETH", Rate: 1 / 11.11, Timestamp: 333, Provider: provider},
+				blockatlas.Rate{Currency: "BTC", Rate: 1 / 223.5, Timestamp: 333, Provider: provider, PercentChange24h: big.NewFloat(0.33)},
+				blockatlas.Rate{Currency: "ETH", Rate: 1 / 11.11, Timestamp: 333, Provider: provider, PercentChange24h: big.NewFloat(-1.22)},
 			},
 		},
 		{
@@ -59,7 +62,8 @@ func Test_normalizeRates(t *testing.T) {
 						},
 						Quote: cmc.Quote{
 							USD: cmc.USD{
-								Price: 30.333,
+								Price:            30.333,
+								PercentChange24h: 2.1,
 							},
 						},
 						LastUpdated: time.Unix(123, 0),
@@ -78,8 +82,8 @@ func Test_normalizeRates(t *testing.T) {
 				},
 			},
 			blockatlas.Rates{
-				blockatlas.Rate{Currency: "BNB", Rate: 1 / 30.333, Timestamp: 123, Provider: provider},
-				blockatlas.Rate{Currency: "XRP", Rate: 1 / 0.4687, Timestamp: 123, Provider: provider},
+				blockatlas.Rate{Currency: "BNB", Rate: 1 / 30.333, Timestamp: 123, Provider: provider, PercentChange24h: big.NewFloat(2.1)},
+				blockatlas.Rate{Currency: "XRP", Rate: 1 / 0.4687, Timestamp: 123, Provider: provider, PercentChange24h: big.NewFloat(0)},
 			},
 		},
 	}

--- a/marketdata/rates.go
+++ b/marketdata/rates.go
@@ -18,16 +18,16 @@ var rateProviders rate.Providers
 func InitRates(storage storage.Market) {
 	rateProviders = rate.Providers{
 		// Add Market Quote Providers:
-		0: fixer.InitRate(
-			viper.GetString("market.fixer.api"),
-			viper.GetString("market.fixer.api_key"),
-			viper.GetString("market.fixer.rate_update_time"),
-		),
-		1: cmc.InitRate(
+		0: cmc.InitRate(
 			viper.GetString("market.cmc.api"),
 			viper.GetString("market.cmc.api_key"),
 			viper.GetString("market.cmc.map_url"),
 			viper.GetString("market.rate_update_time"),
+		),
+		1: fixer.InitRate(
+			viper.GetString("market.fixer.api"),
+			viper.GetString("market.fixer.api_key"),
+			viper.GetString("market.fixer.rate_update_time"),
 		),
 		2: compound.InitRate(
 			viper.GetString("market.compound.api"),

--- a/pkg/blockatlas/marketdata.go
+++ b/pkg/blockatlas/marketdata.go
@@ -1,6 +1,7 @@
 package blockatlas
 
 import (
+	"math/big"
 	"time"
 )
 
@@ -60,25 +61,31 @@ type TickerPrice struct {
 }
 
 type Rate struct {
-	Currency  string  `json:"currency"`
-	Rate      float64 `json:"rate"`
-	Timestamp int64   `json:"timestamp"`
-	Provider  string  `json:"provider,omitempty"`
+	Currency         string     `json:"currency"`
+	Rate             float64    `json:"rate"`
+	Timestamp        int64      `json:"timestamp"`
+	PercentChange24h *big.Float `json:"percent_change_24h,omitempty"`
+	Provider         string     `json:"provider,omitempty"`
 }
 
 type Rates []Rate
 type Tickers []*Ticker
 
-func (ts Tickers) ApplyRate(rate float64, currency string) {
+func (ts Tickers) ApplyRate(currency string, rate float64, percentChange24h *big.Float) {
 	for _, t := range ts {
-		t.ApplyRate(rate, currency)
+		t.ApplyRate(currency, rate, percentChange24h)
 	}
 }
 
-func (t *Ticker) ApplyRate(rate float64, currency string) {
+func (t *Ticker) ApplyRate(currency string, rate float64, percentChange24h *big.Float) {
 	if t.Price.Currency == currency {
 		return
 	}
 	t.Price.Value *= rate
 	t.Price.Currency = currency
+
+	if percentChange24h != nil {
+		change24h, _ := percentChange24h.Float64()
+		t.Price.Change24h -= change24h
+	}
 }

--- a/pkg/blockatlas/marketdata_test.go
+++ b/pkg/blockatlas/marketdata_test.go
@@ -47,6 +47,10 @@ func TestTicker_ApplyRate(t *testing.T) {
 			"apply rate 6",
 			args{0.00000001, -0.0003, 10, -0.0003, "BTC"},
 			want{0.0000001, 0},
+		}, {
+			"apply for same currency",
+			args{0.33333, -0.0003, 10, -0.0003, "USD"},
+			want{0.33333, -0.0003},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/blockatlas/marketdata_test.go
+++ b/pkg/blockatlas/marketdata_test.go
@@ -2,30 +2,65 @@ package blockatlas
 
 import (
 	"github.com/stretchr/testify/assert"
+	"math/big"
 	"testing"
 )
 
 func TestTicker_ApplyRate(t *testing.T) {
+	type args struct {
+		price            float64
+		percentChange24h float64
+		rate             float64
+		rateChange24h    float64
+		currency         string
+	}
+	type want struct {
+		price            float64
+		percentChange24h float64
+	}
 	tests := []struct {
-		name  string
-		price float64
-		rate  float64
-		want  float64
+		name string
+		args args
+		want want
 	}{
-		{"apply rate 1", 443, 344, 152392},
-		{"apply rate 2", 1111.22, 0.88, 977.8736},
-		{"apply rate 3", 3.33, 22.3, 74.259},
-		{"apply rate 4", 9.3332, 22, 205.3304},
-		{"apply rate 5", 0.00000001, 0.2, 0.000000002},
-		{"apply rate 6", 0.00000001, 10, 0.0000001},
+		{
+			"apply rate 1",
+			args{443, -0.44, 344, -0.33, "BTC"},
+			want{152392, -0.10999999999999999},
+		}, {
+			"apply rate 2",
+			args{1111.22, 3.04, 0.88, -2.12, "BTC"},
+			want{977.8736, 5.16},
+		}, {
+			"apply rate 3",
+			args{3.33, -1.02, 22.3, 1.02, "BTC"},
+			want{74.259, -2.04},
+		}, {
+			"apply rate 4",
+			args{9.3332, -2, 22, -0.555, "BTC"},
+			want{205.3304, -1.4449999999999998},
+		}, {
+			"apply rate 5",
+			args{0.00000001, 0, 0.2, 1.333, "BTC"},
+			want{0.000000002, -1.333},
+		}, {
+			"apply rate 6",
+			args{0.00000001, -0.0003, 10, -0.0003, "BTC"},
+			want{0.0000001, 0},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t1 *testing.T) {
 			ticker := &Ticker{
-				Price: TickerPrice{Value: tt.price},
+				Price: TickerPrice{
+					Value:     tt.args.price,
+					Change24h: tt.args.percentChange24h,
+					Currency:  DefaultCurrency,
+				},
 			}
-			ticker.ApplyRate(tt.rate, DefaultCurrency)
-			assert.Equal(t, tt.want, ticker.Price.Value)
+			ticker.ApplyRate(tt.args.currency, tt.args.rate, big.NewFloat(tt.args.rateChange24h))
+			assert.Equal(t, tt.want.price, ticker.Price.Value)
+			assert.Equal(t, tt.want.percentChange24h, ticker.Price.Change24h)
 		})
 	}
 }


### PR DESCRIPTION
# Headline
Calculate the new price percent change based on the currency selected

## Problem
Now we only convert the price when we select another currency

## Solution
Fetch the 24h price change from a selected currency to calculate the coin price change for other coins

I did try different algorithms to calculate the percent change, but we cannot find a value closes to the coin market cap. To do that, we need to have a percent change based on the coin we are going to convert. So, we have that info only for crypto quotes, but not for FIAT. 

<img width="284" alt="Screen Shot 2019-12-13 at 18 33 13" src="https://user-images.githubusercontent.com/2406457/70835360-98fd4580-1ddb-11ea-9926-db27082e41e5.png">

Request:
```
curl -X POST \
  http://localhost:8420/v1/market/ticker \
  -d '{
  "currency": "USD",
  "assets": [
    {
      "coin": 714,
      "type": "coin"
    }
  ]
}'
```

Response:
```
{
   "currency" : "USD",
   "docs" : [
      {
         "coin" : 714,
         "last_update" : "2019-12-13T21:27:07Z",
         "price" : {
            "change_24h" : 0.547669,
            "value" : 14.8554682852
         },
         "type" : "coin"
      }
   ]
}
```

Request:
```
curl -X POST \
  http://localhost:8420/v1/market/ticker \
  -d '{
  "currency": "BTC",
  "assets": [
    {
      "coin": 714,
      "type": "coin"
    }
  ]
}'
```

Response:
```
{
   "currency" : "BTC",
   "docs" : [
      {
         "coin" : 714,
         "last_update" : "2019-12-13T21:27:07Z",
         "price" : {
            "change_24h" : 0.202461,
            "value" : 0.00204506575902316
         },
         "type" : "coin"
      }
   ]
}
```

closes https://github.com/trustwallet/blockatlas/issues/599