### PR TITLE
[MarketData] Small refactor of SaveRates() method for caching

### DIFF
--- a/marketdata/rates.go
+++ b/marketdata/rates.go
@@ -5,7 +5,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/trustwallet/blockatlas/marketdata/rate"
 	"github.com/trustwallet/blockatlas/marketdata/rate/coingecko"
-	cmc "github.com/trustwallet/blockatlas/marketdata/rate/coinmarketcap"
+	"github.com/trustwallet/blockatlas/marketdata/rate/coinmarketcap"
 	"github.com/trustwallet/blockatlas/marketdata/rate/compound"
 	"github.com/trustwallet/blockatlas/marketdata/rate/fixer"
 	"github.com/trustwallet/blockatlas/pkg/errors"
@@ -54,9 +54,13 @@ func runRate(storage storage.Market, p rate.Provider) error {
 	if err != nil {
 		return errors.E(err, "FetchLatestRates")
 	}
-	if len(rates) > 0 {
-		storage.SaveRates(rates, rateProviders)
-		logger.Info("Market rates", logger.Params{"rates": len(rates), "provider": p.GetId()})
+	if len(rates) == 0 {
+		return nil
 	}
+	err = storage.SaveRates(rates, rateProviders)
+	if err != nil {
+		return errors.E(err, "runRate", errors.Params{"rates": rates})
+	}
+	logger.Info("Market rates", logger.Params{"rates": len(rates), "provider": p.GetId()})
 	return nil
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -30,6 +30,6 @@ type Addresses interface {
 type Market interface {
 	SaveTicker(coin *blockatlas.Ticker, pl ProviderList) error
 	GetTicker(coin, token string) (*blockatlas.Ticker, error)
-	SaveRates(rates blockatlas.Rates, pl ProviderList)
+	SaveRates(rates blockatlas.Rates, pl ProviderList) error
 	GetRate(currency string) (*blockatlas.Rate, error)
 }


### PR DESCRIPTION
change SaveRates(). Now it returns an error if all tokens are not saved in Redis (99% it can be caused only if Redis connection will be lost). It will help to handle the error and change Redis to memory cache (future).