### PR TITLE
Fix overflow in casting to uint64() when blockHeight is -1

### DIFF
--- a/platform/bitcoin/api.go
+++ b/platform/bitcoin/api.go
@@ -206,7 +206,7 @@ func NormalizeTransaction(tx Transaction, coinIndex uint) blockatlas.Tx {
 		Fee:      fees,
 		Date:     int64(tx.BlockTime),
 		Type:     blockatlas.TxTransfer,
-		Block:    uint64(tx.BlockHeight),
+		Block:    tx.GetBlockHeight(),
 		Status:   tx.getStatus(),
 		Sequence: 0,
 		Meta: blockatlas.Transfer{
@@ -298,8 +298,8 @@ func (p *Platform) InferValue(tx *blockatlas.Tx, direction blockatlas.Direction,
 	return value
 }
 
-func (tx *Transaction) getStatus() blockatlas.Status {
-	if tx.Confirmations == 0 {
+func (transaction *Transaction) getStatus() blockatlas.Status {
+	if transaction.Confirmations == 0 {
 		return blockatlas.StatusPending
 	}
 	return blockatlas.StatusCompleted

--- a/platform/bitcoin/api_test.go
+++ b/platform/bitcoin/api_test.go
@@ -79,6 +79,42 @@ const incomingTx = `{
     "hex": "0400008085202f89019b2294e70b52417b96498df97c9add69ecc2963257298768c0e1c48a3264365a000000006b483045022100ec29a476dac49578339a92e6c20451aaf3ff6691efaf7d4d3113d07589771ca702203c0c173bdc356300edbd64cdfaa868b97c13ebc403026b283eb5e1fca398db8b012103729cc4211cf70f87c70c3cef90e0ca9b91e99b42364b8c600d5781277647de5f000000000225110300000000001976a9146fd73e7c147d8ccc15fda31d8429e70f302b843988acf7d70200000000001976a91484f0258cb7974993e6af928921b7f699c51a309488ac00000000000000000000000000000000000000"
 }`
 
+const pendingTx = `{
+    "txid": "a2d70bee124510c476f159fa83cdb34d663fc6020c81aad19b238601d679fed7",
+    "version": 4,
+    "vin": [{
+        "txid": "5a3664328ac4e1c0688729573296c2ec69dd9a7cf98d49967b41520be794229b",
+        "n": 0,
+        "addresses": ["t1T7cLkvDVScjw95WguoAZbbT8mrdqVtpiD"],
+        "isAddress": true,
+        "value": "387582",
+        "hex": "483045022100ec29a476dac49578339a92e6c20451aaf3ff6691efaf7d4d3113d07589771ca702203c0c173bdc356300edbd64cdfaa868b97c13ebc403026b283eb5e1fca398db8b012103729cc4211cf70f87c70c3cef90e0ca9b91e99b42364b8c600d5781277647de5f"
+    }],
+    "vout": [{
+        "value": "200997",
+        "n": 0,
+        "spent": true,
+        "hex": "76a9146fd73e7c147d8ccc15fda31d8429e70f302b843988ac",
+        "addresses": ["t1U4xs3qMxc2TL8wwYufmBngA5mewLHRwhM"],
+        "isAddress": true
+    }, {
+        "value": "186359",
+        "n": 1,
+        "spent": true,
+        "hex": "76a91484f0258cb7974993e6af928921b7f699c51a309488ac",
+        "addresses": ["t1VzWtLj9CSAK3QnxA7uuiK6XhJrjGjKoy4"],
+        "isAddress": true
+    }],
+    "blockHash": "0000000000a8248c4a14a2dcb74d92855bf9440da9b7b1e6d4baa14ee7e3081c",
+    "blockHeight": -1,
+    "confirmations": 116233,
+    "blockTime": 1549793065,
+    "value": "387356",
+    "valueIn": "387582",
+    "fees": "226",
+    "hex": "0400008085202f89019b2294e70b52417b96498df97c9add69ecc2963257298768c0e1c48a3264365a000000006b483045022100ec29a476dac49578339a92e6c20451aaf3ff6691efaf7d4d3113d07589771ca702203c0c173bdc356300edbd64cdfaa868b97c13ebc403026b283eb5e1fca398db8b012103729cc4211cf70f87c70c3cef90e0ca9b91e99b42364b8c600d5781277647de5f000000000225110300000000001976a9146fd73e7c147d8ccc15fda31d8429e70f302b843988acf7d70200000000001976a91484f0258cb7974993e6af928921b7f699c51a309488ac00000000000000000000000000000000000000"
+}`
+
 var expectedOutgoingTx = blockatlas.Tx{
 	ID:   "df63ddab7d4eed2fb6cb40d4d0519e7e5ac7cf5ad556b2edbd45963ea1a2931c",
 	Coin: coin.BTC,
@@ -145,6 +181,41 @@ var expectedIncomingTx = blockatlas.Tx{
 	},
 }
 
+var expectedPendingTx = blockatlas.Tx{
+	ID:   "a2d70bee124510c476f159fa83cdb34d663fc6020c81aad19b238601d679fed7",
+	Coin: coin.ZEC,
+	From: "t1T7cLkvDVScjw95WguoAZbbT8mrdqVtpiD",
+	To:   "t1U4xs3qMxc2TL8wwYufmBngA5mewLHRwhM",
+	Inputs: []blockatlas.TxOutput{
+		{
+			Address: "t1T7cLkvDVScjw95WguoAZbbT8mrdqVtpiD",
+			Value:   "387582",
+		},
+	},
+	Outputs: []blockatlas.TxOutput{
+		{
+			Address: "t1U4xs3qMxc2TL8wwYufmBngA5mewLHRwhM",
+			Value:   "200997",
+		},
+		{
+			Address: "t1VzWtLj9CSAK3QnxA7uuiK6XhJrjGjKoy4",
+			Value:   "186359",
+		},
+	},
+	Fee:       "226",
+	Date:      1549793065,
+	Type:      "transfer",
+	Status:    blockatlas.StatusCompleted,
+	Block:     0,
+	Sequence:  0,
+	Direction: blockatlas.DirectionIncoming,
+	Meta: blockatlas.Transfer{
+		Value:    "200997",
+		Symbol:   "ZEC",
+		Decimals: 8,
+	},
+}
+
 func TestNormalizeTransfer(t *testing.T) {
 
 	outgoingTxSet := mapset.NewSet()
@@ -163,6 +234,7 @@ func TestNormalizeTransfer(t *testing.T) {
 	}{
 		{outgoingTx, expectedOutgoingTx, outgoingTxSet},
 		{incomingTx, expectedIncomingTx, incomingTxSet},
+		{pendingTx, expectedPendingTx, incomingTxSet},
 	}
 
 	for _, test := range tests {
@@ -277,4 +349,3 @@ func TestTransactionStatus(t *testing.T) {
 		assert.Equal(t, test.Expected, test.Tx.getStatus())
 	}
 }
-

--- a/platform/bitcoin/model.go
+++ b/platform/bitcoin/model.go
@@ -47,11 +47,11 @@ type Transaction struct {
 	Fees          string   `json:"fees"`
 }
 
-func (t Transaction) Amount() string {
-	if len(t.Value) == 0 {
-		return t.ValueOut
+func (transaction Transaction) Amount() string {
+	if len(transaction.Value) == 0 {
+		return transaction.ValueOut
 	}
-	return t.Value
+	return transaction.Value
 }
 
 type Output struct {
@@ -87,4 +87,11 @@ type BlockchainStatus struct {
 type Backend struct {
 	Chain  string `json:"chain"`
 	Blocks int64  `json:"blocks"`
+}
+
+func (transaction Transaction) GetBlockHeight() uint64 {
+	if transaction.BlockHeight > 0 {
+		return uint64(transaction.BlockHeight)
+	}
+	return 0
 }


### PR DESCRIPTION
When transaction is pending block is casted to `block: 18446744073709552000`