### PR TITLE
[Transactions] Improve fetching logic for transactions

### DIFF
--- a/platform/stellar/client.go
+++ b/platform/stellar/client.go
@@ -15,6 +15,7 @@ func (c *Client) GetTxsOfAddress(address string) ([]Payment, error) {
 	query := url.Values{
 		"order": {"desc"},
 		"limit": {"25"},
+		"join":  {"transactions"},
 	}
 	path := fmt.Sprintf("accounts/%s/payments", url.PathEscape(address))
 
@@ -24,17 +25,6 @@ func (c *Client) GetTxsOfAddress(address string) ([]Payment, error) {
 		return nil, err
 	}
 	return payments.Embedded.Records, nil
-}
-
-func (c *Client) GetTxHash(id string) (TxHash, error) {
-	path := fmt.Sprintf("transactions/%s", id)
-
-	var hash TxHash
-	err := c.Get(&hash, path, nil)
-	if err != nil {
-		return hash, err
-	}
-	return hash, nil
 }
 
 func (c *Client) CurrentBlockNumber() (int64, error) {
@@ -63,6 +53,7 @@ func (c *Client) GetBlockByNumber(num int64) (*Block, error) {
 	query := url.Values{
 		"order": {"desc"},
 		"limit": {"100"},
+		"join":  {"transactions"},
 	}
 	path := fmt.Sprintf("ledgers/%d/payments", num)
 

--- a/platform/stellar/model.go
+++ b/platform/stellar/model.go
@@ -38,26 +38,22 @@ type Block struct {
 
 // Payment model returned by Horizon
 type Payment struct {
-	ID              string `json:"id"`
-	Type            string `json:"type"`
-	SourceAccount   string `json:"source_account"`
-	CreatedAt       string `json:"created_at"`
-	Account         string `json:"account"`
-	Funder          string `json:"funder"`
-	StartingBalance string `json:"starting_balance"`
-	Into            string `json:"into"`
-	From            string `json:"from"`
-	To              string `json:"to"`
-	AssetType       string `json:"asset_type"`
-	Amount          string `json:"amount"`
-	TransactionHash string `json:"transaction_hash"`
+	ID              string      `json:"id"`
+	Type            string      `json:"type"`
+	SourceAccount   string      `json:"source_account"`
+	CreatedAt       string      `json:"created_at"`
+	Account         string      `json:"account"`
+	Funder          string      `json:"funder"`
+	StartingBalance string      `json:"starting_balance"`
+	Into            string      `json:"into"`
+	From            string      `json:"from"`
+	To              string      `json:"to"`
+	AssetType       string      `json:"asset_type"`
+	Amount          string      `json:"amount"`
+	TransactionHash string      `json:"transaction_hash"`
+	Transaction     Transaction `json:"transaction"`
 }
 
-type TxHash struct {
+type Transaction struct {
 	Memo string `json:"memo"`
-}
-
-type Tuple struct {
-	Payment
-	TxHash
 }

--- a/platform/stellar/model.go
+++ b/platform/stellar/model.go
@@ -55,5 +55,6 @@ type Payment struct {
 }
 
 type Transaction struct {
-	Memo string `json:"memo"`
+	Memo   string `json:"memo"`
+	Ledger uint64 `json:"ledger"`
 }

--- a/platform/stellar/transaction.go
+++ b/platform/stellar/transaction.go
@@ -16,13 +16,13 @@ func (p *Platform) GetTxsByAddress(address string) (blockatlas.TxPage, error) {
 	return p.NormalizePayments(payments), nil
 }
 
-func (p *Platform) NormalizePayments(payments []Payment) (txs []blockatlas.Tx) {
+func (p *Platform) NormalizePayments(payments []Payment) []blockatlas.Tx {
+	txs := make([]blockatlas.Tx, 0, len(payments))
 	for _, payment := range payments {
 		if tx, ok := Normalize(&payment, p.CoinIndex); ok {
 			txs = append(txs, tx)
 		}
 	}
-
 	return txs
 }
 

--- a/platform/stellar/transaction.go
+++ b/platform/stellar/transaction.go
@@ -4,7 +4,6 @@ import (
 	"github.com/trustwallet/blockatlas/coin"
 	"github.com/trustwallet/blockatlas/pkg/blockatlas"
 	"github.com/trustwallet/blockatlas/pkg/numbers"
-	"strconv"
 	"time"
 )
 
@@ -39,10 +38,6 @@ func Normalize(payment *Payment, nativeCoinIndex uint) (tx blockatlas.Tx, ok boo
 	default:
 		return tx, false
 	}
-	id, err := strconv.ParseUint(payment.ID, 10, 64)
-	if err != nil {
-		return tx, false
-	}
 	date, err := time.Parse("2006-01-02T15:04:05Z", payment.CreatedAt)
 	if err != nil {
 		return tx, false
@@ -70,7 +65,7 @@ func Normalize(payment *Payment, nativeCoinIndex uint) (tx blockatlas.Tx, ok boo
 		Fee:   FixedFee,
 		Date:  date.Unix(),
 		Memo:  payment.Transaction.Memo,
-		Block: id,
+		Block: payment.Transaction.Ledger,
 		Meta: blockatlas.Transfer{
 			Value:    blockatlas.Amount(value),
 			Symbol:   coin.Coins[nativeCoinIndex].Symbol,

--- a/platform/stellar/transaction_test.go
+++ b/platform/stellar/transaction_test.go
@@ -31,7 +31,7 @@ var createDst = blockatlas.Tx{
 	To:    "GDKIJJIKXLOM2NRMPNQZUUYK24ZPVFC6426GZAEP3KUK6KEJLACCWNMX",
 	Fee:   "100",
 	Date:  1470850220,
-	Block: 25002129911451649,
+	Block: 0,
 	Meta: blockatlas.Transfer{
 		Value:    "473269393700000000",
 		Symbol:   "XLM",
@@ -54,7 +54,8 @@ const transferSrc = `
 	"to": "GAX3BRBNB5WTJ2GNEFFH7A4CZKT2FORYABDDBZR5FIIT3P7FLS2EFOZZ",
 	"amount": "100000000.0000000",
 	"transaction": {
-		"memo": "testing"
+		"memo": "testing",
+		"ledger": 123
 	}
 }
 `
@@ -67,7 +68,7 @@ var transferDst = blockatlas.Tx{
 	Fee:   "100",
 	Date:  1470857941,
 	Memo:  "testing",
-	Block: 25008572362395649,
+	Block: 123,
 	Meta: blockatlas.Transfer{
 		Value:    blockatlas.Amount("1000000000000000"),
 		Symbol:   "XLM",


### PR DESCRIPTION
In current implementation now we have ability to include transactions details to avoid calling /transactions endpoint for each transaction that is being parsed from the block or list of transactions

**What does this break?** 

It breaks fetching memos for `kin` blockchain, which is acceptable at this point to avoid making so many requests. 

Another fix:
- fixing block number for stellar as it was using wrong field in the past. For kin it will stay as 0, instead of wrong number