### PR TITLE
Removes TODOs to support VIP180 tokens other than VeThor (#596)

### DIFF
--- a/platform/vechain/api_test.go
+++ b/platform/vechain/api_test.go
@@ -145,7 +145,7 @@ var expectedTransferLog = blockatlas.TxPage{
 		Block:  4382764,
 		Meta: blockatlas.TokenTransfer{
 			Name:     gasTokenName,
-			Symbol:   "VTHO",
+			Symbol:   gasTokenSymbol,
 			TokenID:  "0x0000000000000000000000000000456E65726779",
 			From:     "0x2c7A8d5ccE0d5E6a8a31233B7Dc3DAE9AaE4b405",
 			To:       "0xB5e883349e68aB59307d1604555AC890fAC47128",

--- a/platform/vechain/api_test.go
+++ b/platform/vechain/api_test.go
@@ -52,6 +52,10 @@ func TestNormalizeTransaction(t *testing.T) {
 	}{
 		{"Test normalize VET transfer transaction", transferSrc, trxId, expectedTransfer},
 	}
+
+	subject := Platform{}
+
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var tx LogTransfer
@@ -62,7 +66,7 @@ func TestNormalizeTransaction(t *testing.T) {
 			errTrxID := json.Unmarshal([]byte(tt.txId), &tId)
 			assert.Nil(t, errTrxID)
 
-			actual, err := NormalizeTransaction(tx, tId)
+			actual, err := subject.NormalizeTransaction(tx, tId)
 			assert.Nil(t, err)
 
 			assert.Equal(t, tt.expected, actual, "tx don't equal")
@@ -140,7 +144,7 @@ var expectedTransferLog = blockatlas.TxPage{
 		Status: blockatlas.StatusCompleted,
 		Block:  4382764,
 		Meta: blockatlas.TokenTransfer{
-			Name:     "",
+			Name:     "VeThor",
 			Symbol:   "VTHO",
 			TokenID:  "0x0000000000000000000000000000456E65726779",
 			From:     "0x2c7A8d5ccE0d5E6a8a31233B7Dc3DAE9AaE4b405",
@@ -160,6 +164,9 @@ func TestNormalizeTokenTransaction(t *testing.T) {
 	}{
 		{"Normalize VIP180 token transfer", transferLogSrc, trxReceipt, expectedTransferLog},
 	}
+
+	subject := Platform{}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var tx Tx
@@ -170,7 +177,7 @@ func TestNormalizeTokenTransaction(t *testing.T) {
 			errR := json.Unmarshal([]byte(tt.txReceipt), &receipt)
 			assert.Nil(t, errR)
 
-			actual, err := NormalizeTokenTransaction(tx, receipt)
+			actual, err := subject.NormalizeTokenTransaction(tx, receipt)
 			assert.Nil(t, err)
 
 			assert.Equal(t, len(actual), 1, "tx could not be normalized")

--- a/platform/vechain/api_test.go
+++ b/platform/vechain/api_test.go
@@ -53,7 +53,7 @@ func TestNormalizeTransaction(t *testing.T) {
 		{"Test normalize VET transfer transaction", transferSrc, trxId, expectedTransfer},
 	}
 
-	subject := Platform{}
+	platform := Platform{}
 
 
 	for _, tt := range tests {

--- a/platform/vechain/api_test.go
+++ b/platform/vechain/api_test.go
@@ -144,7 +144,7 @@ var expectedTransferLog = blockatlas.TxPage{
 		Status: blockatlas.StatusCompleted,
 		Block:  4382764,
 		Meta: blockatlas.TokenTransfer{
-			Name:     "VeThor",
+			Name:     gasTokenName,
 			Symbol:   "VTHO",
 			TokenID:  "0x0000000000000000000000000000456E65726779",
 			From:     "0x2c7A8d5ccE0d5E6a8a31233B7Dc3DAE9AaE4b405",

--- a/platform/vechain/api_test.go
+++ b/platform/vechain/api_test.go
@@ -66,7 +66,7 @@ func TestNormalizeTransaction(t *testing.T) {
 			errTrxID := json.Unmarshal([]byte(tt.txId), &tId)
 			assert.Nil(t, errTrxID)
 
-			actual, err := subject.NormalizeTransaction(tx, tId)
+			actual, err := platform.NormalizeTransaction(tx, tId)
 			assert.Nil(t, err)
 
 			assert.Equal(t, tt.expected, actual, "tx don't equal")
@@ -177,7 +177,7 @@ func TestNormalizeTokenTransaction(t *testing.T) {
 			errR := json.Unmarshal([]byte(tt.txReceipt), &receipt)
 			assert.Nil(t, errR)
 
-			actual, err := subject.NormalizeTokenTransaction(tx, receipt)
+			actual, err := platform.NormalizeTokenTransaction(tx, receipt)
 			assert.Nil(t, err)
 
 			assert.Equal(t, len(actual), 1, "tx could not be normalized")

--- a/platform/vechain/api_test.go
+++ b/platform/vechain/api_test.go
@@ -165,7 +165,7 @@ func TestNormalizeTokenTransaction(t *testing.T) {
 		{"Normalize VIP180 token transfer", transferLogSrc, trxReceipt, expectedTransferLog},
 	}
 
-	subject := Platform{}
+	platform := Platform{}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/platform/vechain/model.go
+++ b/platform/vechain/model.go
@@ -5,6 +5,12 @@ const (
 	rangeUnit    = "block"
 )
 
+const (
+	gasTokenName     = "VeThor"
+	gasTokenSymbol   = "VTHO"
+	gasTokenDecimals = 18
+)
+
 type LogRequest struct {
 	Options     Options       `json:"options,omitempty"`
 	CriteriaSet []CriteriaSet `json:"criteriaSet,omitempty"`


### PR DESCRIPTION
Resolves #596 

Also: minor improvement by using the `Coin()` method to resolve coin ID, name, decimals instead of repeatedly hardcoding VET.

### TESTING
* `make test`
* was not able to run functional tests either on my branch or on master