### PR TITLE
set minimum timestamp date for charts

### DIFF
--- a/marketdata/charts.go
+++ b/marketdata/charts.go
@@ -7,6 +7,7 @@ import (
 	cmc "github.com/trustwallet/blockatlas/marketdata/chart/coinmarketcap"
 	"github.com/trustwallet/blockatlas/pkg/blockatlas"
 	"github.com/trustwallet/blockatlas/pkg/errors"
+	"github.com/trustwallet/blockatlas/pkg/numbers"
 	"sort"
 )
 
@@ -31,12 +32,9 @@ func InitCharts() *Charts {
 	}}
 }
 
-
 func (c *Charts) GetChartData(coin uint, token string, currency string, timeStart int64) (blockatlas.ChartData, error) {
 	chartsData := blockatlas.ChartData{}
-	if timeStart < minUnixTime {
-		timeStart = minUnixTime
-	}
+	timeStart = numbers.Max(timeStart, minUnixTime)
 	for _, c := range c.chartProviders {
 		charts, err := c.GetChartData(coin, token, currency, timeStart)
 		if err != nil {

--- a/marketdata/charts.go
+++ b/marketdata/charts.go
@@ -10,6 +10,10 @@ import (
 	"sort"
 )
 
+const (
+	minUnixData = 1000000000
+)
+
 type Charts struct {
 	chartProviders chart.Providers
 }
@@ -29,6 +33,9 @@ func InitCharts() *Charts {
 
 func (c *Charts) GetChartData(coin uint, token string, currency string, timeStart int64) (blockatlas.ChartData, error) {
 	chartsData := blockatlas.ChartData{}
+	if timeStart < minUnixData {
+		timeStart = minUnixData
+	}
 	for _, c := range c.chartProviders {
 		charts, err := c.GetChartData(coin, token, currency, timeStart)
 		if err != nil {

--- a/marketdata/charts.go
+++ b/marketdata/charts.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	minUnixData = 1000000000
+	minUnixTime = 1000000000
 )
 
 type Charts struct {
@@ -31,10 +31,11 @@ func InitCharts() *Charts {
 	}}
 }
 
+
 func (c *Charts) GetChartData(coin uint, token string, currency string, timeStart int64) (blockatlas.ChartData, error) {
 	chartsData := blockatlas.ChartData{}
-	if timeStart < minUnixData {
-		timeStart = minUnixData
+	if timeStart < minUnixTime {
+		timeStart = minUnixTime
 	}
 	for _, c := range c.chartProviders {
 		charts, err := c.GetChartData(coin, token, currency, timeStart)

--- a/pkg/numbers/number.go
+++ b/pkg/numbers/number.go
@@ -7,7 +7,7 @@ func Min(x, y int) int {
 	return y
 }
 
-func Max(x, y int) int {
+func Max(x, y int64) int64 {
 	if x > y {
 		return x
 	}

--- a/pkg/numbers/number_test.go
+++ b/pkg/numbers/number_test.go
@@ -9,7 +9,8 @@ func TestMin(t *testing.T) {
 	assert.Equal(t, Min(1, 5), 1)
 	assert.Equal(t, Min(22, 5), 5)
 }
+
 func TestMax(t *testing.T) {
-	assert.Equal(t, Max(1, 5), 5)
-	assert.Equal(t, Max(22, 5), 22)
+	assert.Equal(t, Max(1, 5), int64(5))
+	assert.Equal(t, Max(22, 5), int64(22))
 }


### PR DESCRIPTION
# Headline
set minimum timestamp date for charts 

## Issue
`time_start` must be a valid ISO 8601 timestamp or unix time value

closes https://github.com/trustwallet/blockatlas/issues/708