### PR TITLE
Fix Nimiq transaction requests

### DIFF
--- a/platform/nimiq/tests/getTransactionsByAddress_50.json
+++ b/platform/nimiq/tests/getTransactionsByAddress_50.json
@@ -1,0 +1,62 @@
+[
+  {
+    "hash": "61454a43916e075f0e0a830888db7a37e9ffc42503fa3cd2d9eb85fe8067e435",
+    "blockHash": "ec2c6712a977d62e95e0d43eca02bf4161c86197e576073429c0cdc6b9cc1ce1",
+    "blockNumber": 507486,
+    "timestamp": 1554283830,
+    "confirmations": 450839,
+    "from": "99643a627e867dae6cf10ca73b4aff0345d3b72e",
+    "fromAddress": "NQ76 K5J3 LQKX GRXS UT7H 1JKK NJPY 0D2V 7DRE",
+    "to": "0d609a98033b7b85ab5178c6050ef9ef82d9006e",
+    "toAddress": "NQ64 1MG9 M603 7DVQ BASH F330 A3PR VX1D J03E",
+    "value": 199400,
+    "fee": 300,
+    "data": null,
+    "flags": 0
+  },
+  {
+    "hash": "bc38ac8f4fa67222e38e6120073e327a1cc7c38b8419502f6fd5dc3699853296",
+    "blockHash": "58c6afb786829419c90bdcdaf0ab01630b36105affc1718e3d2e772d91d73621",
+    "blockNumber": 952271,
+    "timestamp": 1581094339,
+    "confirmations": 6054,
+    "from": "fdcc85a8e604f23c7d2cd3c13a5d18dc566a6e7c",
+    "fromAddress": "NQ02 YP68 BA76 0KR3 QY9C SF0K LP8Q THB6 LTKU",
+    "to": "99643a627e867dae6cf10ca73b4aff0345d3b72e",
+    "toAddress": "NQ76 K5J3 LQKX GRXS UT7H 1JKK NJPY 0D2V 7DRE",
+    "value": 100000,
+    "fee": 138,
+    "data": null,
+    "flags": 0
+  },
+  {
+    "hash": "54de2a0c420f9c145320c9a020decb106b0b8989fe4be147144af79dc13e8a1c",
+    "blockHash": "25b73d90dd38ff61f6c8d713671ba576f735fa3f544d0ea9a5f74f00aea082ff",
+    "blockNumber": 933566,
+    "timestamp": 1579965313,
+    "confirmations": 24759,
+    "from": "fdcc85a8e604f23c7d2cd3c13a5d18dc566a6e7c",
+    "fromAddress": "NQ02 YP68 BA76 0KR3 QY9C SF0K LP8Q THB6 LTKU",
+    "to": "99643a627e867dae6cf10ca73b4aff0345d3b72e",
+    "toAddress": "NQ76 K5J3 LQKX GRXS UT7H 1JKK NJPY 0D2V 7DRE",
+    "value": 100000,
+    "fee": 138,
+    "data": null,
+    "flags": 0
+  },
+  {
+    "hash": "874494dc2640876ad1417822e230304050ef37924b06ee84a8d8584935f2707b",
+    "blockHash": "c583c5ee1b375d46d07a1289de036b7e10c426184d8d85de7e6d6eec66681167",
+    "blockNumber": 591542,
+    "timestamp": 1559352602,
+    "confirmations": 366783,
+    "from": "fdcc85a8e604f23c7d2cd3c13a5d18dc566a6e7c",
+    "fromAddress": "NQ02 YP68 BA76 0KR3 QY9C SF0K LP8Q THB6 LTKU",
+    "to": "99643a627e867dae6cf10ca73b4aff0345d3b72e",
+    "toAddress": "NQ76 K5J3 LQKX GRXS UT7H 1JKK NJPY 0D2V 7DRE",
+    "value": 100000,
+    "fee": 138,
+    "data": null,
+    "flags": 0
+  }
+]

--- a/platform/nimiq/transaction.go
+++ b/platform/nimiq/transaction.go
@@ -3,6 +3,7 @@ package nimiq
 import (
 	"github.com/trustwallet/blockatlas/coin"
 	"github.com/trustwallet/blockatlas/pkg/blockatlas"
+	"sort"
 	"time"
 )
 
@@ -39,6 +40,12 @@ func NormalizeTx(srcTx *Tx) blockatlas.Tx {
 
 // NormalizeTxs converts multiple Nimiq transactions
 func NormalizeTxs(srcTxs []Tx) []blockatlas.Tx {
+	sort.SliceStable(srcTxs, func(i, j int) bool {
+		return srcTxs[i].BlockNumber > srcTxs[j].BlockNumber
+	})
+	if len(srcTxs) > blockatlas.TxPerPage {
+		srcTxs = srcTxs[:blockatlas.TxPerPage]
+	}
 	txs := make([]blockatlas.Tx, len(srcTxs))
 	for i, srcTx := range srcTxs {
 		txs[i] = NormalizeTx(&srcTx)


### PR DESCRIPTION
A misinterpretation of the Nimiq RPC API can cause BlockAtlas to return unordered transaction lists or less than 25 transactions even when more are available.
This PR fixes the `getTransactionByAddress` call and ensures transaction count & ordering.

 - [x] tests pass
 - [x] project runs
 - [x] response valid