### PR TITLE
Limit transaction history to 25 objects

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -104,12 +104,11 @@ func makeTxRoute(router gin.IRouter, api blockatlas.Platform, path string) {
 		AddTx:
 			page = append(page, tx)
 		}
-		page.Sort()
-		limitResult := page[0:blockatlas.TxPerPage]
-		if len(limitResult) > blockatlas.TxPerPage {
-			limitResult = page[0:blockatlas.TxPerPage]
+		if len(page) > blockatlas.TxPerPage {
+			page = page[0:blockatlas.TxPerPage]
 		}
-		ginutils.RenderSuccess(c, &limitResult)
+		page.Sort()
+		ginutils.RenderSuccess(c, &page)
 	})
 }
 

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -105,7 +105,8 @@ func makeTxRoute(router gin.IRouter, api blockatlas.Platform, path string) {
 			page = append(page, tx)
 		}
 		page.Sort()
-		ginutils.RenderSuccess(c, &page)
+		result := page[0:blockatlas.TxPerPage]
+		ginutils.RenderSuccess(c, &result)
 	})
 }
 

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -105,8 +105,11 @@ func makeTxRoute(router gin.IRouter, api blockatlas.Platform, path string) {
 			page = append(page, tx)
 		}
 		page.Sort()
-		result := page[0:blockatlas.TxPerPage]
-		ginutils.RenderSuccess(c, &result)
+		limitResult := page[0:blockatlas.TxPerPage]
+		if len(limitResult) > blockatlas.TxPerPage {
+			limitResult = page[0:blockatlas.TxPerPage]
+		}
+		ginutils.RenderSuccess(c, &limitResult)
 	})
 }
 

--- a/platform/bitcoin/client.go
+++ b/platform/bitcoin/client.go
@@ -15,7 +15,7 @@ func (c *Client) GetTransactions(address string) (transactions TransactionsList,
 	path := fmt.Sprintf("address/%s", address)
 	err = c.Get(&transactions, path, url.Values{
 		"details":  {"txs"},
-		"pageSize": {strconv.FormatInt(blockatlas.TxPerPage, 10)},
+		"pageSize": {strconv.Itoa(blockatlas.TxPerPage)},
 	})
 	return transactions, err
 }
@@ -23,7 +23,7 @@ func (c *Client) GetTransactions(address string) (transactions TransactionsList,
 func (c *Client) GetTransactionsByXpub(xpub string) (transactions TransactionsList, err error) {
 	path := fmt.Sprintf("v2/xpub/%s", xpub)
 	args := url.Values{
-		"pageSize": {strconv.FormatInt(blockatlas.TxPerPage, 10)},
+		"pageSize": {strconv.Itoa(blockatlas.TxPerPage)},
 		"details":  {"txs"},
 		"tokens":   {"derived"},
 	}
@@ -34,7 +34,7 @@ func (c *Client) GetTransactionsByXpub(xpub string) (transactions TransactionsLi
 func (c *Client) GetAddressesFromXpub(xpub string) (tokens []Token, err error) {
 	path := fmt.Sprintf("v2/xpub/%s", xpub)
 	args := url.Values{
-		"pageSize": {strconv.FormatInt(blockatlas.TxPerPage*4, 10)},
+		"pageSize": {strconv.Itoa(blockatlas.TxPerPage)},
 		"details":  {"txs"},
 		"tokens":   {"derived"},
 	}

--- a/platform/bitcoin/client.go
+++ b/platform/bitcoin/client.go
@@ -15,7 +15,7 @@ func (c *Client) GetTransactions(address string) (transactions TransactionsList,
 	path := fmt.Sprintf("address/%s", address)
 	err = c.Get(&transactions, path, url.Values{
 		"details":  {"txs"},
-		"pageSize": {strconv.FormatInt(blockatlas.TxPerPage*4, 10)},
+		"pageSize": {strconv.FormatInt(blockatlas.TxPerPage, 10)},
 	})
 	return transactions, err
 }
@@ -23,7 +23,7 @@ func (c *Client) GetTransactions(address string) (transactions TransactionsList,
 func (c *Client) GetTransactionsByXpub(xpub string) (transactions TransactionsList, err error) {
 	path := fmt.Sprintf("v2/xpub/%s", xpub)
 	args := url.Values{
-		"pageSize": {strconv.FormatInt(blockatlas.TxPerPage*4, 10)},
+		"pageSize": {strconv.FormatInt(blockatlas.TxPerPage, 10)},
 		"details":  {"txs"},
 		"tokens":   {"derived"},
 	}

--- a/platform/icon/client.go
+++ b/platform/icon/client.go
@@ -13,7 +13,7 @@ type Client struct {
 func (c *Client) GetAddressTransactions(address string) ([]Tx, error) {
 	query := url.Values{
 		"address": {address},
-		"count":   {strconv.FormatInt(blockatlas.TxPerPage, 10)},
+		"count":   {strconv.Itoa(blockatlas.TxPerPage)},
 	}
 	var res Response
 	err := c.Get(&res, "address/txList", query)

--- a/platform/iotex/client.go
+++ b/platform/iotex/client.go
@@ -40,7 +40,7 @@ func (c *Client) GetTxsOfAddress(address string, start int64) (*Response, error)
 	var response Response
 	err := c.Get(&response, "actions/addr/"+address, url.Values{
 		"start": {strconv.FormatInt(start, 10)},
-		"count": {strconv.FormatInt(blockatlas.TxPerPage, 10)},
+		"count": {strconv.Itoa(blockatlas.TxPerPage)},
 	})
 
 	if err != nil {


### PR DESCRIPTION
Limit the total number of history transactions to 25 objects