### PR TITLE
Sort validators by APR in desc by default

### DIFF
--- a/pkg/blockatlas/staking.go
+++ b/pkg/blockatlas/staking.go
@@ -20,8 +20,6 @@ const (
 	DelegationTypeDelegate DelegationType = "delegate"
 )
 
-const ValidatorsPerPage = 100
-
 type StakingReward struct {
 	Annual float64 `json:"annual"`
 }

--- a/platform/cosmos/client.go
+++ b/platform/cosmos/client.go
@@ -31,7 +31,6 @@ func (c *Client) GetAddrTxs(address string, tag string) (txs TxPage, err error) 
 func (c *Client) GetValidators() (validators Validators, err error) {
 	query := url.Values{
 		"status": {"bonded"},
-		"page":   {"1"},
 	}
 	err = c.Get(&validators, "staking/validators", query)
 	return

--- a/services/assets/client.go
+++ b/services/assets/client.go
@@ -4,6 +4,7 @@ import (
 	"github.com/trustwallet/blockatlas/coin"
 	"github.com/trustwallet/blockatlas/pkg/blockatlas"
 	"github.com/trustwallet/blockatlas/pkg/errors"
+	"sort"
 	"time"
 )
 
@@ -34,6 +35,9 @@ func GetValidators(api blockatlas.StakeAPI) ([]blockatlas.StakeValidator, error)
 		return nil, err
 	}
 	results := NormalizeValidators(validators, assetsValidators, api.Coin())
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Details.Reward.Annual > results[j].Details.Reward.Annual
+	})
 	return results, nil
 }
 
@@ -55,7 +59,7 @@ func NormalizeValidators(validators []blockatlas.Validator, assets []AssetValida
 	results := make([]blockatlas.StakeValidator, 0)
 	for _, v := range validators {
 		for _, v2 := range assets {
-			if v.ID == v2.ID {
+			if v.ID == v2.ID && v2.Status.Disabled != true {
 				results = append(results, NormalizeValidator(v, v2, coin))
 			}
 		}

--- a/services/assets/model.go
+++ b/services/assets/model.go
@@ -6,8 +6,13 @@ type AssetValidator struct {
 	Description string          `json:"description"`
 	Website     string          `json:"website"`
 	Payout      ValidatorPayout `json:"payout,omitempty"`
+	Status      ValidatorStatus `json:"status,omitempty"`
 }
 
 type ValidatorPayout struct {
 	Commission float64 `json:"commission"`
+}
+
+type ValidatorStatus struct {
+	Disabled bool `json:"disabled"`
 }


### PR DESCRIPTION
Closes https://github.com/trustwallet/blockatlas/issues/718
For now just sort in desc by APR as default response, add other sort criteria when needed.
Also do not return validators that disabled on Assets repo, like https://github.com/trustwallet/assets/blob/master/blockchains/tezos/validators/list.json#L82