### PR TITLE
Filter delegations by state

### DIFF
--- a/platform/solana/model.go
+++ b/platform/solana/model.go
@@ -1,5 +1,14 @@
 package solana
 
+const (
+	StakeStateUninitialized StakeState = 0
+	StakeStateInitialized   StakeState = 1
+	StakeStateDelegated     StakeState = 2
+	StakeStateRewardsPool   StakeState = 3
+)
+
+type StakeState uint32
+
 type VoteAccount struct {
 	NodePubkey       string     `json:"nodePubkey"`
 	VotePubkey       string     `json:"votePubkey"`
@@ -38,8 +47,8 @@ type RpcContext struct {
 	Slot uint64 `json:"slot"`
 }
 
-type StakeState struct {
-	State                uint32
+type StakeData struct {
+	State                StakeState
 	RentExemptReserve    uint64
 	AuthorizedStaker     [32]byte
 	AuthorizedWithdrawer [32]byte

--- a/platform/solana/stake_test.go
+++ b/platform/solana/stake_test.go
@@ -81,7 +81,7 @@ var keyedStakeAccount = KeyedAccount{
 	Pubkey: "EgR17fgGmwQQaMZPsuJdk9oHw2xY8TJQj3Bp44o24mar",
 }
 
-var stakeState = StakeState{
+var stakeState = StakeData{
 	State:                2,
 	RentExemptReserve:    2282880,
 	AuthorizedStaker:     arrayOfPubkey("B52Da5MCyTcyVJEsR9RUnbf715YuBAJMxCEEPzyZXgvY"),
@@ -145,7 +145,7 @@ var delegation = blockatlas.DelegationsPage{
 }
 
 func TestNormalizeDelegations(t *testing.T) {
-	result, err := NormalizeDelegations([]StakeState{stakeState}, validatorMap, epochInfo)
+	result, err := NormalizeDelegations([]StakeData{stakeState}, validatorMap, epochInfo)
 	assert.NoError(t, err)
 	assert.Equal(t, delegation, result)
 }

--- a/platform/solana/stake_test.go
+++ b/platform/solana/stake_test.go
@@ -97,6 +97,38 @@ var stakeState = StakeData{
 	CreditsObserved:      21143,
 }
 
+var deactivatedStakeState = StakeData{
+	State:                2,
+	RentExemptReserve:    2282880,
+	AuthorizedStaker:     arrayOfPubkey("B52Da5MCyTcyVJEsR9RUnbf715YuBAJMxCEEPzyZXgvY"),
+	AuthorizedWithdrawer: arrayOfPubkey("B52Da5MCyTcyVJEsR9RUnbf715YuBAJMxCEEPzyZXgvY"),
+	UnixTimestamp:        0,
+	LockupEpoch:          0,
+	Custodian:            arrayOfPubkey("11111111111111111111111111111111"),
+	VoterPubkey:          arrayOfPubkey("5CgQubGD1uwodwCe5UXDADbC69SiqXR8qq6pDMSm7ut5"),
+	Stake:                99997717120,
+	ActivationEpoch:      70,
+	DeactivationEpoch:    78,
+	WarmupCooldownRate:   0.25,
+	CreditsObserved:      21143,
+}
+
+var unpublishedValidatorStakeState = StakeData{
+	State:                2,
+	RentExemptReserve:    2282880,
+	AuthorizedStaker:     arrayOfPubkey("B52Da5MCyTcyVJEsR9RUnbf715YuBAJMxCEEPzyZXgvY"),
+	AuthorizedWithdrawer: arrayOfPubkey("B52Da5MCyTcyVJEsR9RUnbf715YuBAJMxCEEPzyZXgvY"),
+	UnixTimestamp:        0,
+	LockupEpoch:          0,
+	Custodian:            arrayOfPubkey("11111111111111111111111111111111"),
+	VoterPubkey:          arrayOfPubkey("BNTmegvdXzNVyc3UMTWSMSfJUryjr3fXEVErtdqrfs6y"),
+	Stake:                99997717120,
+	ActivationEpoch:      70,
+	DeactivationEpoch:    78,
+	WarmupCooldownRate:   0.25,
+	CreditsObserved:      21143,
+}
+
 func TestParseStakeData(t *testing.T) {
 
 	result, err := parseStakeData(keyedStakeAccount.Account)
@@ -145,7 +177,8 @@ var delegation = blockatlas.DelegationsPage{
 }
 
 func TestNormalizeDelegations(t *testing.T) {
-	result, err := NormalizeDelegations([]StakeData{stakeState}, validatorMap, epochInfo)
+	stakeAccounts := []StakeData{stakeState, deactivatedStakeState, unpublishedValidatorStakeState}
+	result, err := NormalizeDelegations(stakeAccounts, validatorMap, epochInfo)
 	assert.NoError(t, err)
 	assert.Equal(t, delegation, result)
 }


### PR DESCRIPTION
On Solana, stake accounts can exist in an initialized but undelegated state. These should not be returned by GetDelegations api.
This pr also reworks the "validator not found" case to log an unpublished validator, but not error out.

With this change, endpoint `/v2/solana/staking/delegations/so1a4fRBhJojPqeqo3PAymcmzqj1FbBCaRpiSCTimuk` should return results (36 delegations)