### PR TITLE
Fix missing transactions

### DIFF
--- a/platform/cosmos/client.go
+++ b/platform/cosmos/client.go
@@ -15,10 +15,10 @@ type Client struct {
 }
 
 // GetAddrTxs - get all ATOM transactions for a given address
-func (c *Client) GetAddrTxs(address string, tag string) (txs TxPage, err error) {
+func (c *Client) GetAddrTxs(address, tag string, page int) (txs TxPage, err error) {
 	query := url.Values{
 		tag:     {address},
-		"page":  {"1"},
+		"page":  {strconv.Itoa(page)},
 		"limit": {"25"},
 	}
 	err = c.Get(&txs, "txs", query)

--- a/platform/cosmos/model.go
+++ b/platform/cosmos/model.go
@@ -48,7 +48,8 @@ type Tx struct {
 }
 
 type TxPage struct {
-	Txs []Tx `json:"txs"`
+	PageTotal  string `json:"page_total"`
+	Txs        []Tx   `json:"txs"`
 }
 
 // Events


### PR DESCRIPTION
Fixes https://github.com/trustwallet/blockatlas/issues/866

Cosmos's gain client https://github.com/cosmos/gaia/blob/f61b391aee5d04364d2b5539692bbb187ad9b946/docs/resources/gaiacli.md#query-transactions support only pagination to get latest transactions.
PR adds logic to get latest transaction per each tag.

`How to test`
http://localhost:8420/v1/cosmos/cosmos135qla4294zxarqhhgxsx0sw56yssa3z0f78pm0
Compare with explorer
https://www.mintscan.io/account/cosmos135qla4294zxarqhhgxsx0sw56yssa3z0f78pm0
