### PR TITLE
XRP: Query min needed trx in desc order

### DIFF
--- a/platform/ripple/client.go
+++ b/platform/ripple/client.go
@@ -13,8 +13,8 @@ type Client struct {
 func (c *Client) GetTxsOfAddress(address string) ([]Tx, error) {
 	query := url.Values{
 		"type":       {"Payment"},
-		"descending": {"false"},
-		"limit":      {"200"},
+		"descending": {"true"},
+		"limit":      {"25"},
 	}
 	uri := fmt.Sprintf("accounts/%s/transactions", url.PathEscape(address))
 


### PR DESCRIPTION
Tested locally, now it returns `Payment` transaction in correct order and limit query
Close https://github.com/trustwallet/blockatlas/issues/933
https://bithomp.com/explorer/rBaWjyDai2jqdF1aKuMKmSb7uwSfvBPVja for history reference
http://localhost:8420/v1/:platform/:address
```
{
    "total": 25,
    "docs": [
        {
            "id": "89DD58BF8DF44AF0CD6F64DEC19AF17EA1C5BFC3665A8AA74DD04E485F7E1EB3",
            "coin": 144,
            "from": "rJb5KsHsDHF1YS5B5DU6QCkH5NsPaKQTcy",
            "to": "rBaWjyDai2jqdF1aKuMKmSb7uwSfvBPVja",
            "fee": "100000",
            "date": 1582841411,
            "block": 53732801,
            "status": "completed",
            "type": "transfer",
            "direction": "incoming",
            "memo": "",
            "metadata": {
                "value": "19750000",
                "symbol": "XRP",
                "decimals": 6
            }
        },
        {
            "id": "53A6589E304887D766103D0738D092836490464B51FE82D43C06C41D79D7CE44",
            "coin": 144,
            "from": "rMdG3ju8pgyVh29ELPWaDuA74CpWW6Fxns",
            "to": "rBaWjyDai2jqdF1aKuMKmSb7uwSfvBPVja",
            "fee": "100",
            "date": 1582774542,
            "block": 53715361,
            "status": "completed",
            "type": "transfer",
            "direction": "incoming",
            "memo": "",
            "metadata": {
                "value": "1673900000",
                "symbol": "XRP",
                "decimals": 6
            }
        },
        {
            "id": "3750322B020C91EA704F46E548E73E4F69714C4756B7A66C580823CF515F590E",
            "coin": 144,
            "from": "rMdG3ju8pgyVh29ELPWaDuA74CpWW6Fxns",
            "to": "rBaWjyDai2jqdF1aKuMKmSb7uwSfvBPVja",
            "fee": "100000",
            "date": 1582076570,
            "block": 53529640,
            "status": "completed",
            "type": "transfer",
            "direction": "incoming",
            "memo": "",
            "metadata": {
                "value": "3536900000",
                "symbol": "XRP",
                "decimals": 6
            }
        },
        {
            "id": "B2BCCAE32CEB0BE51E7DFB3E589EDA5984E47D32DA4AB6CE3BDDC2D2E5293AF8",
            "coin": 144,
            "from": "rBaWjyDai2jqdF1aKuMKmSb7uwSfvBPVja",
            "to": "rLksQ61jBrF6DgVQzMi5qEygA4LD8ePBUq",
            "fee": "5000",
            "date": 1582033150,
            "block": 53518295,
            "status": "completed",
            "type": "transfer",
            "direction": "outgoing",
            "memo": "",
            "metadata": {
                "value": "36000000",
                "symbol": "XRP",
                "decimals": 6
            }
        },
        {
            "id": "F635720920696A399DC32334857EB6D7C456CEE36E439103EEC8A588A634E492",
            "coin": 144,
            "from": "ra7bacPZ9SzAH5iaxqBf898eE9rFwjKFRj",
            "to": "rBaWjyDai2jqdF1aKuMKmSb7uwSfvBPVja",
            "fee": "12",
            "date": 1581785292,
            "block": 53452458,
            "status": "completed",
            "type": "transfer",
            "direction": "incoming",
            "memo": "",
            "metadata": {
                "value": "264",
                "symbol": "XRP",
                "decimals": 6
            }
        },
        {
            "id": "0513C66549312A38B38E1042B4EE6DCFADC3270B07A55B20E3749F35436E70DF",
            "coin": 144,
            "from": "rMdG3ju8pgyVh29ELPWaDuA74CpWW6Fxns",
            "to": "rBaWjyDai2jqdF1aKuMKmSb7uwSfvBPVja",
            "fee": "100000",
            "date": 1581423371,
            "block": 53357119,
            "status": "completed",
            "type": "transfer",
            "direction": "incoming",
            "memo": "",
            "metadata": {
                "value": "6096900000",
                "symbol": "XRP",
                "decimals": 6
            }
        },
        {
            "id": "9C317E655AB63F5A045CCFB51EC29A16BAFFF6C817EB4A3B262FAAD3A57098D6",
            "coin": 144,
            "from": "rHz4qQuVKPoR6QiWg5cCzkdt5eESEjA3vj",
            "to": "rBaWjyDai2jqdF1aKuMKmSb7uwSfvBPVja",
            "fee": "12",
            "date": 1581037521,
            "block": 53257588,
            "status": "completed",
            "type": "transfer",
            "direction": "incoming",
            "memo": "",
            "metadata": {
                "value": "166",
                "symbol": "XRP",
                "decimals": 6
            }
        },
        {
            "id": "DED6C2B5FF0B3D011347E9FCB5C132675763BC9267F4103EB576D3D1BBE9E1CE",
            "coin": 144,
            "from": "rBaWjyDai2jqdF1aKuMKmSb7uwSfvBPVja",
            "to": "rLksQ61jBrF6DgVQzMi5qEygA4LD8ePBUq",
            "fee": "5000",
            "date": 1580828900,
            "block": 53203901,
            "status": "completed",
            "type": "transfer",
            "direction": "outgoing",
            "memo": "",
            "metadata": {
                "value": "39000000",
                "symbol": "XRP",
                "decimals": 6
            }
        },
        {
            "id": "3A1CF879DECA9B935DE09F1B4AFDB66BC421D6E49EBD9DBA620FC7E1921C2A16",
            "coin": 144,
            "from": "rMdG3ju8pgyVh29ELPWaDuA74CpWW6Fxns",
            "to": "rBaWjyDai2jqdF1aKuMKmSb7uwSfvBPVja",
            "fee": "100000",
            "date": 1580790391,
            "block": 53194059,
            "status": "completed",
            "type": "transfer",
            "direction": "incoming",
            "memo": "",
            "metadata": {
                "value": "5238800000",
                "symbol": "XRP",
                "decimals": 6
            }
        },
        {
            "id": "B4E60E19B09239122A68CA4317DA18E81D484743631E5C9FAA814FB83D110999",
            "coin": 144,
            "from": "rBaWjyDai2jqdF1aKuMKmSb7uwSfvBPVja",
            "to": "rLksQ61jBrF6DgVQzMi5qEygA4LD8ePBUq",
            "fee": "10420",
            "date": 1580577330,
            "block": 53138722,
            "status": "completed",
            "type": "transfer",
            "direction": "outgoing",
            "memo": "",
            "metadata": {
                "value": "42000000",
                "symbol": "XRP",
                "decimals": 6
            }
        },
        {
            "id": "616E5097E01926B86D5DD355AF9F2AB49B3B9E4BA121D17EBC7EDD72AC3F490D",
            "coin": 144,
            "from": "rMdG3ju8pgyVh29ELPWaDuA74CpWW6Fxns",
            "to": "rBaWjyDai2jqdF1aKuMKmSb7uwSfvBPVja",
            "fee": "100000",
            "date": 1580563181,
            "block": 53135037,
            "status": "completed",
            "type": "transfer",
            "direction": "incoming",
            "memo": "",
            "metadata": {
                "value": "5000000000",
                "symbol": "XRP",
                "decimals": 6
            }
        },
        {
            "id": "42E900C8EB3FA6B8BACBE9D6A73016787DC2D808F8DCD3B4BCF3C407CE2EDED1",
            "coin": 144,
            "from": "rBaWjyDai2jqdF1aKuMKmSb7uwSfvBPVja",
            "to": "raLPjTYeGezfdb6crXZzcC8RkLBEwbBHJ5",
            "fee": "5000",
            "date": 1579506531,
            "block": 52860367,
            "status": "completed",
            "type": "transfer",
            "direction": "outgoing",
            "memo": "18135902",
            "metadata": {
                "value": "50000000",
                "symbol": "XRP",
                "decimals": 6
            }
        },
        {
            "id": "AE518F55267A1F12D3B6F3E30B9F9509B85BDB2E3EC141D833BB1D56813A1CB2",
            "coin": 144,
            "from": "rBaWjyDai2jqdF1aKuMKmSb7uwSfvBPVja",
            "to": "rLksQ61jBrF6DgVQzMi5qEygA4LD8ePBUq",
            "fee": "5000",
            "date": 1578496362,
            "block": 52599846,
            "status": "completed",
            "type": "transfer",
            "direction": "outgoing",
            "memo": "",
            "metadata": {
                "value": "47000000",
                "symbol": "XRP",
                "decimals": 6
            }
        },
        {
            "id": "1C9349D77F180E55B5F581A9FFA6FB0ABC35F8C3DC2DBAE8186365B87B4DDDEC",
            "coin": 144,
            "from": "rBaWjyDai2jqdF1aKuMKmSb7uwSfvBPVja",
            "to": "rLksQ61jBrF6DgVQzMi5qEygA4LD8ePBUq",
            "fee": "5000",
            "date": 1578484122,
            "block": 52596713,
            "status": "completed",
            "type": "transfer",
            "direction": "outgoing",
            "memo": "",
            "metadata": {
                "value": "47000000",
                "symbol": "XRP",
                "decimals": 6
            }
        },
        {
            "id": "F2A1E631EF46F5D37FFD1D60E847E75B29453E5523B5FB3EA8CA4C5A6C8033D3",
            "coin": 144,
            "from": "rBaWjyDai2jqdF1aKuMKmSb7uwSfvBPVja",
            "to": "rLksQ61jBrF6DgVQzMi5qEygA4LD8ePBUq",
            "fee": "5000",
            "date": 1577232432,
            "block": 52277035,
            "status": "completed",
            "type": "transfer",
            "direction": "outgoing",
            "memo": "",
            "metadata": {
                "value": "100000000",
                "symbol": "XRP",
                "decimals": 6
            }
        },
        {
            "id": "3B3BF8B4B37EC1C8B03D151D2C949246965EA4B273B3BA1070EE78D38FF437A0",
            "coin": 144,
            "from": "rBaWjyDai2jqdF1aKuMKmSb7uwSfvBPVja",
            "to": "rGbMZtC2PjakWM4TBexfRVUZpUZfDydK1n",
            "fee": "5000",
            "date": 1577232400,
            "block": 52277026,
            "status": "completed",
            "type": "transfer",
            "direction": "outgoing",
            "memo": "",
            "metadata": {
                "value": "100000000",
                "symbol": "XRP",
                "decimals": 6
            }
        },
        {
            "id": "0954DA617DB2CD48C477AECE8FD3370A4CF403C8ABFDA89B41AD87C24BA55275",
            "coin": 144,
            "from": "rBaWjyDai2jqdF1aKuMKmSb7uwSfvBPVja",
            "to": "rLksQ61jBrF6DgVQzMi5qEygA4LD8ePBUq",
            "fee": "10144",
            "date": 1577110010,
            "block": 52245970,
            "status": "completed",
            "type": "transfer",
            "direction": "outgoing",
            "memo": "",
            "metadata": {
                "value": "52000000",
                "symbol": "XRP",
                "decimals": 6
            }
        },
        {
            "id": "0ABC5C4F5571471CC62DE3729095B2C47D7E5BAF38E16455138E75282CBA6148",
            "coin": 144,
            "from": "rBaWjyDai2jqdF1aKuMKmSb7uwSfvBPVja",
            "to": "rLksQ61jBrF6DgVQzMi5qEygA4LD8ePBUq",
            "fee": "5000",
            "date": 1576856380,
            "block": 52181222,
            "status": "completed",
            "type": "transfer",
            "direction": "outgoing",
            "memo": "",
            "metadata": {
                "value": "52000000",
                "symbol": "XRP",
                "decimals": 6
            }
        },
        {
            "id": "2CD6F93DA24FD94682E208BE139CBF406547FE2E5DAEDED50EB659C3626E3D96",
            "coin": 144,
            "from": "rBaWjyDai2jqdF1aKuMKmSb7uwSfvBPVja",
            "to": "rLksQ61jBrF6DgVQzMi5qEygA4LD8ePBUq",
            "fee": "11640",
            "date": 1575992020,
            "block": 51961641,
            "status": "completed",
            "type": "transfer",
            "direction": "outgoing",
            "memo": "",
            "metadata": {
                "value": "45000000",
                "symbol": "XRP",
                "decimals": 6
            }
        },
        {
            "id": "722F608C94D72F9F200936B832E1E0B8F280FA9971EFF44CC7DCBE1E9AFFD543",
            "coin": 144,
            "from": "rBaWjyDai2jqdF1aKuMKmSb7uwSfvBPVja",
            "to": "rLksQ61jBrF6DgVQzMi5qEygA4LD8ePBUq",
            "fee": "5000",
            "date": 1575644732,
            "block": 51873523,
            "status": "completed",
            "type": "transfer",
            "direction": "outgoing",
            "memo": "",
            "metadata": {
                "value": "20000000",
                "symbol": "XRP",
                "decimals": 6
            }
        },
        {
            "id": "8CB339658B02DC2EE78171F51D643E5B648EFD21F5F85F2CB724527B97D1003E",
            "coin": 144,
            "from": "rBaWjyDai2jqdF1aKuMKmSb7uwSfvBPVja",
            "to": "rLksQ61jBrF6DgVQzMi5qEygA4LD8ePBUq",
            "fee": "11298",
            "date": 1575644691,
            "block": 51873512,
            "status": "completed",
            "type": "transfer",
            "direction": "outgoing",
            "memo": "",
            "metadata": {
                "value": "45000000",
                "symbol": "XRP",
                "decimals": 6
            }
        },
        {
            "id": "12C082E5572178AF1FBB37DC40293040F65617AEB4C07ACA93B190A1CD9B041F",
            "coin": 144,
            "from": "rMdG3ju8pgyVh29ELPWaDuA74CpWW6Fxns",
            "to": "rBaWjyDai2jqdF1aKuMKmSb7uwSfvBPVja",
            "fee": "100000",
            "date": 1575482050,
            "block": 51832366,
            "status": "completed",
            "type": "transfer",
            "direction": "incoming",
            "memo": "",
            "metadata": {
                "value": "4194900000",
                "symbol": "XRP",
                "decimals": 6
            }
        },
        {
            "id": "0684B036F4FC4DC2CC7517AABE973DA4681B49868275DAA52EEDF6A070E3914F",
            "coin": 144,
            "from": "rBaWjyDai2jqdF1aKuMKmSb7uwSfvBPVja",
            "to": "raLPjTYeGezfdb6crXZzcC8RkLBEwbBHJ5",
            "fee": "5000",
            "date": 1574535112,
            "block": 51594937,
            "status": "completed",
            "type": "transfer",
            "direction": "outgoing",
            "memo": "18200785",
            "metadata": {
                "value": "99999995000",
                "symbol": "XRP",
                "decimals": 6
            }
        },
        {
            "id": "326831DF7DFBE138A89A0A0DF5DFBA2005C4247822F0F296A46F2A5DC8CAAF71",
            "coin": 144,
            "from": "raLPjTYeGezfdb6crXZzcC8RkLBEwbBHJ5",
            "to": "rBaWjyDai2jqdF1aKuMKmSb7uwSfvBPVja",
            "fee": "10000",
            "date": 1573709430,
            "block": 51384180,
            "status": "completed",
            "type": "transfer",
            "direction": "incoming",
            "memo": "",
            "metadata": {
                "value": "50000000000",
                "symbol": "XRP",
                "decimals": 6
            }
        },
        {
            "id": "C94DA84FC57D2A4E7FC234B4E0F532BB4367E6364C5E03C80F245462F5FA245E",
            "coin": 144,
            "from": "raLPjTYeGezfdb6crXZzcC8RkLBEwbBHJ5",
            "to": "rBaWjyDai2jqdF1aKuMKmSb7uwSfvBPVja",
            "fee": "10000",
            "date": 1573617802,
            "block": 51360690,
            "status": "completed",
            "type": "transfer",
            "direction": "incoming",
            "memo": "",
            "metadata": {
                "value": "50000000000",
                "symbol": "XRP",
                "decimals": 6
            }
        }
    ],
    "status": true
}
```