### PR TITLE
Add FIO naming support (testnet)

### DIFF
--- a/api/naming_service.go
+++ b/api/naming_service.go
@@ -3,6 +3,7 @@ package api
 import (
 	"github.com/trustwallet/blockatlas/pkg/errors"
 	"net/http"
+	"math"
 	"strconv"
 	"strings"
 
@@ -126,18 +127,14 @@ func handleLookup(name string, coins []uint64) (result []blockatlas.Resolved, er
 
 // Obtain tld from then name, e.g. ".ens" from "nick.ens"
 func getTLD(name string) (tld string, ok bool) {
-	if strings.Index(name, ".") >= 0 {
-		// xxx.tld format
-		ss := strings.Split(name, ".")
-		tld := "." + ss[len(ss)-1]
-		return tld, true
+	// find last separator
+	lastSeparatorIdx := int(math.Max(
+		float64(strings.LastIndex(name, ".")),
+		float64(strings.LastIndex(name, "@"))))
+	if (lastSeparatorIdx <= -1 || lastSeparatorIdx >= len(name)-1) {
+		// no separator inside string
+		return "", false
 	}
-	if strings.Index(name, "@") >= 0 {
-		// xxx@tld format
-		ss := strings.Split(name, "@")
-		tld := "@" + ss[len(ss)-1]
-		return tld, true
-	}
-	// none matched
-	return "", false
+	// return tail including separator
+	return name[lastSeparatorIdx:], true
 }

--- a/api/naming_service.go
+++ b/api/naming_service.go
@@ -2,8 +2,8 @@ package api
 
 import (
 	"github.com/trustwallet/blockatlas/pkg/errors"
-	"net/http"
 	"math"
+	"net/http"
 	"strconv"
 	"strings"
 
@@ -131,7 +131,7 @@ func getTLD(name string) (tld string, ok bool) {
 	lastSeparatorIdx := int(math.Max(
 		float64(strings.LastIndex(name, ".")),
 		float64(strings.LastIndex(name, "@"))))
-	if (lastSeparatorIdx <= -1 || lastSeparatorIdx >= len(name)-1) {
+	if lastSeparatorIdx <= -1 || lastSeparatorIdx >= len(name)-1 {
 		// no separator inside string
 		return "", false
 	}

--- a/api/naming_service_test.go
+++ b/api/naming_service_test.go
@@ -1,0 +1,24 @@
+package api
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func checkGetTLD(t *testing.T, name string, expectedTLD string, expectedOk bool) {
+	tld, ok := getTLD(name)
+	assert.Equal(t, expectedTLD, tld)
+	assert.Equal(t, expectedOk, ok)
+}
+
+func Test_getTLD(t *testing.T) {
+	checkGetTLD(t, "vitalik.eth", ".eth", true)
+	checkGetTLD(t, "vitalik.ens", ".ens", true)
+	checkGetTLD(t, "ourxyzwallet.xyz", ".xyz", true)
+	checkGetTLD(t, "btc.zil", ".zil", true)
+	checkGetTLD(t, "btc.crypto", ".crypto", true)
+	checkGetTLD(t, "nick@fiotestnet", "@fiotestnet", true)
+	checkGetTLD(t, "a", "", false) // no tld
+	checkGetTLD(t, "a@b.c", ".c", true)
+	checkGetTLD(t, "a.b@c", ".b@c", true)
+}

--- a/api/naming_service_test.go
+++ b/api/naming_service_test.go
@@ -2,24 +2,29 @@ package api
 
 import (
 	"github.com/stretchr/testify/assert"
+	"github.com/trustwallet/blockatlas/pkg/errors"
 	"testing"
 )
 
-func checkGetTLD(t *testing.T, name string, expectedTLD string, expectedOk bool) {
-	tld, ok := getTLD(name)
+func checkGetTLD(t *testing.T, name string, expectedTLD string, expectedError error) {
+	tld, err := getTLD(name)
 	assert.Equal(t, expectedTLD, tld)
-	assert.Equal(t, expectedOk, ok)
+	if expectedError == nil {
+		assert.Nil(t, err)
+	} else {
+		assert.NotNil(t, err)
+	}
 }
 
 func Test_getTLD(t *testing.T) {
-	checkGetTLD(t, "vitalik.eth", ".eth", true)
-	checkGetTLD(t, "vitalik.ens", ".ens", true)
-	checkGetTLD(t, "ourxyzwallet.xyz", ".xyz", true)
-	checkGetTLD(t, "btc.zil", ".zil", true)
-	checkGetTLD(t, "btc.crypto", ".crypto", true)
-	checkGetTLD(t, "nick@fiotestnet", "@fiotestnet", true)
-	checkGetTLD(t, "a", "", false)  // no tld
-	checkGetTLD(t, "a.", "", false) // empty tld
-	checkGetTLD(t, "a@b.c", ".c", true)
-	checkGetTLD(t, "a.b@c", "@c", true)
+	checkGetTLD(t, "vitalik.eth", ".eth", nil)
+	checkGetTLD(t, "vitalik.ens", ".ens", nil)
+	checkGetTLD(t, "ourxyzwallet.xyz", ".xyz", nil)
+	checkGetTLD(t, "btc.zil", ".zil", nil)
+	checkGetTLD(t, "btc.crypto", ".crypto", nil)
+	checkGetTLD(t, "nick@fiotestnet", "@fiotestnet", nil)
+	checkGetTLD(t, "a", "", errors.E("No TLD found in name"))  // no tld
+	checkGetTLD(t, "a.", "", errors.E("No TLD found in name")) // empty tld
+	checkGetTLD(t, "a@b.c", ".c", nil)
+	checkGetTLD(t, "a.b@c", "@c", nil)
 }

--- a/api/naming_service_test.go
+++ b/api/naming_service_test.go
@@ -18,7 +18,7 @@ func Test_getTLD(t *testing.T) {
 	checkGetTLD(t, "btc.zil", ".zil", true)
 	checkGetTLD(t, "btc.crypto", ".crypto", true)
 	checkGetTLD(t, "nick@fiotestnet", "@fiotestnet", true)
-	checkGetTLD(t, "a", "", false) // no tld
+	checkGetTLD(t, "a", "", false)  // no tld
 	checkGetTLD(t, "a.", "", false) // empty tld
 	checkGetTLD(t, "a@b.c", ".c", true)
 	checkGetTLD(t, "a.b@c", "@c", true)

--- a/api/naming_service_test.go
+++ b/api/naming_service_test.go
@@ -19,6 +19,7 @@ func Test_getTLD(t *testing.T) {
 	checkGetTLD(t, "btc.crypto", ".crypto", true)
 	checkGetTLD(t, "nick@fiotestnet", "@fiotestnet", true)
 	checkGetTLD(t, "a", "", false) // no tld
+	checkGetTLD(t, "a.", "", false) // empty tld
 	checkGetTLD(t, "a@b.c", ".c", true)
-	checkGetTLD(t, "a.b@c", ".b@c", true)
+	checkGetTLD(t, "a.b@c", "@c", true)
 }

--- a/config.yml
+++ b/config.yml
@@ -174,7 +174,8 @@ nebulas:
   api: https://explorer-backend.nebulas.io/api
 
 fio:
-  api: https://addresses.fio.foundation
+#  api: https://addresses.fio.foundation
+  api: http://testnet.fioprotocol.io/v1/chain
 
 # [BTC] Bitcoin: https://bitcoin.org/ (Blockbook API https://github.com/trezor/blockbook)
 bitcoin:

--- a/pkg/tests/functional/testdata/query_fixtures.json
+++ b/pkg/tests/functional/testdata/query_fixtures.json
@@ -11,7 +11,8 @@
     "name=vitalik.luxe&coins=60",
     "name=ourxyzwallet.xyz&coins=60",
     "name=btc.zil&coins=313",
-    "name=btc.crypto&coins=313"
+    "name=btc.crypto&coins=313",
+    "name=adam@fiotestnet&coins=60"
   ],
   "/v1/market/charts": [
     "currency=USD&time_start=1574483028&coin=60&token=0xdAC17F958D2ee523a2206206994597C13D831ec7",

--- a/platform/fio/api.go
+++ b/platform/fio/api.go
@@ -22,3 +22,20 @@ func (p *Platform) Coin() coin.Coin {
 func (p *Platform) GetTxsByAddress(address string) (page blockatlas.TxPage, err error) {
 	return page, err
 }
+
+func (p *Platform) Lookup(coins []uint64, name string) ([]blockatlas.Resolved, error) {
+	var result []blockatlas.Resolved
+	for _, coinId := range coins {
+		coinObj := coin.Coins[uint(coinId)]
+		address, err := p.client.lookupPubAddress(name, coinObj.Symbol)
+		if err != nil {
+			return result, err
+		}
+		result = append(result, blockatlas.Resolved{Coin: coinId, Result: address})
+	}
+
+	return result, nil
+}
+
+
+

--- a/platform/fio/api.go
+++ b/platform/fio/api.go
@@ -36,6 +36,3 @@ func (p *Platform) Lookup(coins []uint64, name string) ([]blockatlas.Resolved, e
 
 	return result, nil
 }
-
-
-

--- a/platform/fio/client.go
+++ b/platform/fio/client.go
@@ -2,8 +2,32 @@ package fio
 
 import (
 	"github.com/trustwallet/blockatlas/pkg/blockatlas"
+	"github.com/trustwallet/blockatlas/pkg/errors"
 )
 
 type Client struct {
 	blockatlas.Request
+}
+
+type GetPubAddressRequest struct {
+	FioAddress  string  `json:"fio_address"`
+	TokenCode   string 	`json:"token_code"`
+}
+
+type GetPubAddressResponse struct {
+	PublicAddress 	string  `json:"public_address"`
+	BlockNum  		int 	`json:"block_num"`
+	Message         string  `json:"message"`
+}
+
+func (c *Client) lookupPubAddress(name string, coinSymbol string) (address string, error error) {
+	var res GetPubAddressResponse
+	err := c.Post(&res, "get_pub_address", GetPubAddressRequest{FioAddress: name, TokenCode: coinSymbol})
+	if err != nil {
+		return "", err
+	}
+	if res.Message != "" {
+		return "", errors.E("Error lokking up FIO name: " + res.Message, errors.Params{"name": name, "coinSymbol": coinSymbol})
+	}
+	return res.PublicAddress, nil
 }

--- a/platform/fio/client.go
+++ b/platform/fio/client.go
@@ -16,7 +16,7 @@ func (c *Client) lookupPubAddress(name string, coinSymbol string) (address strin
 		return "", err
 	}
 	if res.Message != "" {
-		return "", errors.E("Error lokking up FIO name: " + res.Message, errors.Params{"name": name, "coinSymbol": coinSymbol})
+		return "", errors.E("Error lokking up FIO name: "+res.Message, errors.Params{"name": name, "coinSymbol": coinSymbol})
 	}
 	return res.PublicAddress, nil
 }

--- a/platform/fio/client.go
+++ b/platform/fio/client.go
@@ -5,6 +5,7 @@ import (
 	"github.com/trustwallet/blockatlas/pkg/errors"
 )
 
+// Client for FIO API
 type Client struct {
 	blockatlas.Request
 }
@@ -13,10 +14,10 @@ func (c *Client) lookupPubAddress(name string, coinSymbol string) (address strin
 	var res GetPubAddressResponse
 	err := c.Post(&res, "get_pub_address", GetPubAddressRequest{FioAddress: name, TokenCode: coinSymbol})
 	if err != nil {
-		return "", err
+		return "", errors.E(err, "Error lokking up FIO name", errors.Params{"name": name, "coinSymbol": coinSymbol, "inner_error": err.Error()})
 	}
 	if res.Message != "" {
-		return "", errors.E("Error lokking up FIO name: "+res.Message, errors.Params{"name": name, "coinSymbol": coinSymbol})
+		return "", errors.E("Error lokking up FIO name", errors.Params{"name": name, "coinSymbol": coinSymbol, "inner_error": res.Message})
 	}
 	return res.PublicAddress, nil
 }

--- a/platform/fio/client.go
+++ b/platform/fio/client.go
@@ -9,17 +9,6 @@ type Client struct {
 	blockatlas.Request
 }
 
-type GetPubAddressRequest struct {
-	FioAddress  string  `json:"fio_address"`
-	TokenCode   string 	`json:"token_code"`
-}
-
-type GetPubAddressResponse struct {
-	PublicAddress 	string  `json:"public_address"`
-	BlockNum  		int 	`json:"block_num"`
-	Message         string  `json:"message"`
-}
-
 func (c *Client) lookupPubAddress(name string, coinSymbol string) (address string, error error) {
 	var res GetPubAddressResponse
 	err := c.Post(&res, "get_pub_address", GetPubAddressRequest{FioAddress: name, TokenCode: coinSymbol})

--- a/platform/fio/model.go
+++ b/platform/fio/model.go
@@ -1,10 +1,12 @@
 package fio
 
+// GetPubAddressRequest request struct for get_pub_address
 type GetPubAddressRequest struct {
 	FioAddress string `json:"fio_address"`
 	TokenCode  string `json:"token_code"`
 }
 
+// GetPubAddressResponse response struct for get_pub_address
 type GetPubAddressResponse struct {
 	PublicAddress string `json:"public_address"`
 	BlockNum      int    `json:"block_num"`

--- a/platform/fio/model.go
+++ b/platform/fio/model.go
@@ -1,12 +1,12 @@
 package fio
 
 type GetPubAddressRequest struct {
-	FioAddress  string  `json:"fio_address"`
-	TokenCode   string 	`json:"token_code"`
+	FioAddress string `json:"fio_address"`
+	TokenCode  string `json:"token_code"`
 }
 
 type GetPubAddressResponse struct {
-	PublicAddress 	string  `json:"public_address"`
-	BlockNum  		int 	`json:"block_num"`
-	Message         string  `json:"message"`
+	PublicAddress string `json:"public_address"`
+	BlockNum      int    `json:"block_num"`
+	Message       string `json:"message"`
 }

--- a/platform/fio/model.go
+++ b/platform/fio/model.go
@@ -1,0 +1,12 @@
+package fio
+
+type GetPubAddressRequest struct {
+	FioAddress  string  `json:"fio_address"`
+	TokenCode   string 	`json:"token_code"`
+}
+
+type GetPubAddressResponse struct {
+	PublicAddress 	string  `json:"public_address"`
+	BlockNum  		int 	`json:"block_num"`
+	Message         string  `json:"message"`
+}


### PR DESCRIPTION
Extending naming providers with FIO naming, FIO testnet for now.  Issue #760 .
Format:  'name@fiotestnet'; API endpoint: http://testnet.fioprotocol.io/v1/chain

For testing:
make functional

```
curl http://localhost:8420/v2/ns/lookup?name=adam@fiotestnet\&coins=60
[{"result":"0xce5cB6c92Da37bbBa91Bd40D4C9D4D724A3a8F51","coin":60}]
```
