### PR TITLE
Add integration tests for naming service

### DIFF
--- a/pkg/tests/integration/domains/domains.go
+++ b/pkg/tests/integration/domains/domains.go
@@ -1,0 +1,112 @@
+// +build integration
+
+package domains
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/trustwallet/blockatlas/coin"
+	"github.com/trustwallet/blockatlas/pkg/blockatlas"
+	"github.com/trustwallet/blockatlas/services/domains"
+	"testing"
+)
+
+func TestDomains(t *testing.T) {
+	var tests = []struct {
+		name     string
+		domain   string
+		coins    []uint64
+		Expected []blockatlas.Resolved
+		wantErr  bool
+	}{
+		{
+			"test .eth domain",
+			"vitalik.eth",
+			[]uint64{coin.ETH},
+			[]blockatlas.Resolved{{Result: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", Coin: coin.ETH}},
+			false,
+		},
+		{
+			"test .luxe domain",
+			"vitalik.luxe",
+			[]uint64{coin.ETH},
+			[]blockatlas.Resolved{{Result: "0xD8A667312D5260F12a306Ae7730C754d938da86c", Coin: coin.ETH}},
+			false,
+		},
+		{
+			"test .xyz domain",
+			"ourxyzwallet.xyz",
+			[]uint64{coin.ETH},
+			[]blockatlas.Resolved{{Result: "0x0C54eEAd78d555bE3cbCD451424F9A27a7843935", Coin: coin.ETH}},
+			false,
+		},
+		{
+			"test .zil domain",
+			"dpantani.zil",
+			[]uint64{coin.ZIL},
+			[]blockatlas.Resolved{{Result: "zil1vdntvlk47j9kh9a85klqcd9rvgze06ruhmna64", Coin: coin.ZIL}},
+			false,
+		},
+		{
+			"test batch .zil domains",
+			"dpantani.zil",
+			[]uint64{coin.BTC, coin.ETH, coin.ZIL, coin.LTC, coin.BNB, coin.BCH, coin.DOGE, coin.XRP},
+			[]blockatlas.Resolved{
+				{Result: "bc1qd7eystu9xl53hkyxm4kyg7h5yk4p436sqx6f27", Coin: coin.BTC},
+				{Result: "0x5574Cd97432cEd0D7Caf58ac3c4fEDB2061C98fB", Coin: coin.ETH},
+				{Result: "zil1vdntvlk47j9kh9a85klqcd9rvgze06ruhmna64", Coin: coin.ZIL},
+				{Result: "ltc1qz6nd472gx5gl3urfeldkrhg3h83c8tp2m7m6sd", Coin: coin.LTC},
+				{Result: "bnb1h4vyuuytu4rm86ust29wwlevt95du52383cctm", Coin: coin.BNB},
+				{Result: "qzpjlfnzudeu83krv0yk0r2kys67qptj6ys6eg6dms", Coin: coin.BCH},
+				{Result: "DP9VmQyDMyB1TWwgXkyRpBa7rTfPYgMvjy", Coin: coin.DOGE},
+				{Result: "rUvXBttEXhdwaKjEM2MxbtswHU6AMhUTgJ", Coin: coin.XRP},
+			},
+			false,
+		},
+		{
+			"test .crypto domain",
+			"dpantani.crypto",
+			[]uint64{coin.ZIL},
+			[]blockatlas.Resolved{
+				{Result: "zil1vdntvlk47j9kh9a85klqcd9rvgze06ruhmna64", Coin: coin.ZIL},
+			},
+			false,
+		},
+		{
+			"test batch .crypto domains",
+			"dpantani.crypto",
+			[]uint64{coin.BTC, coin.ETH, coin.ZIL, coin.LTC, coin.BNB, coin.BCH, coin.DOGE, coin.XRP},
+			[]blockatlas.Resolved{
+				{Result: "bc1qd7eystu9xl53hkyxm4kyg7h5yk4p436sqx6f27", Coin: coin.BTC},
+				{Result: "0x5574Cd97432cEd0D7Caf58ac3c4fEDB2061C98fB", Coin: coin.ETH},
+				{Result: "zil1vdntvlk47j9kh9a85klqcd9rvgze06ruhmna64", Coin: coin.ZIL},
+				{Result: "ltc1qz6nd472gx5gl3urfeldkrhg3h83c8tp2m7m6sd", Coin: coin.LTC},
+				{Result: "bnb1h4vyuuytu4rm86ust29wwlevt95du52383cctm", Coin: coin.BNB},
+				{Result: "qzpjlfnzudeu83krv0yk0r2kys67qptj6ys6eg6dms", Coin: coin.BCH},
+				{Result: "DP9VmQyDMyB1TWwgXkyRpBa7rTfPYgMvjy", Coin: coin.DOGE},
+				{Result: "rUvXBttEXhdwaKjEM2MxbtswHU6AMhUTgJ", Coin: coin.XRP},
+			},
+			false,
+		},
+		{
+			"test batch with invalid coin",
+			"vitalik.eth",
+			[]uint64{44, coin.ETH},
+			[]blockatlas.Resolved{{Result: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", Coin: coin.ETH}},
+			false,
+		},
+		{"test invalid coin", "vitalik.eth", []uint64{44}, nil, false},
+		{"test invalid name", "z9z9z900s982jidhwallet.eth", []uint64{coin.ALGO}, nil, true},
+		{"test invalid domain", "vitalik.blabla", []uint64{coin.ALGO}, nil, true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := domains.HandleLookup(test.domain, test.coins)
+			if test.wantErr {
+				assert.NotNil(t, err)
+				return
+			}
+			assert.Nil(t, err)
+			assert.EqualValues(t, test.Expected, got)
+		})
+	}
+}

--- a/pkg/tests/integration/integration_test.go
+++ b/pkg/tests/integration/integration_test.go
@@ -4,8 +4,8 @@ package integration
 
 import (
 	"github.com/trustwallet/blockatlas/config"
-	"github.com/trustwallet/blockatlas/pkg/tests/integration/bitcoin"
-	"github.com/trustwallet/blockatlas/pkg/tests/integration/ontology"
+	"github.com/trustwallet/blockatlas/pkg/tests/integration/domains"
+	"github.com/trustwallet/blockatlas/platform"
 	"os"
 	"testing"
 )
@@ -17,6 +17,9 @@ func Test(t *testing.T) {
 	} else {
 		config.LoadConfig(configPath)
 	}
-	ontology.TestOntology(t)
-	bitcoin.TestBitcoin(t)
+	platform.Init()
+
+	//ontology.TestOntology(t)
+	//bitcoin.TestBitcoin(t)
+	domains.TestDomains(t)
 }

--- a/services/domains/domains.go
+++ b/services/domains/domains.go
@@ -1,0 +1,56 @@
+package domains
+
+import (
+	CoinType "github.com/trustwallet/blockatlas/coin"
+	"github.com/trustwallet/blockatlas/pkg/blockatlas"
+	"github.com/trustwallet/blockatlas/pkg/errors"
+	"github.com/trustwallet/blockatlas/platform"
+	"math"
+	"strings"
+)
+
+// TLDMapping Mapping of name TLD's to coin where they are handled
+var TLDMapping = map[string]uint64{
+	".eth":        CoinType.ETH,
+	".xyz":        CoinType.ETH,
+	".luxe":       CoinType.ETH,
+	".zil":        CoinType.ZIL,
+	".crypto":     CoinType.ZIL,
+	"@fiotestnet": CoinType.FIO,
+}
+
+func HandleLookup(name string, coins []uint64) ([]blockatlas.Resolved, error) {
+	// Assumption: format of the name can be decided (top-level-domain), and at most one naming service is tried
+	name = strings.ToLower(name)
+	tld, err := getTLD(name)
+	if err != nil {
+		return nil, errors.E(err, "name format not recognized", errors.Params{"name": name, "coins": coins})
+	}
+	id, ok := TLDMapping[tld]
+	if !ok {
+		return nil, errors.E("name not found", errors.Params{"name": name, "coins": coins, "tld": tld})
+	}
+	api, ok := platform.NamingAPIs[id]
+	if !ok {
+		return nil, errors.E("platform not found", errors.Params{"name": name, "coins": coins})
+	}
+	result, err := api.Lookup(coins, name)
+	if err != nil {
+		return nil, errors.E(err, "name format not recognized", errors.Params{"name": name, "coins": coins})
+	}
+	return result, nil
+}
+
+// Obtain tld from then name, e.g. ".ens" from "nick.ens"
+func getTLD(name string) (tld string, error error) {
+	// find last separator
+	lastSeparatorIdx := int(math.Max(
+		float64(strings.LastIndex(name, ".")),
+		float64(strings.LastIndex(name, "@"))))
+	if lastSeparatorIdx <= -1 || lastSeparatorIdx >= len(name)-1 {
+		// no separator inside string
+		return "", errors.E("No TLD found in name", errors.Params{"name": name})
+	}
+	// return tail including separator
+	return name[lastSeparatorIdx:], nil
+}

--- a/services/domains/domains_test.go
+++ b/services/domains/domains_test.go
@@ -1,4 +1,4 @@
-package api
+package domains
 
 import (
 	"github.com/stretchr/testify/assert"


### PR DESCRIPTION
closes https://github.com/trustwallet/blockatlas/issues/541

# Headline 

Add integrations tests for naming service domains

## Changes
- Move ens methods to `domains` package inside the `services` folder
- Create a package for `naming service` integrations tests