### PR TITLE
FIO name lookup: add new chain_code parameter to get_pub_address call

### DIFF
--- a/platform/fio/client.go
+++ b/platform/fio/client.go
@@ -12,12 +12,12 @@ type Client struct {
 
 func (c *Client) lookupPubAddress(name string, coinSymbol string) (address string, error error) {
 	var res GetPubAddressResponse
-	err := c.Post(&res, "get_pub_address", GetPubAddressRequest{FioAddress: name, TokenCode: coinSymbol})
+	err := c.Post(&res, "get_pub_address", GetPubAddressRequest{FioAddress: name, TokenCode: coinSymbol, ChainCode: coinSymbol})
 	if err != nil {
-		return "", errors.E(err, "Error lokking up FIO name", errors.Params{"name": name, "coinSymbol": coinSymbol, "inner_error": err.Error()})
+		return "", errors.E(err, "Error looking up FIO name", errors.Params{"name": name, "coinSymbol": coinSymbol, "inner_error": err.Error()})
 	}
 	if res.Message != "" {
-		return "", errors.E("Error lokking up FIO name", errors.Params{"name": name, "coinSymbol": coinSymbol, "inner_error": res.Message})
+		return "", errors.E("Error looking up FIO name", errors.Params{"name": name, "coinSymbol": coinSymbol, "inner_error": res.Message})
 	}
 	return res.PublicAddress, nil
 }

--- a/platform/fio/model.go
+++ b/platform/fio/model.go
@@ -4,6 +4,7 @@ package fio
 type GetPubAddressRequest struct {
 	FioAddress string `json:"fio_address"`
 	TokenCode  string `json:"token_code"`
+	ChainCode  string `json:"chain_code"`
 }
 
 // GetPubAddressResponse response struct for get_pub_address


### PR DESCRIPTION
FIO name lookup: add new chain_code parameter to get_pub_address call.
Needed to follow changes in FIO API, FIO testnet version changed to v0.9 recently.