### PR TITLE
Add version control

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 #! /usr/bin/make -f
 
 # Project variables.
+PACKAGE := github.com/trustwallet/blockatlas
 VERSION := $(shell git describe --tags)
 BUILD := $(shell git rev-parse --short HEAD)
+DATETIME := $(shell date +"%Y.%m.%d-%H:%M:%S")
 PROJECT_NAME := $(shell basename "$(PWD)")
 API_SERVICE := platform_api
 OBSERVER_SERVICE := platform_observer
@@ -26,7 +28,7 @@ CONFIG_FILE=$(GOBASE)/config.yml
 GOFMT_FILES?=$$(find . -name '*.go' | grep -v vendor)
 
 # Use linker flags to provide version/build settings
-LDFLAGS=-ldflags "-X=main.Version=$(VERSION) -X=main.Build=$(BUILD)"
+LDFLAGS=-ldflags "-X=$(PACKAGE)/build.Version=$(VERSION) -X=$(PACKAGE)/build.Build=$(BUILD) -X=$(PACKAGE)/build.Date=$(DATETIME)"
 
 # Redirect error output to a file, so we can show it in development mode.
 STDERR := /tmp/.$(PROJECT_NAME)-stderr.txt

--- a/build/build.go
+++ b/build/build.go
@@ -1,0 +1,26 @@
+package build
+
+import (
+	"fmt"
+	"runtime"
+)
+
+var (
+	Version = "dev"
+	Build   = "dev"
+	Date    = ""
+)
+
+func LogVersionInfo() {
+	fmt.Printf(`
+************************************************
+Version: %v
+Build: %v
+Date: %v
+OS: %s
+Arch: %s
+Go: %s
+************************************************
+`,
+		Version, Build, Date, runtime.GOOS, runtime.GOARCH, runtime.Version())
+}

--- a/cmd/market_api/main.go
+++ b/cmd/market_api/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/trustwallet/blockatlas/api"
+	"github.com/trustwallet/blockatlas/build"
 	"github.com/trustwallet/blockatlas/config"
 	_ "github.com/trustwallet/blockatlas/docs"
 	"github.com/trustwallet/blockatlas/internal"
@@ -23,6 +24,7 @@ var (
 )
 
 func init() {
+	build.LogVersionInfo()
 	port, confPath, sg, cache = internal.InitAPIWithRedis(defaultPort, defaultConfigPath)
 }
 
@@ -38,7 +40,10 @@ func main() {
 	engine.GET("/", api.GetRoot)
 	engine.GET("/status", func(c *gin.Context) {
 		ginutils.RenderSuccess(c, map[string]interface{}{
-			"status": true,
+			"status":  true,
+			"version": build.Version,
+			"build":   build.Build,
+			"date":    build.Date,
 		})
 	})
 

--- a/cmd/market_observer/main.go
+++ b/cmd/market_observer/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/trustwallet/blockatlas/build"
 	"github.com/trustwallet/blockatlas/internal"
 	"github.com/trustwallet/blockatlas/market"
 	"github.com/trustwallet/blockatlas/storage"
@@ -16,6 +17,7 @@ var (
 )
 
 func init() {
+	build.LogVersionInfo()
 	_, confPath, _, cache = internal.InitAPIWithRedis("", defaultConfigPath)
 }
 

--- a/cmd/observer_api/main.go
+++ b/cmd/observer_api/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/trustwallet/blockatlas/api"
+	"github.com/trustwallet/blockatlas/build"
 	"github.com/trustwallet/blockatlas/config"
 	_ "github.com/trustwallet/blockatlas/docs"
 	"github.com/trustwallet/blockatlas/internal"
@@ -23,6 +24,7 @@ var (
 )
 
 func init() {
+	build.LogVersionInfo()
 	port, confPath, sg, cache = internal.InitAPIWithRedis(defaultPort, defaultConfigPath)
 }
 
@@ -38,7 +40,10 @@ func main() {
 	engine.GET("/", api.GetRoot)
 	engine.GET("/status", func(c *gin.Context) {
 		ginutils.RenderSuccess(c, map[string]interface{}{
-			"status": true,
+			"status":  true,
+			"version": build.Version,
+			"build":   build.Build,
+			"date":    build.Date,
 		})
 	})
 

--- a/cmd/platform_api/main.go
+++ b/cmd/platform_api/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/trustwallet/blockatlas/api"
+	"github.com/trustwallet/blockatlas/build"
 	"github.com/trustwallet/blockatlas/config"
 	_ "github.com/trustwallet/blockatlas/docs"
 	"github.com/trustwallet/blockatlas/internal"
@@ -22,6 +23,7 @@ var (
 )
 
 func init() {
+	build.LogVersionInfo()
 	port, confPath, sg = internal.InitAPI(defaultPort, defaultConfigPath)
 	platform.Init(config.Configuration.Platform)
 }
@@ -37,7 +39,10 @@ func main() {
 	engine.GET("/", api.GetRoot)
 	engine.GET("/status", func(c *gin.Context) {
 		ginutils.RenderSuccess(c, map[string]interface{}{
-			"status": true,
+			"status":  true,
+			"version": build.Version,
+			"build":   build.Build,
+			"date":    build.Date,
 		})
 	})
 

--- a/cmd/platform_observer/main.go
+++ b/cmd/platform_observer/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"github.com/trustwallet/blockatlas/build"
 	"github.com/trustwallet/blockatlas/config"
 	"github.com/trustwallet/blockatlas/internal"
 	"github.com/trustwallet/blockatlas/observer"
@@ -21,6 +22,7 @@ var (
 )
 
 func init() {
+	build.LogVersionInfo()
 	_, confPath, _, cache = internal.InitAPIWithRedis("", defaultConfigPath)
 	platform.Init(config.Configuration.Platform)
 }

--- a/cmd/swagger_api/main.go
+++ b/cmd/swagger_api/main.go
@@ -5,6 +5,7 @@ import (
 	ginSwagger "github.com/swaggo/gin-swagger"
 	"github.com/swaggo/gin-swagger/swaggerFiles"
 	"github.com/trustwallet/blockatlas/api"
+	"github.com/trustwallet/blockatlas/build"
 	"github.com/trustwallet/blockatlas/config"
 	_ "github.com/trustwallet/blockatlas/docs"
 	"github.com/trustwallet/blockatlas/internal"
@@ -23,6 +24,7 @@ var (
 )
 
 func init() {
+	build.LogVersionInfo()
 	port, confPath, sg = internal.InitAPI(defaultPort, defaultConfigPath)
 }
 
@@ -37,7 +39,10 @@ func main() {
 	engine.GET("/", api.GetRoot)
 	engine.GET("/status", func(c *gin.Context) {
 		ginutils.RenderSuccess(c, map[string]interface{}{
-			"status": true,
+			"status":  true,
+			"version": build.Version,
+			"build":   build.Build,
+			"date":    build.Date,
 		})
 	})
 


### PR DESCRIPTION
# Headline

Add version control with `ldflags`

## Issue

Now we don't have good version control for binaries

## Changes

- Add parameters to `ldflags`
- Add version print inside binary initialization
- Add binary version inside the status API

## How to test

- run: `make compile`
- run: `bin/platform_api/platform_api platform_api`
- access: http://localhost:8420/status

<img width="1351" alt="Screen Shot 2020-02-19 at 23 39 43" src="https://user-images.githubusercontent.com/2406457/74895873-91c15d80-5371-11ea-90e7-c7a64cfde48d.png">
<img width="333" alt="Screen Shot 2020-02-19 at 23 39 22" src="https://user-images.githubusercontent.com/2406457/74895881-96861180-5371-11ea-88b2-cb7b427f94f1.png">

closes https://github.com/trustwallet/blockatlas/issues/293