### PR TITLE
Remove duplicate txs

### DIFF
--- a/platform/harmony/transaction.go
+++ b/platform/harmony/transaction.go
@@ -19,7 +19,8 @@ func (p *Platform) GetTxsByAddress(address string) (blockatlas.TxPage, error) {
 
 func NormalizeTxs(txs []Transaction) blockatlas.TxPage {
 	normalizeTxs := make([]blockatlas.Tx, 0)
-	for _, srcTx := range txs {
+	filteredTxs := unique(txs)
+	for _, srcTx := range filteredTxs {
 		normalized, isCorrect, err := NormalizeTx(&srcTx)
 		if !isCorrect || err != nil {
 			return []blockatlas.Tx{}
@@ -85,4 +86,17 @@ func NormalizeTx(trx *Transaction) (tx blockatlas.Tx, b bool, err error) {
 			Decimals: coin.Coins[coin.ONE].Decimals,
 		},
 	}, true, nil
+}
+
+// Remove duplicate transaction with same hash
+func unique(intSlice []Transaction) []Transaction {
+	keys := make(map[string]bool)
+	list := make([]Transaction, 0)
+	for _, entry := range intSlice {
+		if _, value := keys[entry.Hash]; !value {
+			keys[entry.Hash] = true
+			list = append(list, entry)
+		}
+	}
+	return list
 }


### PR DESCRIPTION
```js
curl --location --request POST 'https://api.s0.t.hmny.io/' \
--header 'Content-Type: application/json' \
--data-raw '{
    "jsonrpc": "2.0",
    "method": "hmy_getTransactionsHistory",
    "params": [
        {
            "address": "one1d3nel63ypa4fsk7v3mddw0a8vud85mlanpgq3k",
            "fullTx": true
        }
    ],
    "id": "hmy_getTransactionsHistory"
}'
```
returns two identical tx with the same hash `0xdd93ac393e9be328d7b47a634bf50912b7721c8631cfe1d18978c9872375e60e`