### PR TITLE
fix gin cache for validators

### DIFF
--- a/pkg/blockatlas/clientcache.go
+++ b/pkg/blockatlas/clientcache.go
@@ -52,11 +52,11 @@ func (r *Request) GetWithCache(result interface{}, path string, query url.Values
 }
 
 func getCache(key string, value interface{}) error {
-	cache, ok := memoryCache.Get(key)
+	c, ok := memoryCache.Get(key)
 	if !ok {
 		return errors.E("validator cache: invalid cache key")
 	}
-	r, ok := cache.([]byte)
+	r, ok := c.([]byte)
 	if !ok {
 		return errors.E("validator cache: failed to cast cache to bytes")
 	}

--- a/pkg/tests/functional/functional_test.go
+++ b/pkg/tests/functional/functional_test.go
@@ -36,8 +36,6 @@ func TestApis(t *testing.T) {
 	p := ":8420"
 
 	engine := gin.New()
-
-	engine.Use(gin.Recovery())
 	engine.Use(ginutils.CheckReverseProxy, sg)
 	engine.Use(ginutils.CORSMiddleware())
 


### PR DESCRIPTION
- Remove `gin.Recovery()` to avoid crash the cache middleware
- Change the variable name to avoid conflicts to the cache package