### PR TITLE
Add harmony staking support in mainnet

### DIFF
--- a/platform/harmony/client.go
+++ b/platform/harmony/client.go
@@ -2,9 +2,11 @@ package harmony
 
 import (
 	"fmt"
-	"github.com/trustwallet/blockatlas/pkg/blockatlas"
-	"github.com/trustwallet/blockatlas/pkg/numbers"
 	"strconv"
+
+	"github.com/trustwallet/blockatlas/pkg/blockatlas"
+	"github.com/trustwallet/blockatlas/pkg/logger"
+	"github.com/trustwallet/blockatlas/pkg/numbers"
 )
 
 type Client struct {
@@ -39,6 +41,36 @@ func (c *Client) GetBlockByNumber(num int64) (info BlockInfo, err error) {
 	n := fmt.Sprintf("0x%x", num)
 	err = c.RpcCall(&info, "hmy_getBlockByNumber", []interface{}{n, true})
 	return
+}
+
+func (c *Client) GetValidators() (validators Validators, err error) {
+	err = c.RpcCall(&validators.Validators, "hmy_getAllValidatorInformation", []interface{}{-1})
+	if err != nil {
+		logger.Error(err, "Harmony: Failed to get all validator addresses")
+	}
+
+	return
+}
+
+func (c *Client) GetDelegations(address string) (delegations Delegations, err error) {
+	err = c.RpcCall(&delegations.List, "hmy_getDelegationsByDelegator", []interface{}{address})
+	if err != nil {
+		logger.Error(err, "Harmony: Failed to get delegations for address")
+	}
+	return
+}
+
+func (c *Client) GetBalance(address string) (string, error) {
+	var result string
+	err := c.RpcCall(&result, "hmy_getBalance", []interface{}{address, "latest"})
+	if err != nil {
+		return "0", err
+	}
+	balance, err := numbers.HexToDecimal(result)
+	if err != nil {
+		return "0", err
+	}
+	return balance, nil
 }
 
 func hexToInt(hex string) (uint64, error) {

--- a/platform/harmony/client.go
+++ b/platform/harmony/client.go
@@ -43,8 +43,10 @@ func (c *Client) GetBlockByNumber(num int64) (info BlockInfo, err error) {
 	return
 }
 
+
 func (c *Client) GetValidators() (validators Validators, err error) {
-	err = c.RpcCall(&validators.Validators, "hmy_getAllValidatorInformation", []interface{}{-1})
+	err = rpcCallStub(c, &validators.Validators, "hmy_getAllValidatorInformation", []interface{}{-1})
+
 	if err != nil {
 		logger.Error(err, "Harmony: Failed to get all validator addresses")
 	}
@@ -53,7 +55,8 @@ func (c *Client) GetValidators() (validators Validators, err error) {
 }
 
 func (c *Client) GetDelegations(address string) (delegations Delegations, err error) {
-	err = c.RpcCall(&delegations.List, "hmy_getDelegationsByDelegator", []interface{}{address})
+	err = rpcCallStub(c, &delegations.List, "hmy_getDelegationsByDelegator", []interface{}{address})
+
 	if err != nil {
 		logger.Error(err, "Harmony: Failed to get delegations for address")
 	}
@@ -79,4 +82,9 @@ func hexToInt(hex string) (uint64, error) {
 		return 0, err
 	}
 	return strconv.ParseUint(nonceStr, 10, 64)
+}
+
+// rpcCallStub is can be overwritten by the unit test
+var rpcCallStub = func (c *Client, result interface{}, method string, params interface{}) error {
+	return c.RpcCall(result, method, params)
 }

--- a/platform/harmony/client.go
+++ b/platform/harmony/client.go
@@ -65,7 +65,8 @@ func (c *Client) GetDelegations(address string) (delegations Delegations, err er
 
 func (c *Client) GetBalance(address string) (string, error) {
 	var result string
-	err := c.RpcCall(&result, "hmy_getBalance", []interface{}{address, "latest"})
+	err := rpcCallStub(c, &result, "hmy_getBalance", []interface{}{address, "latest"})
+
 	if err != nil {
 		return "0", err
 	}

--- a/platform/harmony/model.go
+++ b/platform/harmony/model.go
@@ -26,3 +26,31 @@ type BlockInfo struct {
 	Number       string        `json:"number"`
 	Transactions []Transaction `json:"transactions"`
 }
+
+type ValidatorInfo struct {
+	Address string  `json:"address"`
+}
+
+type LifetimeInfo struct {
+	Apr     string `json:"apr"`
+}
+
+type Validator struct {
+	Info      ValidatorInfo    `json:"validator"`
+	Active    bool             `json:"currently-in-committee"`
+	Lifetime  LifetimeInfo      `json:"lifetime"`
+}
+
+type Validators struct {
+	Validators []Validator `json:"result"`
+}
+
+type Delegation struct {
+	DelegatorAddress string   `json:"delegator_address"`
+	ValidatorAddress string   `json:"validator_address"`
+	Amount           float64  `json:"amount"`
+}
+
+type Delegations struct {
+	List []Delegation `json:"result"`
+}

--- a/platform/harmony/stake.go
+++ b/platform/harmony/stake.go
@@ -1,0 +1,123 @@
+package harmony
+
+import (
+	"github.com/trustwallet/blockatlas/pkg/blockatlas"
+	"github.com/trustwallet/blockatlas/pkg/errors"
+	"github.com/trustwallet/blockatlas/pkg/logger"
+	services "github.com/trustwallet/blockatlas/services/assets"
+	"math/big"
+	"strconv"
+)
+
+const (
+	lockTime  = 604800 // in seconds (7 epochs or 7 days)
+)
+
+func (p *Platform) GetValidators() (blockatlas.ValidatorPage, error) {
+	results := make(blockatlas.ValidatorPage, 0)
+	validators, err := p.client.GetValidators()
+	if err != nil {
+		return results, err
+	}
+
+	for _, v := range validators.Validators {
+		var apr float64
+		if apr, err = strconv.ParseFloat(v.Lifetime.Apr, 64); err != nil {
+			apr = 0
+		}
+		results = append(results, normalizeValidator(v, apr))
+	}
+
+	return results, nil
+}
+
+func (p *Platform) GetDetails() blockatlas.StakingDetails {
+	apr := p.GetMaxAPR()
+	return getDetails(apr)
+}
+
+func (p *Platform) GetMaxAPR() float64 {
+	validators, err := p.client.GetValidators()
+	if err != nil {
+		logger.Error("GetMaxAPR", logger.Params{"details": err, "platform": p.Coin().Symbol})
+		return Annual
+	}
+
+	var max = 0.0
+	for _, e := range validators.Validators {
+		var apr float64
+		if apr, err = strconv.ParseFloat(e.Lifetime.Apr, 64); err != nil {
+			apr = 0.0
+		}
+
+		if apr > max {
+			max = apr
+		}
+	}
+
+	return max
+}
+
+func (p *Platform) GetDelegations(address string) (blockatlas.DelegationsPage, error) {
+	delegations, err := p.client.GetDelegations(address)
+	if err != nil {
+		return nil, err
+	}
+
+	validators, err := services.GetValidatorsMap(p)
+	if err != nil {
+		return nil, err
+	}
+
+	return NormalizeDelegations(delegations.List, validators), nil
+}
+
+func (p *Platform) UndelegatedBalance(address string) (string, error) {
+	balance, err := p.client.GetBalance(address)
+	if err != nil {
+		return "0", err
+	}
+	return balance, nil
+}
+
+func NormalizeDelegations(delegations []Delegation, validators blockatlas.ValidatorMap) []blockatlas.Delegation {
+	results := make([]blockatlas.Delegation, 0)
+	for _, v := range delegations {
+		validator, ok := validators[v.ValidatorAddress]
+		if !ok {
+			logger.Error(errors.E("Validator not found", errors.Params{"address": v.ValidatorAddress, "platform": "harmony", "delegation": v.DelegatorAddress}))
+			continue
+		}
+
+		bigval := new(big.Float)
+		bigval.SetFloat64(v.Amount)
+
+		result := new(big.Int)
+		bigval.Int(result) // store converted number in result
+
+		delegation := blockatlas.Delegation{
+			Delegator: validator,
+			Value:     result.String(), // v.Amount.String(),
+			Status:    blockatlas.DelegationStatusActive,
+		}
+		results = append(results, delegation)
+	}
+	return results
+}
+
+func getDetails(apr float64) blockatlas.StakingDetails {
+	return blockatlas.StakingDetails{
+		Reward:        blockatlas.StakingReward{Annual: apr},
+		MinimumAmount: blockatlas.Amount("0"),
+		LockTime:      lockTime,
+		Type:          blockatlas.DelegationTypeDelegate,
+	}
+}
+
+func normalizeValidator(v Validator, apr float64) (validator blockatlas.Validator) {
+	return blockatlas.Validator{
+		Status:  v.Active,
+		ID:      v.Info.Address,
+		Details: getDetails(apr),
+	}
+}

--- a/platform/harmony/stake.go
+++ b/platform/harmony/stake.go
@@ -108,7 +108,7 @@ func NormalizeDelegations(delegations []Delegation, validators blockatlas.Valida
 func getDetails(apr float64) blockatlas.StakingDetails {
 	return blockatlas.StakingDetails{
 		Reward:        blockatlas.StakingReward{Annual: apr},
-		MinimumAmount: blockatlas.Amount("0"),
+		MinimumAmount: blockatlas.Amount("1000"),
 		LockTime:      lockTime,
 		Type:          blockatlas.DelegationTypeDelegate,
 	}

--- a/platform/harmony/stake_test.go
+++ b/platform/harmony/stake_test.go
@@ -1,0 +1,151 @@
+package harmony
+
+import (
+	"encoding/json"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/trustwallet/blockatlas/pkg/blockatlas"
+)
+
+const validatorSrc = `
+ {
+	"validator": {
+		"bls-public-keys": [
+			"29fb5d202e2f6f7955b425dc706fc0b29047067e51ba583fbb017c0f51186d5e1eaf6dd4059848be311ab5a49d625309"
+		],
+		"last-epoch-in-committee": 18,
+		"min-self-delegation": 10999000000000000000000,
+		"max-total-delegation": 100000000000000000000000000,
+		"rate": "0.100000000000000000",
+		"max-rate": "0.100000000000000000",
+		"max-change-rate": "0.100000000000000000",
+		"update-height": 88,
+		"name": "sieemma node",
+		"identity": "sieemma node by ankr",
+		"website": "www.ankr.com",
+		"security-contact": "info@ankr.com",
+		"details": "This validator is launched from app.ankr.com",
+		"creation-height": 88,
+		"address": "one1v8pukmelacy3xdap773rpg5pax3tmu40wmwr2j",
+		"delegations": [
+			{
+				"delegator-address": "one1v8pukmelacy3xdap773rpg5pax3tmu40wmwr2j",
+				"amount": 10999000000000000000000,
+				"reward": 2328233463148225437028,
+				"undelegations": []
+			}
+		]
+	},
+	"current-epoch-performance": {
+		"current-epoch-signing-percent": {
+			"current-epoch-signed": 3,
+			"current-epoch-to-sign": 3,
+			"num-beacon-blocks-until-next-epoch": 37,
+			"current-epoch-signing-percentage": "1.000000000000000000"
+		}
+	},
+	"metrics": {
+		"by-bls-key": [
+			{
+				"key": {
+					"bls-public-key": "29fb5d202e2f6f7955b425dc706fc0b29047067e51ba583fbb017c0f51186d5e1eaf6dd4059848be311ab5a49d625309",
+					"group-percent": "0.056856187290969900",
+					"effective-stake": "85000000000000000000000.000000000000000000",
+					"earning-account": "one1v8pukmelacy3xdap773rpg5pax3tmu40wmwr2j",
+					"overall-percent": "0.018193979933110368",
+					"shard-id": 1
+				},
+				"earned-reward": 4478494623655913952
+			}
+		]
+	},
+	"total-delegation": 10999000000000000000000,
+	"currently-in-committee": true,
+	"epos-status": "currently elected",
+	"epos-winning-stake": "85000000000000000000000.000000000000000000",
+	"booted-status": null,
+	"lifetime": {
+		"reward-accumulated": 2328233463148225437028,
+		"blocks": {
+			"to-sign": 525,
+			"signed": 504
+		},
+		"apr": "12.345"
+	}
+}`
+
+const delegationsSrc = `
+[
+	{
+		"validator_address": "one1pdv9lrdwl0rg5vglh4xtyrv3wjk3wsqket7zxy",
+		"delegator_address": "one1pf75h0t4am90z8uv3y0dgunfqp4lj8wr3t5rsp",
+		"amount": 12345678900000000000,
+		"reward": 15854399877248931866418,
+		"Undelegations": []
+	}
+]`
+
+func TestNormalizeValidator(t *testing.T) {
+	var v Validator
+	_ = json.Unmarshal([]byte(validatorSrc), &v)
+	expected := blockatlas.Validator{
+		Status: v.Active,
+		ID:     v.Info.Address,
+		Details: blockatlas.StakingDetails{
+			Reward:        blockatlas.StakingReward{Annual: 12.345},
+			LockTime:      0,
+			MinimumAmount: "0",
+			Type:          blockatlas.DelegationTypeDelegate,
+		},
+	}
+
+	var apr float64
+	var err error
+	if apr, err = strconv.ParseFloat(v.Lifetime.Apr,64); err != nil {
+		apr = 0
+	}
+
+	result := normalizeValidator(v, apr)
+	assert.Equal(t, expected, result)
+}
+
+var validator1 = blockatlas.StakeValidator{
+	ID:     "one1pdv9lrdwl0rg5vglh4xtyrv3wjk3wsqket7zxy",
+	Status: true,
+	Info: blockatlas.StakeValidatorInfo{
+		Name:        "Harmony One",
+		Description: "Stake and earn rewards with the most secure and stable validator. Operated by Harmony One Inc.",
+		Image:       "https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/harmony/validators/assets/one1pdv9lrdwl0rg5vglh4xtyrv3wjk3wsqket7zxy/logo.png",
+		Website:     "https://harmony.one",
+	},
+	Details: blockatlas.StakingDetails{
+		Reward: blockatlas.StakingReward{
+			Annual: 10,
+		},
+		LockTime:      0,
+		MinimumAmount: "0",
+	},
+}
+
+var validatorMap = blockatlas.ValidatorMap{
+	"one1pdv9lrdwl0rg5vglh4xtyrv3wjk3wsqket7zxy": validator1,
+}
+
+func TestNormalizeDelegations(t *testing.T) {
+	var delegations []Delegation
+	err := json.Unmarshal([]byte(delegationsSrc), &delegations)
+	assert.NoError(t, err)
+	assert.NotNil(t, delegations)
+
+	expected := []blockatlas.Delegation{
+		{
+			Delegator: validator1,
+			Value:     "12345678900000000000",
+			Status:    blockatlas.DelegationStatusActive,
+		},
+	}
+	result := NormalizeDelegations(delegations, validatorMap)
+	assert.Equal(t, expected, result)
+}

--- a/platform/harmony/stake_test.go
+++ b/platform/harmony/stake_test.go
@@ -2,11 +2,10 @@ package harmony
 
 import (
 	"encoding/json"
-	"strconv"
-	"testing"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/trustwallet/blockatlas/pkg/blockatlas"
+	"strconv"
+	"testing"
 )
 
 const validatorSrc = `
@@ -166,4 +165,58 @@ func TestGetDetails(t *testing.T) {
 
 	result := getDetails(10)
 	assert.Equal(t,expected, result)
+}
+
+
+func TestGetValidators(t *testing.T) {
+	var c Client
+
+	p := Platform{
+		client: c,
+	}
+
+	var validators = []Validator{
+		Validator{
+			Info: ValidatorInfo{
+				Address: "one1pdv9lrdwl0rg5vglh4xtyrv3wjk3wsqket7zxy",
+			},
+			Active: true,
+			Lifetime: LifetimeInfo{Apr: "10"},
+		},
+	}
+
+	rpcCallStub = func (c *Client, result interface{}, method string, params interface{}) error {
+		jsonData, _ := json.Marshal(validators)
+		 _ = json.Unmarshal(jsonData, result)
+		return nil
+	}
+
+	result, _ := p.GetValidators()
+	assert.Equal(t, lockTime, result[0].Details.LockTime)
+	assert.Equal(t, float64(10), result[0].Details.Reward.Annual)
+}
+
+func TestGetDelegation(t *testing.T) {
+	var c Client
+
+	p := Platform{
+		client: c,
+	}
+
+	var delegations = []Delegation{
+		Delegation{
+			DelegatorAddress: "one1pdv9lrdwl0rg5vglh4xtyrv3wjk3wsqket7zxy",
+			ValidatorAddress: "one1pdv9lrdwl0rg5vglh4xtyrv3wjk3wsqket7zxy",
+			Amount:           100,
+		},
+	}
+
+	rpcCallStub = func (c *Client, result interface{}, method string, params interface{}) error {
+		jsonData, _ := json.Marshal(delegations)
+		_ = json.Unmarshal(jsonData, result)
+		return nil
+	}
+
+	result, _ := p.GetDelegations("one1pdv9lrdwl0rg5vglh4xtyrv3wjk3wsqket7zxy")
+	assert.Equal(t, 0, len(result))
 }

--- a/platform/harmony/stake_test.go
+++ b/platform/harmony/stake_test.go
@@ -158,12 +158,12 @@ func TestHexToInt(t *testing.T) {
 
 func TestGetDetails(t *testing.T) {
 	var expected = blockatlas.StakingDetails{
-		blockatlas.StakingReward{Annual: 10},
-		lockTime ,
-		"1000",
-		blockatlas.DelegationTypeDelegate}
+			Reward:        blockatlas.StakingReward{Annual: 10},
+			LockTime:      lockTime,
+			MinimumAmount: "1000",
+			Type:          blockatlas.DelegationTypeDelegate,
+		}
 
 	result := getDetails(10)
-
 	assert.Equal(t,expected, result)
 }

--- a/platform/harmony/stake_test.go
+++ b/platform/harmony/stake_test.go
@@ -95,7 +95,7 @@ func TestNormalizeValidator(t *testing.T) {
 		ID:     v.Info.Address,
 		Details: blockatlas.StakingDetails{
 			Reward:        blockatlas.StakingReward{Annual: 12.345},
-			LockTime:      0,
+			LockTime:      604800,
 			MinimumAmount: "0",
 			Type:          blockatlas.DelegationTypeDelegate,
 		},

--- a/platform/harmony/stake_test.go
+++ b/platform/harmony/stake_test.go
@@ -205,18 +205,53 @@ func TestGetDelegation(t *testing.T) {
 
 	var delegations = []Delegation{
 		Delegation{
-			DelegatorAddress: "one1pdv9lrdwl0rg5vglh4xtyrv3wjk3wsqket7zxy",
-			ValidatorAddress: "one1pdv9lrdwl0rg5vglh4xtyrv3wjk3wsqket7zxy",
+			DelegatorAddress: "one1a0au0p33zrns49h3qw7prn02s4wphu0ggcqrhm",
+			ValidatorAddress: "one1a0au0p33zrns49h3qw7prn02s4wphu0ggcqrhm",
 			Amount:           100,
 		},
 	}
 
+	var validators = []Validator{
+		Validator{
+			Info: ValidatorInfo{
+				Address: "one1a0au0p33zrns49h3qw7prn02s4wphu0ggcqrhm",
+			},
+			Active: true,
+			Lifetime: LifetimeInfo{Apr: "10"},
+		},
+	}
+
 	rpcCallStub = func (c *Client, result interface{}, method string, params interface{}) error {
-		jsonData, _ := json.Marshal(delegations)
-		_ = json.Unmarshal(jsonData, result)
+		if (method == "hmy_getAllValidatorInformation") {
+			jsonData, _ := json.Marshal(validators)
+			_ = json.Unmarshal(jsonData, result)
+		} else {
+			jsonData, _ := json.Marshal(delegations)
+			_ = json.Unmarshal(jsonData, result)
+		}
 		return nil
 	}
 
 	result, _ := p.GetDelegations("one1pdv9lrdwl0rg5vglh4xtyrv3wjk3wsqket7zxy")
-	assert.Equal(t, 0, len(result))
+	assert.Equal(t, delegations[0].DelegatorAddress, result[0].Delegator.ID)
+}
+
+
+func TestGeBalance(t *testing.T) {
+	var c Client
+
+	p := Platform{
+		client: c,
+	}
+
+	var balance = "0x100"
+
+	rpcCallStub = func (c *Client, result interface{}, method string, params interface{}) error {
+		jsonData, _ := json.Marshal(balance)
+		_ = json.Unmarshal(jsonData, result)
+		return nil
+	}
+
+	result, _ := p.UndelegatedBalance("one1pdv9lrdwl0rg5vglh4xtyrv3wjk3wsqket7zxy")
+	assert.Equal(t, "256",result)
 }

--- a/platform/harmony/stake_test.go
+++ b/platform/harmony/stake_test.go
@@ -95,7 +95,7 @@ func TestNormalizeValidator(t *testing.T) {
 		ID:     v.Info.Address,
 		Details: blockatlas.StakingDetails{
 			Reward:        blockatlas.StakingReward{Annual: 12.345},
-			LockTime:      604800,
+			LockTime:      lockTime,
 			MinimumAmount: "1000",
 			Type:          blockatlas.DelegationTypeDelegate,
 		},
@@ -148,4 +148,22 @@ func TestNormalizeDelegations(t *testing.T) {
 	}
 	result := NormalizeDelegations(delegations, validatorMap)
 	assert.Equal(t, expected, result)
+}
+
+func TestHexToInt(t *testing.T) {
+	result, _ := hexToInt("0x604800")
+
+	assert.Equal(t,uint64(6309888), result)
+}
+
+func TestGetDetails(t *testing.T) {
+	var expected = blockatlas.StakingDetails{
+		blockatlas.StakingReward{Annual: 10},
+		lockTime ,
+		"1000",
+		blockatlas.DelegationTypeDelegate}
+
+	result := getDetails(10)
+
+	assert.Equal(t,expected, result)
 }

--- a/platform/harmony/stake_test.go
+++ b/platform/harmony/stake_test.go
@@ -96,7 +96,7 @@ func TestNormalizeValidator(t *testing.T) {
 		Details: blockatlas.StakingDetails{
 			Reward:        blockatlas.StakingReward{Annual: 12.345},
 			LockTime:      604800,
-			MinimumAmount: "0",
+			MinimumAmount: "1000",
 			Type:          blockatlas.DelegationTypeDelegate,
 		},
 	}

--- a/platform/harmony/transaction.go
+++ b/platform/harmony/transaction.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 )
 
+const Annual = 10
+
 func (p *Platform) GetTxsByAddress(address string) (blockatlas.TxPage, error) {
 	result, err := p.client.GetTxsOfAddress(address)
 	if err != nil {


### PR DESCRIPTION
This is resubmit for old PRs (#733 and #923) which supports harmony staking in block atlas.
The old PR failed test because the Harmony Mainnet didn't have the staking RPC (and I can't use testnet endpoints).

Now I can re-submit this PR since Harmony MainNet has staking RPC ready. 


Test status:
1) passed local test
2) passed the tests which failed in the previous PRs:
1. cd cmd/platform_api
2. ATLAS_PLATFORM=harmony go run main.go
3. Try these requests:

http://localhost:8420/v2/harmony/staking/validators
http://localhost:8420/v2/harmony/staking/delegations/one1e4mr7tp0a76wnhv9xd0wzentdjnjnsh3fwzgfv
