### PR TITLE
Sort Txs on api level now

### DIFF
--- a/api/endpoint/transaction.go
+++ b/api/endpoint/transaction.go
@@ -6,7 +6,6 @@ import (
 	"github.com/trustwallet/blockatlas/pkg/blockatlas"
 	"github.com/trustwallet/blockatlas/pkg/errors"
 	"net/http"
-	"sort"
 )
 
 // @Summary Get Transactions
@@ -63,16 +62,17 @@ func GetTransactionsHistory(c *gin.Context, txAPI blockatlas.TxAPI, tokenTxAPI b
 			return
 		}
 	}
-
-	page := make(blockatlas.TxPage, 0)
-	for _, tx := range txs {
+	var (
+		page        = make(blockatlas.TxPage, 0)
+		filteredTxs = blockatlas.Txs(txs).FilterUniqueID().SortByDate()
+	)
+	for _, tx := range filteredTxs {
 		tx.Direction = tx.GetTransactionDirection(address)
 		page = append(page, tx)
 	}
 	if len(page) > blockatlas.TxPerPage {
 		page = page[0:blockatlas.TxPerPage]
 	}
-	sort.Sort(&page)
 	c.JSON(http.StatusOK, &page)
 }
 
@@ -114,11 +114,13 @@ func GetTransactionsByXpub(c *gin.Context, api blockatlas.TxUtxoAPI) {
 			return
 		}
 	}
+	var (
+		filteredTxs = blockatlas.Txs(txs).FilterUniqueID().SortByDate()
+		page        = blockatlas.TxPage(filteredTxs)
+	)
 
-	page := blockatlas.TxPage(txs)
 	if len(page) > blockatlas.TxPerPage {
 		page = page[0:blockatlas.TxPerPage]
 	}
-	sort.Sort(&page)
 	c.JSON(http.StatusOK, &page)
 }

--- a/pkg/blockatlas/tx.go
+++ b/pkg/blockatlas/tx.go
@@ -4,6 +4,7 @@ import (
 	mapset "github.com/deckarep/golang-set"
 	"github.com/trustwallet/blockatlas/coin"
 	"github.com/trustwallet/blockatlas/pkg/numbers"
+	"sort"
 )
 
 const (
@@ -208,6 +209,25 @@ type (
 
 	Txs []Tx
 )
+
+func (t Txs) FilterUniqueID() Txs {
+	keys := make(map[string]bool)
+	list := make(Txs, 0)
+	for _, entry := range t {
+		if _, value := keys[entry.ID]; !value {
+			keys[entry.ID] = true
+			list = append(list, entry)
+		}
+	}
+	return list
+}
+
+func (t Txs) SortByDate() Txs {
+	sort.Slice(t, func(i, j int) bool {
+		return t[i].Date > t[j].Date
+	})
+	return t
+}
 
 func (t Txs) GetTransactionsMap() TxSetMap {
 	txSetMap := TxSetMap{Map: make(map[string]*TxSet)}

--- a/pkg/blockatlas/tx_test.go
+++ b/pkg/blockatlas/tx_test.go
@@ -4,6 +4,7 @@ import (
 	mapset "github.com/deckarep/golang-set"
 	"github.com/stretchr/testify/assert"
 	"github.com/trustwallet/blockatlas/coin"
+	"sort"
 	"testing"
 )
 
@@ -529,4 +530,96 @@ func TestTx_GetTransactionDirection(t *testing.T) {
 	tx.Direction = DirectionSelf
 	tx.Direction = tx.GetTransactionDirection("0x38d45371993eEc84f38FEDf93C646aA2D2267CEA")
 	assert.Equal(t, Direction("yourself"), tx.Direction)
+}
+
+func TestTxs_FilterUniqueID(t *testing.T) {
+	tx := Tx{
+		ID:       "0xbcd1a43e796de4035e5e2991d8db332958e36031d54cb1d3a08d2cb790e338c4",
+		Coin:     60,
+		From:     "0x08777CB1e80F45642752662B04886Df2d271E049",
+		To:       "0xdd974D5C2e2928deA5F71b9825b8b646686BD200",
+		Fee:      "52473000000000",
+		Date:     1585169424,
+		Block:    9742705,
+		Status:   "completed",
+		Sequence: 149,
+		Type:     "token_transfer",
+	}
+	tx2 := Tx{
+		ID:       "0xbcd1a43e796de4035e5e2991d8db332958e36031d54cb1d3a08d2cb790e338c4",
+		Coin:     60,
+		From:     "0x08777CB1e80F45642752662B04886Df2d271E049",
+		To:       "0xdd974D5C2e2928deA5F71b9825b8b646686BD200",
+		Fee:      "52473000000000",
+		Date:     1585169424,
+		Block:    9742705,
+		Status:   "completed",
+		Sequence: 149,
+		Type:     "token_transfer",
+	}
+
+	txs := make([]Tx, 0)
+	txs = append(txs, tx)
+	txs = append(txs, tx2)
+
+	entry := Txs(txs)
+
+	result := entry.FilterUniqueID()
+
+	assert.Equal(t, entry[:1], result)
+}
+
+func TestTxs_SortByDate(t *testing.T) {
+	tx := Tx{
+		ID:       "0xbcd1a43e796de4035e5e2991d8db332958e36031d54cb1d3a08d2cb790e338c4",
+		Coin:     60,
+		From:     "0x08777CB1e80F45642752662B04886Df2d271E049",
+		To:       "0xdd974D5C2e2928deA5F71b9825b8b646686BD200",
+		Fee:      "52473000000000",
+		Date:     1585169423,
+		Block:    9742705,
+		Status:   "completed",
+		Sequence: 149,
+		Type:     "token_transfer",
+	}
+	tx2 := Tx{
+		ID:       "0xbcd1a43e796de4035e5e2991d8db332958e36031d54cb1d3a08d2cb790e338c5",
+		Coin:     60,
+		From:     "0x08777CB1e80F45642752662B04886Df2d271E049",
+		To:       "0xdd974D5C2e2928deA5F71b9825b8b646686BD200",
+		Fee:      "52473000000000",
+		Date:     1585169424,
+		Block:    9742705,
+		Status:   "completed",
+		Sequence: 149,
+		Type:     "token_transfer",
+	}
+	tx3 := Tx{
+		ID:       "0xbcd1a43e796de4035e5e2991d8db332958e36031d54cb1d3a08d2cb790e338c6",
+		Coin:     60,
+		From:     "0x08777CB1e80F45642752662B04886Df2d271E049",
+		To:       "0xdd974D5C2e2928deA5F71b9825b8b646686BD200",
+		Fee:      "52473000000000",
+		Date:     1585169425,
+		Block:    9742705,
+		Status:   "completed",
+		Sequence: 149,
+		Type:     "token_transfer",
+	}
+
+	txs := make([]Tx, 0)
+	txs = append(txs, tx)
+	txs = append(txs, tx2)
+	txs = append(txs, tx3)
+
+	entry := Txs(txs)
+	isNotSorted := sort.SliceIsSorted(entry, func(i, j int) bool {
+		return entry[i].Date > entry[j].Date
+	})
+	assert.True(t, !isNotSorted)
+	result := entry.SortByDate()
+	isSorted := sort.SliceIsSorted(result, func(i, j int) bool {
+		return result[i].Date > result[j].Date
+	})
+	assert.True(t, isSorted)
 }

--- a/platform/harmony/transaction.go
+++ b/platform/harmony/transaction.go
@@ -5,7 +5,6 @@ import (
 	"github.com/trustwallet/blockatlas/pkg/blockatlas"
 	"github.com/trustwallet/blockatlas/pkg/errors"
 	"github.com/trustwallet/blockatlas/pkg/numbers"
-	"sort"
 	"strconv"
 )
 
@@ -19,17 +18,13 @@ func (p *Platform) GetTxsByAddress(address string) (blockatlas.TxPage, error) {
 
 func NormalizeTxs(txs []Transaction) blockatlas.TxPage {
 	normalizeTxs := make([]blockatlas.Tx, 0)
-	filteredTxs := unique(txs)
-	for _, srcTx := range filteredTxs {
+	for _, srcTx := range txs {
 		normalized, isCorrect, err := NormalizeTx(&srcTx)
 		if !isCorrect || err != nil {
 			return []blockatlas.Tx{}
 		}
 		normalizeTxs = append(normalizeTxs, normalized)
 	}
-	sort.Slice(normalizeTxs, func(i, j int) bool {
-		return normalizeTxs[i].Date > normalizeTxs[j].Date
-	})
 	return normalizeTxs
 }
 
@@ -86,17 +81,4 @@ func NormalizeTx(trx *Transaction) (tx blockatlas.Tx, b bool, err error) {
 			Decimals: coin.Coins[coin.ONE].Decimals,
 		},
 	}, true, nil
-}
-
-// Remove duplicate transaction with same hash
-func unique(intSlice []Transaction) []Transaction {
-	keys := make(map[string]bool)
-	list := make([]Transaction, 0)
-	for _, entry := range intSlice {
-		if _, value := keys[entry.Hash]; !value {
-			keys[entry.Hash] = true
-			list = append(list, entry)
-		}
-	}
-	return list
 }


### PR DESCRIPTION
Cleanup prev PRs. Now we sort all txs on api level, not on provider level. Add tests for it