### PR TITLE
Remove request only_confirmed transactions

### DIFF
--- a/platform/tron/client.go
+++ b/platform/tron/client.go
@@ -31,8 +31,7 @@ func (c *Client) GetTxsOfAddress(address, token string) ([]Tx, error) {
 
 	var txs Page
 	err := c.Get(&txs, path, url.Values{
-		"only_confirmed": {"true"},
-		"limit":          {"200"},
+		"limit":          {"25"},
 		"token_id":       {token},
 		"order_by":       {"block_timestamp,desc"},
 	})


### PR DESCRIPTION
User reported missing token transfer:

All indicates that transaction is confirmed https://tronscan.org/#/transaction/49730f9593bb38402084b568b3217dfd97d2e42ab51c1d5ccedd970bbb758be4 and
```
curl --location --request POST 'https://api.trongrid.io/wallet/gettransactionbyid' \
--header 'Content-Type: application/json' \
--data-raw '{
	"value": "49730f9593bb38402084b568b3217dfd97d2e42ab51c1d5ccedd970bbb758be4"
}'
```
but missing in request we do https://api.trongrid.io/v1/accounts/:address/transactions?limit=25&only_confirmed=true&token_id=1002000&order_by=block_timestamp,desc

Remove request only confirmed transactions and decrease transactions limit to return

How to test:
 `go build -o platform-api-bin cmd/platform_api/main.go  && ./platform-api-bin -p 8420 -c config.yml`
`http://localhost:8420/v1/tron/TCh3vEZ5jsUkaGD12ZixTTcgtkB3aQ7yG4?token=1002000`

Reported to Tron team