### PR TITLE
Change GetTxsOfAddress() ripple client function

### DIFF
--- a/platform/ripple/client.go
+++ b/platform/ripple/client.go
@@ -18,10 +18,11 @@ func (c *Client) GetTxsOfAddress(address string) ([]Tx, error) {
 
 	if res.Result == "error" {
 		res, err = c.fetchTransactions(address, "false")
+		if err != nil {
+			return nil, err
+		}
 	}
-	if err != nil {
-		return nil, err
-	}
+
 	return res.Transactions, nil
 }
 

--- a/platform/ripple/client.go
+++ b/platform/ripple/client.go
@@ -11,9 +11,24 @@ type Client struct {
 }
 
 func (c *Client) GetTxsOfAddress(address string) ([]Tx, error) {
+	res, err := c.fetchTransactions(address, "true")
+	if err != nil {
+		return nil, err
+	}
+
+	if res.Result == "error" {
+		res, err = c.fetchTransactions(address, "false")
+	}
+	if err != nil {
+		return nil, err
+	}
+	return res.Transactions, nil
+}
+
+func (c *Client) fetchTransactions(address, descending string) (Response, error) {
 	query := url.Values{
 		"type":       {"Payment"},
-		"descending": {"true"},
+		"descending": {descending},
 		"limit":      {"25"},
 	}
 	uri := fmt.Sprintf("accounts/%s/transactions", url.PathEscape(address))
@@ -21,9 +36,9 @@ func (c *Client) GetTxsOfAddress(address string) ([]Tx, error) {
 	var res Response
 	err := c.Get(&res, uri, query)
 	if err != nil {
-		return nil, err
+		return Response{}, err
 	}
-	return res.Transactions, nil
+	return res, nil
 }
 
 func (c *Client) GetCurrentBlock() (int64, error) {


### PR DESCRIPTION
There were cases when GetTxsOfAddress was failing with descending == true. If so, we will try to fetch transactions with  descending == false again to return at least some transactions to user