### PR TITLE
[ONTOLOGY] normalizeBlock and normalizeBlockTransaction methods

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -144,7 +144,7 @@ cosmos:
 
 # [ONTOLOGY] ONT: https://ont.io/
 ontology:
-  api: https://explorer.ont.io/api/v1/explorer
+  api: https://explorer.ont.io
 
 # [ZIL] Zilliqa: https://zilliqa.com
 zilliqa:

--- a/pkg/tests/integration/integration_test.go
+++ b/pkg/tests/integration/integration_test.go
@@ -13,23 +13,37 @@ import (
 
 var (
 	testBlock = blockatlas.Block{
-		Number: 7677564,
-		ID:     "168d35ae9333f1d53ee0c124b44d268701df001df1313b388d001a5808f66d01",
+		Number: 7707834,
+		ID:     "a5f3ee1a102df7196bb1e262a05435f260392fae6be676ae2c0a6147f8ecf94c",
 		Txs: []blockatlas.Tx{
 			{
-				ID:     "736fab4fa13435f201bc90a43ca5cd8c324ec88d6048fedb136f267371daee39",
-				Block:  7677564,
+				ID:     "266d9d7282a5601bf6cb8fc5368a76a2aa54f45731a063a699a692487bcbd0cb",
+				Block:  7707834,
 				Status: blockatlas.StatusCompleted,
-				Date:   1580115134,
+				Date:   1580481541,
 				Coin:   coin.Ontology().ID,
+				Meta: blockatlas.NativeTokenTransfer{
+					Name:     "Ontology Gas",
+					Symbol:   "ONG",
+					TokenID:  "ong",
+					Decimals: 9,
+					Value:    "51000000000000",
+					From:     "AbEeCHUWpzQaxUN7G1a83N3P2XtVLuMLaE",
+					To:       "ASLbwuar3ZTbUbLPnCgjGUw2WHhMfvJJtx",
+				},
 			},
 		},
 	}
-	blockNum = 7677564
+	blockNum = 7707834
 )
 
 func TestOntology(t *testing.T) {
-	config.LoadConfig(os.Getenv("TEST_CONFIG"))
+	configPath := os.Getenv("TEST_CONFIG")
+	if configPath == "" {
+		config.LoadConfig("../../../config.yml")
+	} else {
+		config.LoadConfig(configPath)
+	}
 	p := &ontology.Platform{}
 	_ = p.Init()
 	testCurrentBlockNumber(p, t)
@@ -54,12 +68,26 @@ func testGetBlockByNumber(p *ontology.Platform, t *testing.T) {
 
 	isSame := resp.ID == testBlock.ID &&
 		resp.Number == testBlock.Number &&
-		resp.Txs[0].ID == testBlock.Txs[0].ID &&
 		resp.Txs[0].Block == testBlock.Txs[0].Block &&
 		resp.Txs[0].Status == testBlock.Txs[0].Status &&
 		resp.Txs[0].Date == testBlock.Txs[0].Date &&
 		resp.Txs[0].Coin == testBlock.Txs[0].Coin
 
+	if isSame {
+		// check that we have tx hashes of parsed block
+		for _, tx := range resp.Txs {
+			switch tx.ID {
+			case "40976edc1306b0e5f55b90c8d3ca248bb544e5ebbadb02be6146ba0a0de402c3":
+				isSame = true
+			case "266d9d7282a5601bf6cb8fc5368a76a2aa54f45731a063a699a692487bcbd0cb":
+				isSame = true
+			case "2935268c5715f1f2015ba828681c39399dedbe7a24ed628ef7b85d9aac8045fd":
+				isSame = true
+			default:
+				isSame = false
+			}
+		}
+	}
 	if !isSame {
 		t.Error("Block is not the same")
 	}

--- a/platform/ontology/api_test.go
+++ b/platform/ontology/api_test.go
@@ -3,6 +3,7 @@ package ontology
 import (
 	"bytes"
 	"encoding/json"
+	"github.com/magiconair/properties/assert"
 	"github.com/trustwallet/blockatlas/coin"
 	"github.com/trustwallet/blockatlas/pkg/blockatlas"
 	"testing"
@@ -144,22 +145,23 @@ func TestNormalize(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		var sourceTx Tx
+		var (
+			sourceTx Tx
+			ok       bool
+		)
 
 		tErr := json.Unmarshal([]byte(test.Transaction), &sourceTx)
 		if tErr != nil {
 			t.Fatal("Ontology: Can't unmarshal transaction", tErr)
 		}
 
-		var tx blockatlas.Tx
-		var ok bool
-		tx, ok = Normalize(&sourceTx, test.AssetName)
+		tx, ok := Normalize(sourceTx, test.AssetName)
 
 		if !ok {
 			t.Fatal("Ontology: Can't normalize transaction")
 		}
 
-		actual, err := json.Marshal(&tx)
+		actual, err := json.Marshal(tx)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -175,4 +177,143 @@ func TestNormalize(t *testing.T) {
 			t.Error("Transactions not equal")
 		}
 	}
+}
+
+var (
+	ontBlockResult = BlockResult{
+		Error: 0,
+		Result: Block{
+			Height: 7707834,
+			TxnList: []Tx{
+				{
+					TxnHash:     "266d9d7282a5601bf6cb8fc5368a76a2aa54f45731a063a699a692487bcbd0cb",
+					ConfirmFlag: 1,
+					TxnTime:     1580481541,
+					Height:      7707834,
+				},
+				{
+					TxnHash:     "2935268c5715f1f2015ba828681c39399dedbe7a24ed628ef7b85d9aac8045fd",
+					ConfirmFlag: 1,
+					TxnTime:     1580481541,
+					Height:      7707834,
+				},
+				{
+					TxnHash:     "40976edc1306b0e5f55b90c8d3ca248bb544e5ebbadb02be6146ba0a0de402c3",
+					ConfirmFlag: 1,
+					TxnTime:     1580481541,
+					Height:      7707834,
+				},
+			},
+			Hash: "a5f3ee1a102df7196bb1e262a05435f260392fae6be676ae2c0a6147f8ecf94c",
+		},
+	}
+)
+
+var (
+	ontTxResp1 = TxResponse{
+		Code: 0,
+		Msg:  "SUCCESS",
+		Result: TxV2{
+			Hash:        "266d9d7282a5601bf6cb8fc5368a76a2aa54f45731a063a699a692487bcbd0cb",
+			Type:        209,
+			Time:        1580481541,
+			BlockHeight: 7707834,
+			Fee:         "0.01",
+			Description: "transfer",
+			BlockIndex:  2,
+			ConfirmFlag: 1,
+			EventType:   3,
+			Details: TransactionDetails{
+				Transfers: []TransferDetails{
+					{
+						Amount:      "51000",
+						AssetName:   "ong",
+						FromAddress: "AbEeCHUWpzQaxUN7G1a83N3P2XtVLuMLaE",
+						ToAddress:   "ASLbwuar3ZTbUbLPnCgjGUw2WHhMfvJJtx",
+					},
+					{
+						Amount:      "0.01",
+						AssetName:   "ong",
+						FromAddress: "ANKXUWXy6XrhQvqbjhKJPH9AnLa2CuEMRK",
+						ToAddress:   "AFmseVrdL9f9oyCzZefL9tG6UbviEH9ugK",
+					},
+				},
+			},
+		},
+	}
+
+	ontTxResp2 = TxResponse{
+		Code: 0,
+		Msg:  "SUCCESS",
+		Result: TxV2{
+			Hash:        "2935268c5715f1f2015ba828681c39399dedbe7a24ed628ef7b85d9aac8045fd",
+			Type:        209,
+			Time:        1580481541,
+			BlockHeight: 7707834,
+			Fee:         "0.01",
+			Description: "transfer",
+			BlockIndex:  3,
+			ConfirmFlag: 1,
+			EventType:   3,
+			Details: TransactionDetails{
+				Transfers: []TransferDetails{
+					{
+						Amount:      "113.2",
+						AssetName:   "ong",
+						FromAddress: "ANdrA47zDXUu8MCkMdD3FYPmpSNGYeAvKz",
+						ToAddress:   "ASLbwuar3ZTbUbLPnCgjGUw2WHhMfvJJtx",
+					},
+					{
+						Amount:      "0.01",
+						AssetName:   "ong",
+						FromAddress: "ANKXUWXy6XrhQvqbjhKJPH9AnLa2CuEMRK",
+						ToAddress:   "AFmseVrdL9f9oyCzZefL9tG6UbviEH9ugK",
+					},
+				},
+			},
+		},
+	}
+
+	ontTxResp3 = TxResponse{
+		Code: 0,
+		Msg:  "SUCCESS",
+		Result: TxV2{
+			Hash:        "40976edc1306b0e5f55b90c8d3ca248bb544e5ebbadb02be6146ba0a0de402c3",
+			Type:        209,
+			Time:        1580481541,
+			BlockHeight: 7707834,
+			Fee:         "0.01",
+			Description: "transfer",
+			BlockIndex:  1,
+			ConfirmFlag: 1,
+			EventType:   3,
+			Details: TransactionDetails{
+				Transfers: []TransferDetails{
+					{
+						Amount:      "10949",
+						AssetName:   "ong",
+						FromAddress: "Abg2gs6pfpQu82jXbm8EYGiipRBvf9ktVS",
+						ToAddress:   "ASLbwuar3ZTbUbLPnCgjGUw2WHhMfvJJtx",
+					}, {
+						Amount:      "0.01",
+						AssetName:   "ong",
+						FromAddress: "ANKXUWXy6XrhQvqbjhKJPH9AnLa2CuEMRK",
+						ToAddress:   "AFmseVrdL9f9oyCzZefL9tG6UbviEH9ugK",
+					},
+				},
+			},
+		},
+	}
+)
+
+func TestNormalizeBlock(t *testing.T) {
+	block := normalizeBlock(ontBlockResult, []TxV2{ontTxResp1.Result, ontTxResp2.Result, ontTxResp3.Result})
+	got, err := json.Marshal(block)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := `{"number":7707834,"id":"a5f3ee1a102df7196bb1e262a05435f260392fae6be676ae2c0a6147f8ecf94c","txs":[{"id":"266d9d7282a5601bf6cb8fc5368a76a2aa54f45731a063a699a692487bcbd0cb","coin":1024,"from":"AbEeCHUWpzQaxUN7G1a83N3P2XtVLuMLaE","to":"ASLbwuar3ZTbUbLPnCgjGUw2WHhMfvJJtx","fee":"10000000","date":1580481541,"block":7707834,"status":"completed","type":"native_token_transfer","memo":"","metadata":{"name":"Ontology Gas","symbol":"ONG","token_id":"ong","decimals":9,"value":"51000000000000","from":"AbEeCHUWpzQaxUN7G1a83N3P2XtVLuMLaE","to":"ASLbwuar3ZTbUbLPnCgjGUw2WHhMfvJJtx"}},{"id":"2935268c5715f1f2015ba828681c39399dedbe7a24ed628ef7b85d9aac8045fd","coin":1024,"from":"ANdrA47zDXUu8MCkMdD3FYPmpSNGYeAvKz","to":"ASLbwuar3ZTbUbLPnCgjGUw2WHhMfvJJtx","fee":"10000000","date":1580481541,"block":7707834,"status":"completed","type":"native_token_transfer","memo":"","metadata":{"name":"Ontology Gas","symbol":"ONG","token_id":"ong","decimals":9,"value":"113200000000","from":"ANdrA47zDXUu8MCkMdD3FYPmpSNGYeAvKz","to":"ASLbwuar3ZTbUbLPnCgjGUw2WHhMfvJJtx"}},{"id":"40976edc1306b0e5f55b90c8d3ca248bb544e5ebbadb02be6146ba0a0de402c3","coin":1024,"from":"Abg2gs6pfpQu82jXbm8EYGiipRBvf9ktVS","to":"ASLbwuar3ZTbUbLPnCgjGUw2WHhMfvJJtx","fee":"10000000","date":1580481541,"block":7707834,"status":"completed","type":"native_token_transfer","memo":"","metadata":{"name":"Ontology Gas","symbol":"ONG","token_id":"ong","decimals":9,"value":"10949000000000","from":"Abg2gs6pfpQu82jXbm8EYGiipRBvf9ktVS","to":"ASLbwuar3ZTbUbLPnCgjGUw2WHhMfvJJtx"}}]}`
+
+	assert.Equal(t, string(got), want)
 }

--- a/platform/ontology/client.go
+++ b/platform/ontology/client.go
@@ -3,6 +3,7 @@ package ontology
 import (
 	"fmt"
 	"github.com/trustwallet/blockatlas/pkg/blockatlas"
+	"github.com/trustwallet/blockatlas/pkg/errors"
 )
 
 type Client struct {
@@ -15,20 +16,55 @@ const (
 	requestOnlyLatestBlockAmount = 1
 )
 
-func (c *Client) GetTxsOfAddress(address, assetName string) (txPage *TxPage, err error) {
-	url := fmt.Sprintf("address/%s/%s/%d/1", address, assetName, TxPerPage)
-	err = c.Get(&txPage, url, nil)
-	return
+func (c *Client) GetTxsOfAddress(address, assetName string) (*TxPage, error) {
+	url := fmt.Sprintf("api/v1/explorer/address/%s/%s/%d/1", address, assetName, TxPerPage)
+	var txPage TxPage
+	err := c.Get(&txPage, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &txPage, nil
 }
 
-func (c *Client) CurrentBlockNumber() (response *BlockResults, err error) {
-	url := fmt.Sprintf("blocklist/%d", requestOnlyLatestBlockAmount)
-	err = c.Get(&response, url, nil)
-	return
+func (c *Client) CurrentBlockNumber() (*BlockResults, error) {
+	url := fmt.Sprintf("api/v1/explorer/blocklist/%d", requestOnlyLatestBlockAmount)
+	var response BlockResults
+	err := c.Get(&response, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	if response.Error != 0 {
+		return nil, errors.E("explorer client CurrentBlockNumber", errors.Params{"platform": "ONT"})
+	}
+	return &response, nil
 }
 
-func (c *Client) GetBlockByNumber(num int64) (block *BlockResult, err error) {
-	url := fmt.Sprintf("block/%d", num)
-	err = c.Get(&block, url, nil)
-	return
+func (c *Client) GetBlockByNumber(num int64) (*BlockResult, error) {
+	url := fmt.Sprintf("api/v1/explorer/block/%d", num)
+	var block BlockResult
+	err := c.Get(&block, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	if block.Error != 0 {
+		return nil, errors.E("explorer client GetBlockByNumber", errors.Params{"platform": "ONT"})
+	}
+	return &block, nil
+}
+
+func (c *Client) GetTxDetailsByHash(hash string) (*TxV2, error) {
+	url := fmt.Sprintf("v2/transactions/%s", hash)
+	var response TxResponse
+	err := c.Get(&response, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	if response.Msg != "SUCCESS" {
+		return nil, errors.E("explorer client GetTxDetailsByHash", errors.Params{"platform": "ONT"})
+	}
+	var ontTxV2 TxV2
+	if response.Result.EventType == 3 {
+		ontTxV2 = response.Result
+	}
+	return &ontTxV2, nil
 }

--- a/platform/ontology/model.go
+++ b/platform/ontology/model.go
@@ -41,3 +41,33 @@ type Block struct {
 	TxnList []Tx   `json:"TxnList"`
 	Hash    string `json:"Hash"`
 }
+
+type TxResponse struct {
+	Code   int    `json:"code"`
+	Msg    string `json:"msg"`
+	Result TxV2   `json:"Result"`
+}
+
+type TxV2 struct {
+	Hash        string             `json:"tx_hash"`
+	Type        int                `json:"tx_type"`
+	Time        int64              `json:"tx_time"`
+	BlockHeight uint64             `json:"block_height"`
+	Fee         string             `json:"fee"`
+	Description string             `json:"description"`
+	BlockIndex  int                `json:"block_index"`
+	ConfirmFlag int                `json:"confirm_flag"`
+	EventType   int                `json:"event_type"`
+	Details     TransactionDetails `json:"detail"`
+}
+
+type TransactionDetails struct {
+	Transfers []TransferDetails `json:"transfers"`
+}
+
+type TransferDetails struct {
+	Amount      string `json:"amount"`
+	AssetName   string `json:"asset_name"`
+	FromAddress string `json:"from_address"`
+	ToAddress   string `json:"to_address"`
+}


### PR DESCRIPTION
normalizeBlock() and normalizeBlockTransaction() are implemented as well as unit test for.
Please, pay attention to https://github.com/EnoRage/blockatlas/blob/feature-ontology/platform/ontology/api.go#L118
I decided to use empty blockatlas.Transfer{} for Meta, because there is no detailed information about tx from block using last block api and also there is no way not to create Meta object (if there will be null - you will got JSON Marshaling error)