### PR TITLE
Fix date for NIMIQ pending transaction

### DIFF
--- a/platform/nimiq/transaction.go
+++ b/platform/nimiq/transaction.go
@@ -3,6 +3,7 @@ package nimiq
 import (
 	"github.com/trustwallet/blockatlas/coin"
 	"github.com/trustwallet/blockatlas/pkg/blockatlas"
+	"time"
 )
 
 func (p *Platform) GetTxsByAddress(address string) (blockatlas.TxPage, error) {
@@ -15,7 +16,11 @@ func (p *Platform) GetTxsByAddress(address string) (blockatlas.TxPage, error) {
 
 // NormalizeTx converts a Nimiq transaction into the generic model
 func NormalizeTx(srcTx *Tx) blockatlas.Tx {
-	date, _ := srcTx.Timestamp.Int64()
+	date, err := srcTx.Timestamp.Int64()
+	// Pending transaction doesn't have a timestamp, we gonna use the current time
+	if err != nil || len(srcTx.BlockHash) == 0 {
+		date = time.Now().Unix()
+	}
 	return blockatlas.Tx{
 		ID:    srcTx.Hash,
 		Coin:  coin.NIM,

--- a/platform/nimiq/transaction_test.go
+++ b/platform/nimiq/transaction_test.go
@@ -1,14 +1,16 @@
 package nimiq
 
 import (
-	"bytes"
 	"encoding/json"
+	"github.com/stretchr/testify/assert"
 	"github.com/trustwallet/blockatlas/coin"
 	"github.com/trustwallet/blockatlas/pkg/blockatlas"
 	"testing"
+	"time"
 )
 
-const basicSrc = `
+const (
+	basicSrc = `
 {
 	"hash": "8b219949f4c1dfe9e7a9cdc5dbbc507e40dc16f44a1a5182ed6125c9a6891a50",
 	"blockHash": "ab36a0909c6ed5761a984ef261d9c3456b7c1aea6a52d531c5bf2518526a32e6",
@@ -26,44 +28,71 @@ const basicSrc = `
 	"flags": 0
 }
 `
-
-var basicDst = blockatlas.Tx{
-	ID:    "8b219949f4c1dfe9e7a9cdc5dbbc507e40dc16f44a1a5182ed6125c9a6891a50",
-	Coin:  coin.NIM,
-	From:  "NQ69 9A4A MB83 HXDQ 4J46 BH5R 4JFF QMA9 C3GN",
-	To:    "NQ15 MLJN 23YB 8FBM 61TN 7LYG 2212 LVBG 4V19",
-	Fee:   "138",
-	Date:  1538924505,
-	Block: 252575,
-	Meta: blockatlas.Transfer{
-		Value:    "10000000000000",
-		Symbol:   "NIM",
-		Decimals: 5,
-	},
+	pendingSrc = `
+{
+  "data": null,
+  "fee": 300,
+  "flags": 0,
+  "from": "d48182276127b149a9710e78c436fb4bc1c4dc0b",
+  "fromAddress": "NQ74 SJ0Q 49T1 4XQL KABH 1RUC 8DPT 9F0U 9P0B",
+  "hash": "79719d16f3f347cc98c35cd7a9af708cdce97de578b5135c5ae4393fd7920d61",
+  "to": "0a17218ffdc42385f45329ba4089919236dd2743",
+  "toAddress": "NQ97 18BJ 33YV QGHQ BV2K 56V4 12CH J8TD S9S3",
+  "value": 100000
 }
+`
+)
 
-func TestNormalizeTx(t *testing.T) {
-	var srcTx Tx
-	err := json.Unmarshal([]byte(basicSrc), &srcTx)
-	if err != nil {
-		t.Error(err)
-		return
+var (
+	basicDst = blockatlas.Tx{
+		ID:    "8b219949f4c1dfe9e7a9cdc5dbbc507e40dc16f44a1a5182ed6125c9a6891a50",
+		Coin:  coin.NIM,
+		From:  "NQ69 9A4A MB83 HXDQ 4J46 BH5R 4JFF QMA9 C3GN",
+		To:    "NQ15 MLJN 23YB 8FBM 61TN 7LYG 2212 LVBG 4V19",
+		Fee:   "138",
+		Date:  1538924505,
+		Block: 252575,
+		Meta: blockatlas.Transfer{
+			Value:    "10000000000000",
+			Symbol:   "NIM",
+			Decimals: 5,
+		},
 	}
-
-	tx := NormalizeTx(&srcTx)
-	resJSON, err := json.Marshal(&tx)
-	if err != nil {
-		t.Fatal(err)
+	pendingDst = blockatlas.Tx{
+		ID:    "79719d16f3f347cc98c35cd7a9af708cdce97de578b5135c5ae4393fd7920d61",
+		Coin:  coin.NIM,
+		From:  "NQ74 SJ0Q 49T1 4XQL KABH 1RUC 8DPT 9F0U 9P0B",
+		To:    "NQ97 18BJ 33YV QGHQ BV2K 56V4 12CH J8TD S9S3",
+		Fee:   "300",
+		Date:  time.Now().Unix(),
+		Block: 0,
+		Meta: blockatlas.Transfer{
+			Value:    "100000",
+			Symbol:   "NIM",
+			Decimals: 5,
+		},
 	}
+)
 
-	dstJSON, err := json.Marshal(&basicDst)
-	if err != nil {
-		t.Fatal(err)
+func TestNormalizeTx1(t *testing.T) {
+	tests := []struct {
+		name  string
+		srcTx string
+		want  blockatlas.Tx
+	}{
+		{"test transaction", basicSrc, basicDst},
+		{"test pending transaction", pendingSrc, pendingDst},
 	}
-
-	if !bytes.Equal(resJSON, dstJSON) {
-		println(string(resJSON))
-		println(string(dstJSON))
-		t.Error("basic: tx don't equal")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var srcTx Tx
+			err := json.Unmarshal([]byte(tt.srcTx), &srcTx)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			got := NormalizeTx(&srcTx)
+			assert.Equal(t, tt.want, got)
+		})
 	}
 }


### PR DESCRIPTION
# Headline 

Fix empty timestamp for NIMIQ pending transactions

## Issue

The API doesn't return the timestamp if the transaction is pending

## Solution

Add current time for pending transactions

closes https://github.com/trustwallet/blockatlas/issues/880