### PR TITLE
fix Zilliqa block request and data race

### DIFF
--- a/platform/zilliqa/block.go
+++ b/platform/zilliqa/block.go
@@ -21,19 +21,15 @@ func (p *Platform) CurrentBlockNumber() (int64, error) {
 
 func (p *Platform) GetBlockByNumber(num int64) (*blockatlas.Block, error) {
 	var normalized []blockatlas.Tx
-	txs, err := p.rpcClient.GetTxInBlock(num)
-	if err != nil {
-		return nil, err
-	}
-
+	txs := p.rpcClient.GetTxInBlock(num)
 	for _, srcTx := range txs {
 		tx := Normalize(&srcTx)
 		normalized = append(normalized, tx)
 	}
+
 	block := blockatlas.Block{
 		Number: num,
 		Txs:    normalized,
 	}
-
 	return &block, nil
 }

--- a/platform/zilliqa/block.go
+++ b/platform/zilliqa/block.go
@@ -21,7 +21,11 @@ func (p *Platform) CurrentBlockNumber() (int64, error) {
 
 func (p *Platform) GetBlockByNumber(num int64) (*blockatlas.Block, error) {
 	var normalized []blockatlas.Tx
-	txs := p.rpcClient.GetTxInBlock(num)
+	txs, err := p.rpcClient.GetTxInBlock(num)
+	if err != nil {
+		return nil, err
+	}
+
 	for _, srcTx := range txs {
 		tx := Normalize(&srcTx)
 		normalized = append(normalized, tx)

--- a/platform/zilliqa/model.go
+++ b/platform/zilliqa/model.go
@@ -2,6 +2,7 @@ package zilliqa
 
 import (
 	"encoding/hex"
+	"github.com/trustwallet/blockatlas/pkg/blockatlas"
 	"math/big"
 	"strconv"
 )
@@ -86,4 +87,11 @@ func (t *TxRPC) toTx() Tx {
 		ReceiptSuccess: t.Receipt.Success,
 	}
 	return tx
+}
+
+type BlockTxRpc struct {
+	JsonRpc string               `json:"jsonrpc"`
+	Error   *blockatlas.RpcError `json:"error,omitempty"`
+	Result  BlockTxs             `json:"result,omitempty"`
+	Id      string               `json:"id,omitempty"`
 }

--- a/platform/zilliqa/model.go
+++ b/platform/zilliqa/model.go
@@ -6,6 +6,18 @@ import (
 	"strconv"
 )
 
+type BlockTxs [][]string
+
+func (b BlockTxs) txs() []string {
+	txs := make([]string, 0)
+	for _, ids := range b {
+		for _, id := range ids {
+			txs = append(txs, id)
+		}
+	}
+	return txs
+}
+
 type Tx struct {
 	Hash           string      `json:"hash"`
 	BlockHeight    uint64      `json:"blockHeight"`

--- a/platform/zilliqa/model_test.go
+++ b/platform/zilliqa/model_test.go
@@ -70,3 +70,25 @@ func TestTx_NonceValue(t *testing.T) {
 		})
 	}
 }
+
+func TestBlockTxs_txs(t *testing.T) {
+	tests := []struct {
+		name string
+		b    BlockTxs
+		want []string
+	}{
+		{"test 1 tx", BlockTxs{{"tx1"}, {}}, []string{"tx1"}},
+		{"test 2 txs  1", BlockTxs{{"tx1"}, {"tx2"}}, []string{"tx1", "tx2"}},
+		{"test 2 txs 2", BlockTxs{{"tx1", "tx2"}}, []string{"tx1", "tx2"}},
+		{"test 3 txs 1", BlockTxs{{"tx1", "tx2"}, {"tx3"}}, []string{"tx1", "tx2", "tx3"}},
+		{"test 3 txs 2", BlockTxs{{"tx1"}, {"tx2"}, {"tx3"}}, []string{"tx1", "tx2", "tx3"}},
+		{"test 4 txs", BlockTxs{{"tx1", "tx2"}, {"tx3"}, {"tx4"}}, []string{"tx1", "tx2", "tx3", "tx4"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.b.txs(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("txs() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/platform/zilliqa/rpc.go
+++ b/platform/zilliqa/rpc.go
@@ -20,12 +20,14 @@ func (c *RpcClient) GetTx(hash string) (tx TxRPC, err error) {
 	return
 }
 
-func (c *RpcClient) GetTxInBlock(number int64) ([]Tx, error) {
+func (c *RpcClient) GetTxInBlock(number int64) []Tx {
 	strNumber := strconv.Itoa(int(number))
+	txs := make([]Tx, 0)
+
 	var results BlockTxs
 	err := c.RpcCall(&results, "GetTransactionsForTxBlock", []string{strNumber})
 	if err != nil {
-		return nil, err
+		return txs
 	}
 
 	var wg sync.WaitGroup
@@ -45,9 +47,8 @@ func (c *RpcClient) GetTxInBlock(number int64) ([]Tx, error) {
 	wg.Wait()
 	close(out)
 
-	txs := make([]Tx, 0)
 	for tx := range out {
 		txs = append(txs, tx)
 	}
-	return txs, nil
+	return txs
 }


### PR DESCRIPTION
# Headline

- Fix block parser for Zilliqa
- Fix data race
- Ignore 'TxBlock has no transactions' error to avoid retries

## Issue

- The object to parse block transactions was wrong
- Data race
- If the block doesn't have a transaction, the retry system tries to fetch the block again

closes https://github.com/trustwallet/blockatlas/issues/863
closes https://github.com/trustwallet/blockatlas/issues/885