### PR TITLE
improve naming service api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,11 +138,11 @@ go-clean:
 
 go-test:
 	@echo "  >  Runing unit tests"
-	GOBIN=$(GOBIN) go test -cover -v ./...
+	GOBIN=$(GOBIN) go test -cover -race -v ./...
 
 go-integration:
 	@echo "  >  Runing integration tests"
-	GOBIN=$(GOBIN) TEST_CONFIG=$(TEST_CONFIG) go test -tags=integration -v ./pkg/integration
+	GOBIN=$(GOBIN) TEST_CONFIG=$(TEST_CONFIG) go test -race -tags=integration -v ./pkg/integration
 
 go-fmt:
 	@echo "  >  Format all go files"

--- a/api/naming_service.go
+++ b/api/naming_service.go
@@ -106,15 +106,19 @@ func sliceAtoi(sa []string) ([]uint64, error) {
 
 func handleLookup(name string, coins []uint64) (result []blockatlas.Resolved, err error) {
 	name = strings.ToLower(name)
-	for tld, id := range TLDMapping {
-		if strings.HasSuffix(name, tld) {
-			api := platform.NamingAPIs[id]
-			result, err = api.Lookup(coins, name)
-			if err != nil {
-				return
-			}
-			return
-		}
+	ss := strings.Split(name, ".")
+	if len(ss) == 0 {
+		return nil, errors.E("name not found", errors.Params{"name": name, "coins": coins})
 	}
-	return nil, errors.E("name not found", errors.Params{"name": name})
+	tld := "." + ss[len(ss)-1]
+	id, ok := TLDMapping[tld]
+	if !ok {
+		return nil, errors.E("name not found", errors.Params{"name": name, "coins": coins})
+	}
+	api, ok := platform.NamingAPIs[id]
+	if !ok {
+		return nil, errors.E("platform not found", errors.Params{"name": name, "coins": coins})
+	}
+	result, err = api.Lookup(coins, name)
+	return
 }

--- a/pkg/blockatlas/api.go
+++ b/pkg/blockatlas/api.go
@@ -72,6 +72,7 @@ type CustomAPI interface {
 	RegisterRoutes(router gin.IRouter)
 }
 
+// NamingServiceAPI provides public name service domains HTTP routes
 type NamingServiceAPI interface {
 	Platform
 	Lookup(coins []uint64, name string) ([]Resolved, error)


### PR DESCRIPTION
- fix panic with the coin doesn't implement the naming service API
- avoid iterate from TLD Mapping
- add more context to errors
- add [race condition detector](https://blog.golang.org/race-detector) parameter to run unit and integration tests