### PR TITLE
[Observer-Parser] Change tracker model to handle, not ID of coin

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -16,3 +16,4 @@ coverage:
     - "services"
     - "scripts"
     - "docs"
+    - "db/models"

--- a/db/models/tracker.go
+++ b/db/models/tracker.go
@@ -1,6 +1,6 @@
 package models
 
 type Tracker struct {
-	Coin   string `gorm:"primary_key:true;"`
+	Coin   string `gorm:"primary_key:true; type:varchar(64)"`
 	Height int64
 }

--- a/db/models/tracker.go
+++ b/db/models/tracker.go
@@ -1,6 +1,6 @@
 package models
 
 type Tracker struct {
-	Coin   uint `gorm:"primary_key:true; auto_increment:false"`
+	Coin   string `gorm:"primary_key:true;"`
 	Height int64
 }

--- a/db/tracker.go
+++ b/db/tracker.go
@@ -8,28 +8,28 @@ import (
 var memoryCache heightBlockMap
 
 func init() {
-	memoryCache.m = make(map[uint]int64)
+	memoryCache.m = make(map[string]int64)
 }
 
 type heightBlockMap struct {
-	m map[uint]int64
+	m map[string]int64
 	sync.RWMutex
 }
 
-func (hbm *heightBlockMap) SetHeight(coin uint, b int64) {
+func (hbm *heightBlockMap) SetHeight(coin string, b int64) {
 	hbm.Lock()
 	defer hbm.Unlock()
 	hbm.m[coin] = b
 }
 
-func (hbm *heightBlockMap) GetHeight(coin uint) (int64, bool) {
+func (hbm *heightBlockMap) GetHeight(coin string) (int64, bool) {
 	hbm.RLock()
 	defer hbm.RUnlock()
 	b, ok := hbm.m[coin]
 	return b, ok
 }
 
-func (i *Instance) GetLastParsedBlockNumber(coin uint) (int64, error) {
+func (i *Instance) GetLastParsedBlockNumber(coin string) (int64, error) {
 	height, ok := memoryCache.GetHeight(coin)
 	if ok {
 		return height, nil
@@ -41,7 +41,7 @@ func (i *Instance) GetLastParsedBlockNumber(coin uint) (int64, error) {
 	return tracker.Height, nil
 }
 
-func (i *Instance) SetLastParsedBlockNumber(coin uint, num int64) error {
+func (i *Instance) SetLastParsedBlockNumber(coin string, num int64) error {
 	memoryCache.SetHeight(coin, num)
 	tracker := models.Tracker{
 		Coin:   coin,

--- a/db/tracker_test.go
+++ b/db/tracker_test.go
@@ -1,0 +1,64 @@
+package db
+
+import (
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/jinzhu/gorm"
+	"github.com/stretchr/testify/assert"
+	"regexp"
+	"testing"
+)
+
+func TestHeightBlockMap_SetHeight(t *testing.T) {
+	db, mock := setupDB(t)
+	defer db.Close()
+	mock.ExpectBegin()
+	mock.ExpectQuery(
+		regexp.QuoteMeta(
+			`INSERT INTO "trackers" ("coin","height") VALUES ($1,$2) ON CONFLICT (coin) DO UPDATE SET height = excluded.height RETURNING "trackers"."coin"`)).WithArgs("bitcoin", 1).WillReturnRows(sqlmock.NewRows([]string{"id"}).
+		AddRow("id"))
+	mock.ExpectCommit()
+	i := Instance{Gorm: db}
+
+	assert.Nil(t, i.SetLastParsedBlockNumber("bitcoin", 1))
+}
+
+func TestHeightBlockMap_GetHeight(t *testing.T) {
+	db, mock := setupDB(t)
+	defer db.Close()
+	mock.ExpectBegin()
+	mock.ExpectQuery(
+		regexp.QuoteMeta(
+			`INSERT INTO "trackers" ("coin","height") VALUES ($1,$2) ON CONFLICT (coin) DO UPDATE SET height = excluded.height RETURNING "trackers"."coin"`)).WithArgs("bitcoin", 1).WillReturnRows(sqlmock.NewRows([]string{"id"}).
+		AddRow("id"))
+	mock.ExpectCommit()
+	i := Instance{Gorm: db}
+
+	assert.Nil(t, i.SetLastParsedBlockNumber("bitcoin", 1))
+	block, err := i.GetLastParsedBlockNumber("bitcoin")
+	assert.Nil(t, err)
+	assert.Equal(t, int64(1), block)
+
+	mock.ExpectQuery(
+		regexp.QuoteMeta(
+			`SELECT * FROM "trackers"  WHERE ("trackers"."coin" = $1`)).WithArgs("ethereum").WillReturnRows(sqlmock.NewRows([]string{"coin", "height"}).
+		AddRow("ethereum", 1))
+
+	b, err := i.GetLastParsedBlockNumber("ethereum")
+	assert.Nil(t, err)
+	assert.Equal(t, int64(1), b)
+
+}
+
+func setupDB(t *testing.T) (*gorm.DB, sqlmock.Sqlmock) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when sqlmock", err)
+	}
+
+	d, err := gorm.Open("postgres", db)
+	if err != nil {
+		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
+	}
+	d.LogMode(true)
+	return d, mock
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/trustwallet/blockatlas
 go 1.14
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.4.1
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
 	github.com/btcsuite/btcutil v1.0.1
 	github.com/chenjiandongx/ginprom v0.0.0-20200410120253-7cfb22707fa6

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/CloudyKit/fastprinter v0.0.0-20170127035650-74b38d55f37a h1:3SgJcK9l5
 github.com/CloudyKit/fastprinter v0.0.0-20170127035650-74b38d55f37a/go.mod h1:EFZQ978U7x8IRnstaskI3IysnWY5Ao3QgZUKOXlsAdw=
 github.com/CloudyKit/jet v2.1.3-0.20180809161101-62edd43e4f88+incompatible h1:rZgFj+Gtf3NMi/U5FvCvhzaxzW/TaPYgUYx3bAPz9DE=
 github.com/CloudyKit/jet v2.1.3-0.20180809161101-62edd43e4f88+incompatible/go.mod h1:HPYO+50pSWkPoj9Q/eq0aRGByCL6ScRlUmiEX5Zgm+w=
+github.com/DATA-DOG/go-sqlmock v1.4.1 h1:ThlnYciV1iM/V0OSF/dtkqWb6xo5qITT1TJBG1MRDJM=
+github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/Joker/hpp v1.0.0 h1:65+iuJYdRXv/XyN62C1uEmmOx3432rNG/rKlX6V7Kkc=
 github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKzY=
 github.com/Joker/jade v1.0.1-0.20190614124447-d475f43051e7 h1:mreN1m/5VJ/Zc3b4pzj9qU6D9SRQ6Vm+3KfI328t3S8=
@@ -184,8 +186,6 @@ github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.3 h1:gyjaxf+svBWX08ZjK86iN9geUJF0H6gp2IRKX6Nf6/I=
 github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
-github.com/golang/protobuf v1.3.5 h1:F768QJ1E9tib+q5Sc8MkdJi1RxLTbRcTf8LJV56aRls=
-github.com/golang/protobuf v1.3.5/go.mod h1:6O5/vntMXwX2lRkT1hjjk0nAC1IDOTvTlVgjlRvqsdk=
 github.com/gomodule/redigo v1.7.1-0.20190724094224-574c33c3df38/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
 github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -263,13 +263,9 @@ github.com/klauspost/compress v1.9.0/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0
 github.com/klauspost/cpuid v1.2.1/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
-github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=
-github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
-github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
-github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
@@ -374,9 +370,8 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084 h1:sofwID9zm4tzrgykg80hfFph1mryUeLRsUfoocVVmRY=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
+github.com/prometheus/procfs v0.0.8 h1:+fpWZdT24pJBiqJdAwYBjPSk+5YmQzYNPYzQsdzLkt8=
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
-github.com/prometheus/procfs v0.0.11 h1:DhHlBtkHWPYi8O2y31JkK0TF+DGM+51OopZjH/Ia5qI=
-github.com/prometheus/procfs v0.0.11/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
@@ -543,13 +538,10 @@ golang.org/x/sys v0.0.0-20190610200419-93c9922d18ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200409092240-59c9f1ba88fa h1:mQTN3ECqfsViCNBgq+A40vdwhkGykrrQlYe3mPj6BoU=
-golang.org/x/sys v0.0.0-20200409092240-59c9f1ba88fa/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/services/observer/parser/parser.go
+++ b/services/observer/parser/parser.go
@@ -79,7 +79,7 @@ func RunParser(params Params) {
 }
 
 func GetBlocksIntervalToFetch(params Params) (int64, int64, error) {
-	lastParsedBlock, err := params.Database.GetLastParsedBlockNumber(params.Api.Coin().ID)
+	lastParsedBlock, err := params.Database.GetLastParsedBlockNumber(params.Api.Coin().Handle)
 	if err != nil {
 		return 0, 0, errors.E(err, "Polling failed: tracker didn't return last known block number")
 	}
@@ -178,7 +178,7 @@ func SaveLastParsedBlock(params Params, blocks []blockatlas.Block) error {
 	if lastBlockNumber <= 0 {
 		return errors.E(fmt.Sprintf("Parser of %s failed to save last block, lastBlockNumber <= 0", params.Api.Coin().Handle))
 	}
-	err := params.Database.SetLastParsedBlockNumber(params.Api.Coin().ID, lastBlockNumber)
+	err := params.Database.SetLastParsedBlockNumber(params.Api.Coin().Handle, lastBlockNumber)
 	if err != nil {
 		return err
 	}

--- a/tests/integration/db_test/tracker_test.go
+++ b/tests/integration/db_test/tracker_test.go
@@ -11,15 +11,15 @@ import (
 func TestDb_SetBlock(t *testing.T) {
 	setup.CleanupPgContainer(database.Gorm)
 
-	assert.Nil(t, database.SetLastParsedBlockNumber(60, 0))
+	assert.Nil(t, database.SetLastParsedBlockNumber("ethereum", 0))
 
-	block, err := database.GetLastParsedBlockNumber(60)
+	block, err := database.GetLastParsedBlockNumber("ethereum")
 	assert.Nil(t, err)
 	assert.Equal(t, block, int64(0))
 
-	assert.Nil(t, database.SetLastParsedBlockNumber(60, 110))
+	assert.Nil(t, database.SetLastParsedBlockNumber("ethereum", 110))
 
-	newBlock, err := database.GetLastParsedBlockNumber(60)
+	newBlock, err := database.GetLastParsedBlockNumber("ethereum")
 	assert.Nil(t, err)
 	assert.Equal(t, newBlock, int64(110))
 }


### PR DESCRIPTION
Due to limitation of ID != 0 BTC was not working with DB and last parsed blocks were stored at memory cache only