### PR TITLE
Remove unactive delegate only for stake list

### DIFF
--- a/api/stake.go
+++ b/api/stake.go
@@ -30,7 +30,7 @@ func makeStakingValidatorsRoute(router gin.IRouter, api blockatlas.Platform) {
 	}
 
 	router.GET("/staking/validators", gincache.CacheMiddleware(time.Hour, func(c *gin.Context) {
-		results, err := services.GetValidators(stakingAPI)
+		results, err := services.GetActiveValidators(stakingAPI)
 		if err != nil {
 			logger.Error(err)
 			ginutils.ErrorResponse(c).Message(err.Error()).Render()

--- a/services/assets/model.go
+++ b/services/assets/model.go
@@ -27,3 +27,13 @@ func (av AssetValidators) toMap() AssetValidatorMap {
 	}
 	return validators
 }
+
+func (av AssetValidators) activeValidators() AssetValidators {
+	activeAssets := make(AssetValidators, 0)
+	for _, a := range av {
+		if !a.Status.Disabled {
+			activeAssets = append(activeAssets, a)
+		}
+	}
+	return activeAssets
+}

--- a/services/assets/model_test.go
+++ b/services/assets/model_test.go
@@ -1,7 +1,7 @@
 package assets
 
 import (
-	"reflect"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
@@ -17,9 +17,38 @@ func TestAssetValidators_toMap(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.av.toMap(); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("toMap() = %v, want %v", got, tt.want)
-			}
+			got := tt.av.toMap()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestAssetValidators_activeValidators(t *testing.T) {
+	tests := []struct {
+		name string
+		av   AssetValidators
+		want AssetValidators
+	}{
+		{
+			"test get active validators 1",
+			AssetValidators{{ID: "test1", Status: ValidatorStatus{false}}},
+			AssetValidators{{ID: "test1", Status: ValidatorStatus{false}}},
+		},
+		{
+			"test get active validators 2",
+			AssetValidators{{ID: "test1", Status: ValidatorStatus{true}}},
+			AssetValidators{},
+		},
+		{
+			"test get active validators 3",
+			AssetValidators{{ID: "test1", Status: ValidatorStatus{true}}, {ID: "test2", Status: ValidatorStatus{false}}},
+			AssetValidators{{ID: "test2", Status: ValidatorStatus{false}}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.av.activeValidators()
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/services/assets/stake.go
+++ b/services/assets/stake.go
@@ -27,7 +27,7 @@ func GetValidatorsMap(api blockatlas.StakeAPI) (blockatlas.ValidatorMap, error) 
 	if err != nil {
 		return nil, err
 	}
-	results := normalizeValidators(assets, validators, api.Coin(), false)
+	results := normalizeValidators(assets, validators, api.Coin())
 	return results.ToMap(), nil
 }
 
@@ -36,7 +36,7 @@ func GetActiveValidators(api blockatlas.StakeAPI) (blockatlas.StakeValidators, e
 	if err != nil {
 		return nil, err
 	}
-	results := normalizeValidators(assets, validators, api.Coin(), true)
+	results := normalizeValidators(assets.activeValidators(), validators, api.Coin())
 	return results, nil
 }
 
@@ -53,15 +53,12 @@ func GetValidators(api blockatlas.StakeAPI) (AssetValidators, blockatlas.Validat
 	return assetsValidators, validators, nil
 }
 
-func normalizeValidators(assets AssetValidators, validators []blockatlas.Validator, coin coin.Coin, onlyActive bool) blockatlas.StakeValidators {
+func normalizeValidators(assets AssetValidators, validators []blockatlas.Validator, coin coin.Coin) blockatlas.StakeValidators {
 	results := make(blockatlas.StakeValidators, 0)
 	assetsMap := assets.toMap()
 	for _, v := range validators {
 		asset, ok := assetsMap[v.ID]
 		if !ok {
-			continue
-		}
-		if onlyActive && asset.Status.Disabled {
 			continue
 		}
 		results = append(results, normalizeValidator(v, asset, coin))

--- a/services/assets/stake_test.go
+++ b/services/assets/stake_test.go
@@ -19,7 +19,7 @@ var (
 			Status: true,
 		},
 	}
-	assets = []AssetValidator{
+	assets1 = []AssetValidator{
 		{
 			ID:          "test1",
 			Name:        "Spider",
@@ -35,7 +35,7 @@ var (
 			Status:      ValidatorStatus{Disabled: true},
 		},
 	}
-	assetsDisabled = []AssetValidator{
+	assets2 = []AssetValidator{
 		{
 			ID:          "test1",
 			Name:        "Spider",
@@ -140,7 +140,7 @@ func TestCalcAnnual(t *testing.T) {
 }
 
 func TestNormalizeValidator(t *testing.T) {
-	result := normalizeValidator(validators[0], assets[0], cosmosCoin)
+	result := normalizeValidator(validators[0], assets1[0], cosmosCoin)
 	assert.Equal(t, expectedStakeValidator, result)
 }
 
@@ -149,21 +149,18 @@ func Test_normalizeValidators(t *testing.T) {
 		assets     AssetValidators
 		validators []blockatlas.Validator
 		coin       coin.Coin
-		onlyActive bool
 	}
 	tests := []struct {
 		name string
 		args args
 		want blockatlas.StakeValidators
 	}{
-		{"normalize validator", args{assets, validators, cosmosCoin, true}, blockatlas.StakeValidators{expectedStakeValidator}},
-		{"normalize active validator", args{assets, validators, cosmosCoin, false}, blockatlas.StakeValidators{expectedStakeValidator, expectedStakeValidatorDisabled2}},
-		{"normalize validator with disabled assets", args{assetsDisabled, validators, cosmosCoin, true}, blockatlas.StakeValidators{}},
-		{"normalize active validator with disabled assets", args{assetsDisabled, validators, cosmosCoin, false}, blockatlas.StakeValidators{expectedStakeValidatorDisabled1, expectedStakeValidatorDisabled2}},
+		{"normalize validator 1", args{assets1, validators, cosmosCoin}, blockatlas.StakeValidators{expectedStakeValidator, expectedStakeValidatorDisabled2}},
+		{"normalize validator 2", args{assets2, validators, cosmosCoin}, blockatlas.StakeValidators{expectedStakeValidatorDisabled1, expectedStakeValidatorDisabled2}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := normalizeValidators(tt.args.assets, tt.args.validators, tt.args.coin, tt.args.onlyActive)
+			got := normalizeValidators(tt.args.assets, tt.args.validators, tt.args.coin)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/services/assets/stake_test.go
+++ b/services/assets/stake_test.go
@@ -7,51 +7,83 @@ import (
 	"testing"
 )
 
-var cosmosCoin = coin.Coin{Handle: "cosmos"}
-var validators = []blockatlas.Validator{
-	{
-		ID:     "test",
-		Status: true,
-	},
-	{
-		ID:     "test2",
-		Status: true,
-	},
-}
-var assets = []AssetValidator{
-	{
-		ID:          "test",
-		Name:        "Spider",
-		Description: "yo",
-		Website:     "https://tw.com",
-	},
-}
-
-var expectedStakeValidator = blockatlas.StakeValidator{
-	ID: "test", Status: true,
-	Info: blockatlas.StakeValidatorInfo{
-		Name:        "Spider",
-		Description: "yo",
-		Image:       "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/cosmos/validators/assets/test/logo.png",
-		Website:     "https://tw.com",
-	},
-}
+var (
+	cosmosCoin = coin.Coin{Handle: "cosmos"}
+	validators = []blockatlas.Validator{
+		{
+			ID:     "test1",
+			Status: true,
+		},
+		{
+			ID:     "test2",
+			Status: true,
+		},
+	}
+	assets = []AssetValidator{
+		{
+			ID:          "test1",
+			Name:        "Spider",
+			Description: "yo",
+			Website:     "https://tw.com",
+			Status:      ValidatorStatus{Disabled: false},
+		},
+		{
+			ID:          "test2",
+			Name:        "Man",
+			Description: "lo",
+			Website:     "https://tw.com",
+			Status:      ValidatorStatus{Disabled: true},
+		},
+	}
+	assetsDisabled = []AssetValidator{
+		{
+			ID:          "test1",
+			Name:        "Spider",
+			Description: "yo",
+			Website:     "https://tw.com",
+			Status:      ValidatorStatus{Disabled: true},
+		},
+		{
+			ID:          "test2",
+			Name:        "Man",
+			Description: "lo",
+			Website:     "https://tw.com",
+			Status:      ValidatorStatus{Disabled: true},
+		},
+	}
+	expectedStakeValidator = blockatlas.StakeValidator{
+		ID: "test1", Status: true,
+		Info: blockatlas.StakeValidatorInfo{
+			Name:        "Spider",
+			Description: "yo",
+			Image:       "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/cosmos/validators/assets/test1/logo.png",
+			Website:     "https://tw.com",
+		},
+	}
+	expectedStakeValidatorDisabled1 = blockatlas.StakeValidator{
+		ID: "test1", Status: false,
+		Info: blockatlas.StakeValidatorInfo{
+			Name:        "Spider",
+			Description: "yo",
+			Image:       "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/cosmos/validators/assets/test1/logo.png",
+			Website:     "https://tw.com",
+		},
+	}
+	expectedStakeValidatorDisabled2 = blockatlas.StakeValidator{
+		ID: "test2", Status: false,
+		Info: blockatlas.StakeValidatorInfo{
+			Name:        "Man",
+			Description: "lo",
+			Image:       "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/cosmos/validators/assets/test2/logo.png",
+			Website:     "https://tw.com",
+		},
+	}
+)
 
 func TestGetImage(t *testing.T) {
 	image := getImage(cosmosCoin, "TGzz8gjYiYRqpfmDwnLxfgPuLVNmpCswVp")
 	expected := "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/cosmos/validators/assets/TGzz8gjYiYRqpfmDwnLxfgPuLVNmpCswVp/logo.png"
 	assert.Equal(t, expected, image)
-}
-
-func TestNormalizeValidator(t *testing.T) {
-	result := normalizeValidator(validators[0], assets[0], cosmosCoin)
-	assert.Equal(t, expectedStakeValidator, result)
-}
-
-func TestNormalizeValidators(t *testing.T) {
-	result := normalizeValidators(validators, assets, cosmosCoin)
-	expected := blockatlas.StakeValidators{expectedStakeValidator}
-	assert.Equal(t, expected, result)
 }
 
 func TestCalcAnnual(t *testing.T) {
@@ -103,6 +135,36 @@ func TestCalcAnnual(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			gotInfo := calculateAnnual(tt.args.annual, tt.args.commission)
 			assert.Equal(t, tt.wanted, gotInfo)
+		})
+	}
+}
+
+func TestNormalizeValidator(t *testing.T) {
+	result := normalizeValidator(validators[0], assets[0], cosmosCoin)
+	assert.Equal(t, expectedStakeValidator, result)
+}
+
+func Test_normalizeValidators(t *testing.T) {
+	type args struct {
+		assets     AssetValidators
+		validators []blockatlas.Validator
+		coin       coin.Coin
+		onlyActive bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want blockatlas.StakeValidators
+	}{
+		{"normalize validator", args{assets, validators, cosmosCoin, true}, blockatlas.StakeValidators{expectedStakeValidator}},
+		{"normalize active validator", args{assets, validators, cosmosCoin, false}, blockatlas.StakeValidators{expectedStakeValidator, expectedStakeValidatorDisabled2}},
+		{"normalize validator with disabled assets", args{assetsDisabled, validators, cosmosCoin, true}, blockatlas.StakeValidators{}},
+		{"normalize active validator with disabled assets", args{assetsDisabled, validators, cosmosCoin, false}, blockatlas.StakeValidators{expectedStakeValidatorDisabled1, expectedStakeValidatorDisabled2}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeValidators(tt.args.assets, tt.args.validators, tt.args.coin, tt.args.onlyActive)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
# Headline

Remove inactive delegate only for stake list and keep to fetch  for delegations

## Issue

Validators can change the address or be outdated, but the user can already be staked in this validator

## Solution

Use the `disabled` flag to remove the validator from validator list, but we can show if we need to show delegation info for the user

closes https://github.com/trustwallet/blockatlas/issues/834