### PR TITLE
Revert harmony rpc back to http

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -222,4 +222,4 @@ digibyte:
   api: https://dgb1.trezor.io/api
 
 harmony:
-  api: https://e0.t.hmny.io:9500
+  api: http://e0.t.hmny.io:9500


### PR DESCRIPTION
Fixes #653 

Harmony sadly supports only the http version of their working rpc endpoint :( 
Doing otherwise causes "Post https://e0.t.hmny.io:9500: http: server gave HTTP response to HTTPS client"