### PR TITLE
cDai price fix

### DIFF
--- a/api/maketdata.go
+++ b/api/maketdata.go
@@ -129,15 +129,15 @@ func getTickersHandler(storage storage.Market) func(c *gin.Context) {
 				continue
 			}
 			if r.Price.Currency != blockatlas.DefaultCurrency {
-				newRate, err := storage.GetRate(strings.ToUpper(r.Price.Currency))
+				tickerRate, err := storage.GetTicker(strings.ToUpper(r.Price.Currency), "")
 				if err == nil {
-					exchangeRate *= newRate.Rate
-					percentChange = newRate.PercentChange24h
+					exchangeRate *= tickerRate.Price.Value
+					percentChange = big.NewFloat(tickerRate.Price.Change24h)
 				} else {
-					tickerRate, err := storage.GetTicker(strings.ToUpper(r.Price.Currency), "")
+					newRate, err := storage.GetRate(strings.ToUpper(r.Price.Currency))
 					if err == nil {
-						exchangeRate *= tickerRate.Price.Value
-						percentChange = big.NewFloat(tickerRate.Price.Change24h)
+						exchangeRate *= 1.0 / newRate.Rate
+						percentChange = newRate.PercentChange24h
 					}
 				}
 			}

--- a/syncmarkets/clients/compound/models.go
+++ b/syncmarkets/clients/compound/models.go
@@ -6,6 +6,7 @@ type CoinPrices struct {
 
 type CToken struct {
 	UnderlyingPrice Amount `json:"underlying_price"`
+	ExchangeRate    Amount `json:"exchange_rate"`
 	Symbol          string `json:"symbol"`
 	TokenAddress    string `json:"token_address"`
 }

--- a/syncmarkets/market/compound/compound.go
+++ b/syncmarkets/market/compound/compound.go
@@ -44,7 +44,7 @@ func normalizeTicker(ctoken c.CToken, provider string) (*blockatlas.Ticker, erro
 		CoinType: blockatlas.TypeToken,
 		TokenId:  ctoken.TokenAddress,
 		Price: blockatlas.TickerPrice{
-			Value:    ctoken.UnderlyingPrice.Value,
+			Value:    ctoken.UnderlyingPrice.Value * ctoken.ExchangeRate.Value,
 			Currency: coin.Coins[coin.ETH].Symbol,
 			Provider: provider,
 		},

--- a/syncmarkets/market/compound/compound_test.go
+++ b/syncmarkets/market/compound/compound_test.go
@@ -27,24 +27,26 @@ func Test_normalizeTickers(t *testing.T) {
 					TokenAddress:    "0x39aa39c021dfbae8fac545936693ac917d5e7563",
 					Symbol:          "cUSDC",
 					UnderlyingPrice: compound.Amount{Value: 0.0021},
+					ExchangeRate:    compound.Amount{Value: 0.1},
 				},
 				{
 					TokenAddress:    "0x158079ee67fce2f58472a96584a73c7ab9ac95c1",
 					Symbol:          "cREP",
 					UnderlyingPrice: compound.Amount{Value: 0.02},
+					ExchangeRate:    compound.Amount{Value: 0.1},
 				},
 			}}, provider: id},
 			blockatlas.Tickers{
 				&blockatlas.Ticker{CoinName: "ETH", TokenId: "0x39aa39c021dfbae8fac545936693ac917d5e7563", CoinType: blockatlas.TypeToken, LastUpdate: time.Unix(222, 0),
 					Price: blockatlas.TickerPrice{
-						Value:    0.0021,
+						Value:    0.0021 * 0.1,
 						Currency: coin.Coins[coin.ETH].Symbol,
 						Provider: id,
 					},
 				},
 				&blockatlas.Ticker{CoinName: "ETH", TokenId: "0x158079ee67fce2f58472a96584a73c7ab9ac95c1", CoinType: blockatlas.TypeToken, LastUpdate: time.Unix(444, 0),
 					Price: blockatlas.TickerPrice{
-						Value:    0.02,
+						Value:    0.02 * 0.1,
 						Currency: coin.Coins[coin.ETH].Symbol,
 						Provider: id,
 					},

--- a/syncmarkets/rate/compound/compound.go
+++ b/syncmarkets/rate/compound/compound.go
@@ -40,7 +40,7 @@ func normalizeRates(coinPrices c.CoinPrices, provider string) (rates blockatlas.
 	for _, cToken := range coinPrices.Data {
 		rates = append(rates, blockatlas.Rate{
 			Currency:  strings.ToUpper(cToken.Symbol),
-			Rate:      1.0 / cToken.UnderlyingPrice.Value,
+			Rate:      1.0 / (cToken.UnderlyingPrice.Value * cToken.ExchangeRate.Value),
 			Timestamp: time.Now().Unix(),
 			Provider:  provider,
 		})

--- a/syncmarkets/rate/compound/compound_test.go
+++ b/syncmarkets/rate/compound/compound_test.go
@@ -23,16 +23,18 @@ func Test_normalizeRates(t *testing.T) {
 					{
 						Symbol:          "cUSDC",
 						UnderlyingPrice: c.Amount{Value: 0.0021},
+						ExchangeRate:    c.Amount{Value: 0.1},
 					},
 					{
 						Symbol:          "cREP",
 						UnderlyingPrice: c.Amount{Value: 0.02},
+						ExchangeRate:    c.Amount{Value: 0.1},
 					},
 				},
 			},
 			blockatlas.Rates{
-				blockatlas.Rate{Currency: "CUSDC", Rate: 1 / 0.0021, Timestamp: 333, Provider: provider},
-				blockatlas.Rate{Currency: "CREP", Rate: 1 / 0.02, Timestamp: 333, Provider: provider},
+				blockatlas.Rate{Currency: "CUSDC", Rate: 1 / (0.0021 * 0.1), Timestamp: 333, Provider: provider},
+				blockatlas.Rate{Currency: "CREP", Rate: 1 / (0.02 * 0.1), Timestamp: 333, Provider: provider},
 			},
 		},
 		{
@@ -41,17 +43,19 @@ func Test_normalizeRates(t *testing.T) {
 				Data: []c.CToken{
 					{
 						Symbol:          "cUSDC",
-						UnderlyingPrice: c.Amount{Value: 110.0021},
+						UnderlyingPrice: c.Amount{Value: 110.1},
+						ExchangeRate:    c.Amount{Value: 0.1},
 					},
 					{
 						Symbol:          "cREP",
-						UnderlyingPrice: c.Amount{Value: 110.02},
+						UnderlyingPrice: c.Amount{Value: 110},
+						ExchangeRate:    c.Amount{Value: 0.1},
 					},
 				},
 			},
 			blockatlas.Rates{
-				blockatlas.Rate{Currency: "CUSDC", Rate: 1 / 110.0021, Timestamp: 123, Provider: provider},
-				blockatlas.Rate{Currency: "CREP", Rate: 1 / 110.02, Timestamp: 123, Provider: provider},
+				blockatlas.Rate{Currency: "CUSDC", Rate: 1.0 / (110.1 * 0.1), Timestamp: 123, Provider: provider},
+				blockatlas.Rate{Currency: "CREP", Rate: 1.0 / (110 * 0.1), Timestamp: 123, Provider: provider},
 			},
 		},
 	}


### PR DESCRIPTION
In this PR:
1. Change order for non USD prices: check data in tickers first then in rates.
2. Change the way price for compound calculates: underlying price used as ETH price actually shows price of underlying token. For example for cDai it is Dai etc. So to calculate actual price we need to multiply that price on exchange rate between token and underlying token. The result price is in Eth. Then on API level we get eth price from ticker and calculate actual price.
![image](https://user-images.githubusercontent.com/16366057/74403995-33254c80-4e64-11ea-9354-814a00ea4716.png)
![image](https://user-images.githubusercontent.com/16366057/74404024-4506ef80-4e64-11ea-8d75-6671d735f449.png)

