### PR TITLE
Compound fix prices

### DIFF
--- a/syncmarkets/clients/compound/models.go
+++ b/syncmarkets/clients/compound/models.go
@@ -5,9 +5,9 @@ type CoinPrices struct {
 }
 
 type CToken struct {
-	ExchangeRate Amount `json:"exchange_rate"`
-	Symbol       string `json:"symbol"`
-	TokenAddress string `json:"token_address"`
+	UnderlyingPrice Amount `json:"underlying_price"`
+	Symbol          string `json:"symbol"`
+	TokenAddress    string `json:"token_address"`
 }
 
 type Amount struct {

--- a/syncmarkets/market/compound/compound.go
+++ b/syncmarkets/market/compound/compound.go
@@ -44,8 +44,8 @@ func normalizeTicker(ctoken c.CToken, provider string) (*blockatlas.Ticker, erro
 		CoinType: blockatlas.TypeToken,
 		TokenId:  ctoken.TokenAddress,
 		Price: blockatlas.TickerPrice{
-			Value:    ctoken.ExchangeRate.Value,
-			Currency: blockatlas.DefaultCurrency,
+			Value:    ctoken.UnderlyingPrice.Value,
+			Currency: coin.Coins[coin.ETH].Symbol,
 			Provider: provider,
 		},
 		LastUpdate: time.Now(),

--- a/syncmarkets/market/compound/compound_test.go
+++ b/syncmarkets/market/compound/compound_test.go
@@ -2,6 +2,7 @@ package compound
 
 import (
 	"github.com/stretchr/testify/assert"
+	"github.com/trustwallet/blockatlas/coin"
 	"github.com/trustwallet/blockatlas/pkg/blockatlas"
 	"github.com/trustwallet/blockatlas/syncmarkets/clients/compound"
 	"sort"
@@ -23,28 +24,28 @@ func Test_normalizeTickers(t *testing.T) {
 			"test normalize compound quote",
 			args{prices: compound.CoinPrices{Data: []compound.CToken{
 				{
-					TokenAddress: "0x39aa39c021dfbae8fac545936693ac917d5e7563",
-					Symbol:       "cUSDC",
-					ExchangeRate: compound.Amount{Value: 0.0021},
+					TokenAddress:    "0x39aa39c021dfbae8fac545936693ac917d5e7563",
+					Symbol:          "cUSDC",
+					UnderlyingPrice: compound.Amount{Value: 0.0021},
 				},
 				{
-					TokenAddress: "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
-					Symbol:       "cREP",
-					ExchangeRate: compound.Amount{Value: 0.02},
+					TokenAddress:    "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
+					Symbol:          "cREP",
+					UnderlyingPrice: compound.Amount{Value: 0.02},
 				},
 			}}, provider: id},
 			blockatlas.Tickers{
 				&blockatlas.Ticker{CoinName: "ETH", TokenId: "0x39aa39c021dfbae8fac545936693ac917d5e7563", CoinType: blockatlas.TypeToken, LastUpdate: time.Unix(222, 0),
 					Price: blockatlas.TickerPrice{
 						Value:    0.0021,
-						Currency: blockatlas.DefaultCurrency,
+						Currency: coin.Coins[coin.ETH].Symbol,
 						Provider: id,
 					},
 				},
 				&blockatlas.Ticker{CoinName: "ETH", TokenId: "0x158079ee67fce2f58472a96584a73c7ab9ac95c1", CoinType: blockatlas.TypeToken, LastUpdate: time.Unix(444, 0),
 					Price: blockatlas.TickerPrice{
 						Value:    0.02,
-						Currency: blockatlas.DefaultCurrency,
+						Currency: coin.Coins[coin.ETH].Symbol,
 						Provider: id,
 					},
 				},

--- a/syncmarkets/rate/compound/compound.go
+++ b/syncmarkets/rate/compound/compound.go
@@ -40,7 +40,7 @@ func normalizeRates(coinPrices c.CoinPrices, provider string) (rates blockatlas.
 	for _, cToken := range coinPrices.Data {
 		rates = append(rates, blockatlas.Rate{
 			Currency:  strings.ToUpper(cToken.Symbol),
-			Rate:      1.0 / cToken.ExchangeRate.Value,
+			Rate:      1.0 / cToken.UnderlyingPrice.Value,
 			Timestamp: time.Now().Unix(),
 			Provider:  provider,
 		})

--- a/syncmarkets/rate/compound/compound_test.go
+++ b/syncmarkets/rate/compound/compound_test.go
@@ -21,12 +21,12 @@ func Test_normalizeRates(t *testing.T) {
 			c.CoinPrices{
 				Data: []c.CToken{
 					{
-						Symbol:       "cUSDC",
-						ExchangeRate: c.Amount{Value: 0.0021},
+						Symbol:          "cUSDC",
+						UnderlyingPrice: c.Amount{Value: 0.0021},
 					},
 					{
-						Symbol:       "cREP",
-						ExchangeRate: c.Amount{Value: 0.02},
+						Symbol:          "cREP",
+						UnderlyingPrice: c.Amount{Value: 0.02},
 					},
 				},
 			},
@@ -40,12 +40,12 @@ func Test_normalizeRates(t *testing.T) {
 			c.CoinPrices{
 				Data: []c.CToken{
 					{
-						Symbol:       "cUSDC",
-						ExchangeRate: c.Amount{Value: 110.0021},
+						Symbol:          "cUSDC",
+						UnderlyingPrice: c.Amount{Value: 110.0021},
 					},
 					{
-						Symbol:       "cREP",
-						ExchangeRate: c.Amount{Value: 110.02},
+						Symbol:          "cREP",
+						UnderlyingPrice: c.Amount{Value: 110.02},
 					},
 				},
 			},


### PR DESCRIPTION
Compound returs price in ETH. There is no option to fetch them in fiat like USD.
This PR makes market prices API to respect stored price currency in QUOTE.

Fixes: #822