### PR TITLE
Fix collections

### DIFF
--- a/pkg/tests/postman/Blockatlas.postman_collection.json
+++ b/pkg/tests/postman/Blockatlas.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "4e4d72ba-02c4-4d87-af91-ea42b6225ee4",
+		"_postman_id": "9cea8a5c-d3e5-40c1-98da-0a7a1742cf6d",
 		"name": "Blockatlas",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -1343,6 +1343,144 @@
 									],
 									"path": [
 										"v2",
+										"collectibles",
+										"categories"
+									]
+								}
+							},
+							"response": []
+						},
+						{
+							"name": "collections batch v3 ",
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "7312c9e7-5330-421a-9ca8-171101050e38",
+										"exec": [
+											""
+										],
+										"type": "text/javascript"
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "acec8baa-0ef0-4703-ab83-c555260deffa",
+										"exec": [
+											"var Ajv = require('ajv');",
+											"var ajv = new Ajv({logger: console});",
+											"let schema = {",
+											"  \"type\": \"object\",",
+											"  \"properties\": {",
+											"    \"total\": {",
+											"      \"type\": \"integer\"",
+											"    },",
+											"    \"docs\": {",
+											"      \"type\": \"array\",",
+											"      \"minItems\": 1,",
+											"      \"uniqueItems\": true,",
+											"      \"items\": {",
+											"        \"type\": \"object\",",
+											"        \"properties\": {",
+											"          \"id\": {",
+											"            \"type\": \"string\"",
+											"          },",
+											"          \"name\": {",
+											"            \"type\": \"string\"",
+											"          },",
+											"          \"symbol\": {",
+											"            \"type\": \"string\"",
+											"          },",
+											"          \"slug\": {",
+											"            \"type\": \"string\"",
+											"          },",
+											"          \"image_url\": {",
+											"            \"type\": \"string\"",
+											"          },",
+											"          \"external_link\": {",
+											"            \"type\": \"string\"",
+											"          },",
+											"          \"total\": {",
+											"            \"type\": \"integer\"",
+											"          },",
+											"          \"category_address\": {",
+											"            \"type\": \"string\"",
+											"          },",
+											"          \"address\": {",
+											"            \"type\": \"string\"",
+											"          },",
+											"          \"nft_version\": {",
+											"            \"type\": \"string\"",
+											"          },",
+											"          \"coin\": {",
+											"            \"type\": \"integer\"",
+											"          },",
+											"          \"type\": {",
+											"            \"type\": \"string\"",
+											"          }",
+											"        }",
+											"      }",
+											"    },",
+											"    \"status\": {",
+											"      \"type\": \"boolean\"",
+											"    }",
+											"  }",
+											"};",
+											"",
+											"let handler = pm.variables.get(\"handler\");",
+											"let address = pm.variables.get(\"address\");",
+											"var jsonData = pm.response.json();",
+											"",
+											"pm.test(handler + \" - response must be valid and have a body: \" + address, function () {",
+											"    pm.response.to.have.status(200);",
+											"    pm.response.to.be.ok;",
+											"    pm.response.to.not.be.error;",
+											"    pm.response.to.be.withBody;",
+											"    pm.response.to.be.json;",
+											"});",
+											"",
+											"pm.test(handler + \" - schema is valid: \" + address, function() {",
+											"    pm.expect(ajv.validate(schema, jsonData)).to.be.true;",
+											"    console.log(JSON.stringify(jsonData))",
+											"});",
+											""
+										],
+										"type": "text/javascript"
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "Bearer {{platform_auth}}",
+										"type": "text"
+									},
+									{
+										"key": "Content-Type",
+										"name": "Content-Type",
+										"value": "application/json",
+										"type": "text"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n\t\"{{coin}}\": [\"{{address}}\"]\n}",
+									"options": {
+										"raw": {
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{host}}/v3/collectibles/categories",
+									"host": [
+										"{{host}}"
+									],
+									"path": [
+										"v3",
 										"collectibles",
 										"categories"
 									]

--- a/platform/ethereum/base.go
+++ b/platform/ethereum/base.go
@@ -12,19 +12,15 @@ type Platform struct {
 	collectionsClient CollectionsClient
 }
 
-func Init(coin uint, api, rpc string) *Platform {
-	return &Platform{
-		CoinIndex: coin,
-		RpcURL:    rpc,
-		client:    Client{blockatlas.InitClient(api)},
+func Init(coin uint, api, rpc, collectionApi, collectionKey string) *Platform {
+	p := Platform{
+		CoinIndex:         coin,
+		RpcURL:            rpc,
+		client:            Client{blockatlas.InitClient(api)},
+		collectionsClient: CollectionsClient{blockatlas.InitClient(collectionApi)},
 	}
-}
-
-func InitWitCollection(coin uint, api, rpc, collectionApi, collectionKey string) *Platform {
-	p := Init(coin, api, rpc)
-	p.collectionsClient = CollectionsClient{blockatlas.InitClient(collectionApi)}
 	p.collectionsClient.Headers["X-API-KEY"] = collectionKey
-	return p
+	return &p
 }
 
 func (p *Platform) Coin() coin.Coin {

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -31,6 +31,8 @@ import (
 	"github.com/trustwallet/blockatlas/platform/zilliqa"
 )
 
+const emptyParam = ""
+
 func GetVar(name string) string {
 	return viper.GetString(name)
 }
@@ -85,13 +87,13 @@ func getPlatformMap() blockatlas.Platforms {
 		coin.Dash().Handle:         bitcoin.Init(coin.DASH, GetApiVar(coin.DASH)),
 		coin.Doge().Handle:         bitcoin.Init(coin.DOGE, GetApiVar(coin.DOGE)),
 		coin.Qtum().Handle:         bitcoin.Init(coin.QTUM, GetApiVar(coin.QTUM)),
-		coin.Gochain().Handle:      ethereum.Init(coin.GO, GetApiVar(coin.GO), GetRpcVar(coin.GO)),
-		coin.Thundertoken().Handle: ethereum.Init(coin.TT, GetApiVar(coin.TT), GetRpcVar(coin.TT)),
-		coin.Classic().Handle:      ethereum.Init(coin.ETC, GetApiVar(coin.ETC), GetRpcVar(coin.ETC)),
-		coin.Poa().Handle:          ethereum.Init(coin.POA, GetApiVar(coin.POA), GetRpcVar(coin.POA)),
-		coin.Callisto().Handle:     ethereum.Init(coin.CLO, GetApiVar(coin.CLO), GetRpcVar(coin.CLO)),
-		coin.Wanchain().Handle:     ethereum.Init(coin.WAN, GetApiVar(coin.WAN), GetRpcVar(coin.WAN)),
-		coin.Tomochain().Handle:    ethereum.Init(coin.TOMO, GetApiVar(coin.TOMO), GetRpcVar(coin.TOMO)),
-		coin.Ethereum().Handle:     ethereum.InitWitCollection(coin.ETH, GetApiVar(coin.ETH), GetRpcVar(coin.ETH), GetVar("ethereum.collections_api"), GetVar("ethereum.collections_api_key")),
+		coin.Gochain().Handle:      ethereum.Init(coin.GO, GetApiVar(coin.GO), GetRpcVar(coin.GO), emptyParam, emptyParam),
+		coin.Thundertoken().Handle: ethereum.Init(coin.TT, GetApiVar(coin.TT), GetRpcVar(coin.TT), emptyParam, emptyParam),
+		coin.Classic().Handle:      ethereum.Init(coin.ETC, GetApiVar(coin.ETC), GetRpcVar(coin.ETC), emptyParam, emptyParam),
+		coin.Poa().Handle:          ethereum.Init(coin.POA, GetApiVar(coin.POA), GetRpcVar(coin.POA), emptyParam, emptyParam),
+		coin.Callisto().Handle:     ethereum.Init(coin.CLO, GetApiVar(coin.CLO), GetRpcVar(coin.CLO), emptyParam, emptyParam),
+		coin.Wanchain().Handle:     ethereum.Init(coin.WAN, GetApiVar(coin.WAN), GetRpcVar(coin.WAN), emptyParam, emptyParam),
+		coin.Tomochain().Handle:    ethereum.Init(coin.TOMO, GetApiVar(coin.TOMO), GetRpcVar(coin.TOMO), emptyParam, emptyParam),
+		coin.Ethereum().Handle:     ethereum.Init(coin.ETH, GetApiVar(coin.ETH), GetRpcVar(coin.ETH), GetVar("ethereum.collections_api"), GetVar("ethereum.collections_api_key")),
 	}
 }


### PR DESCRIPTION
Fix an issue with an empty http client during v3/collections fetch.
The main problem was because the Init function must initialize collections api for all ETH coins. 
It is important to rewrite the logic of collections api, so there will be only suitable for collections tokens (ETH only for now) 