### PR TITLE
Exclude mocked js from repo language statistics

### DIFF
--- a/vendor.yml
+++ b/vendor.yml
@@ -1,0 +1,3 @@
+# test data
+
+- mock/ext-api-dyson/


### PR DESCRIPTION
Although it's not vendor code, I think it's the easiest way to exclude it

From https://github.com/github/linguist#vendored-code