### PR TITLE
Fix DecimalToSatoshis for 0 input.

### DIFF
--- a/pkg/numbers/amount_test.go
+++ b/pkg/numbers/amount_test.go
@@ -33,7 +33,7 @@ func Test_addAmount(t *testing.T) {
 	}
 }
 
-func Test_decimalToSatoshis(t *testing.T) {
+func Test_ToSatoshi(t *testing.T) {
 	tests := []struct {
 		name   string
 		amount string
@@ -47,7 +47,7 @@ func Test_decimalToSatoshis(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := ToSatoshi(tt.amount); got != tt.want {
-				t.Errorf("decimalToSatoshis() = %v, want %v", got, tt.want)
+				t.Errorf("ToSatoshi() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/numbers/decimal.go
+++ b/pkg/numbers/decimal.go
@@ -12,7 +12,10 @@ import (
 // "0.0230" => "230"
 func DecimalToSatoshis(dec string) (string, error) {
 	out := strings.Replace(dec, ".", "", 1)
-	out = strings.TrimLeft(out, "0")
+	// trim left 0's but keep last
+	if l := len(out); l >= 2 {
+		out = strings.TrimLeft(out[:l-1], "0") + out[l-1:l]
+	}
 	for _, c := range out {
 		if !unicode.IsNumber(c) {
 			return "", errors.E("not a number", errors.Params{"dec": dec, "c": c})

--- a/pkg/numbers/decimal.go
+++ b/pkg/numbers/decimal.go
@@ -11,10 +11,15 @@ import (
 // "12.345" => "12345"
 // "0.0230" => "230"
 func DecimalToSatoshis(dec string) (string, error) {
-	out := strings.Replace(dec, ".", "", 1)
+	out := strings.TrimLeft(dec, " ")
+	out = strings.TrimRight(out, " ")
+	out = strings.Replace(out, ".", "", 1)
 	// trim left 0's but keep last
 	if l := len(out); l >= 2 {
 		out = strings.TrimLeft(out[:l-1], "0") + out[l-1:l]
+	}
+	if len(out) == 0 {
+		return "", errors.E("Invalid empty input", errors.Params{"dec": dec, "dec_trimmed": out})
 	}
 	for _, c := range out {
 		if !unicode.IsNumber(c) {

--- a/pkg/numbers/decimal_test.go
+++ b/pkg/numbers/decimal_test.go
@@ -9,14 +9,14 @@ func TestDecimalToSatoshis(t *testing.T) {
 			t.Error(err)
 		}
 		if expected != actual {
-			t.Errorf("expected: %s, got %s", expected, actual)
+			t.Errorf("expected %s, got %s, input %s", expected, actual, input)
 		}
 	}
 
 	assertSatError := func(input string) {
 		actual, err := DecimalToSatoshis(input)
 		if err == nil {
-			t.Errorf("Expected error but no error: got %s", actual)
+			t.Errorf("Expected error but no error: got %s, input %s", actual, input)
 		}
 	}
 
@@ -29,9 +29,15 @@ func TestDecimalToSatoshis(t *testing.T) {
 	assertSatEquals("2030", "0.002030")
 	assertSatEquals("101010", "0101010")
 	assertSatEquals("11001100", "0011001100")
+	assertSatEquals("376", " 376")
+	assertSatEquals("376", "376 ")
 	
 	assertSatError("12NotNumber34")
 	assertSatError("12,34")
+	assertSatError("")
+	assertSatError(" ")
+	assertSatError("37 6")
+	assertSatError("37,6")
 }
 
 func TestDecimalExp(t *testing.T) {

--- a/pkg/numbers/decimal_test.go
+++ b/pkg/numbers/decimal_test.go
@@ -13,10 +13,25 @@ func TestDecimalToSatoshis(t *testing.T) {
 		}
 	}
 
+	assertSatError := func(input string) {
+		actual, err := DecimalToSatoshis(input)
+		if err == nil {
+			t.Errorf("Expected error but no error: got %s", actual)
+		}
+	}
+
 	assertSatEquals("10", "1.0")
 	assertSatEquals("1", "0.1")
 	assertSatEquals("13602", "136.02")
+	assertSatEquals("13602", "0136.02")
 	assertSatEquals("1500000", "0.01500000")
+	assertSatEquals("0", "0")
+	assertSatEquals("2030", "0.002030")
+	assertSatEquals("101010", "0101010")
+	assertSatEquals("11001100", "0011001100")
+	
+	assertSatError("12NotNumber34")
+	assertSatError("12,34")
 }
 
 func TestDecimalExp(t *testing.T) {

--- a/platform/cosmos/transaction.go
+++ b/platform/cosmos/transaction.go
@@ -146,9 +146,13 @@ func (p *Platform) fillTransfer(tx *blockatlas.Tx, transfer MessageValueTransfer
 }
 
 func (p *Platform) fillDelegate(tx *blockatlas.Tx, delegate MessageValueDelegate, events Events, msgType TxType) {
-	value, err := numbers.DecimalToSatoshis(delegate.Amount.Quantity)
-	if err != nil {
-		return
+	value := ""
+	if len(delegate.Amount.Quantity) > 0 {
+		var err error
+		value, err = numbers.DecimalToSatoshis(delegate.Amount.Quantity)
+		if err != nil {
+			return
+		}
 	}
 	tx.From = delegate.DelegatorAddr
 	tx.To = delegate.ValidatorAddr

--- a/platform/nimiq/transaction_test.go
+++ b/platform/nimiq/transaction_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/trustwallet/blockatlas/coin"
 	"github.com/trustwallet/blockatlas/pkg/blockatlas"
 	"io/ioutil"
+	"math"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -68,7 +69,7 @@ var (
 		From:  "NQ74 SJ0Q 49T1 4XQL KABH 1RUC 8DPT 9F0U 9P0B",
 		To:    "NQ97 18BJ 33YV QGHQ BV2K 56V4 12CH J8TD S9S3",
 		Fee:   "300",
-		Date:  time.Now().Unix(),
+		Date:  666666, // special placholder value
 		Block: 0,
 		Meta: blockatlas.Transfer{
 			Value:    "100000",
@@ -79,6 +80,7 @@ var (
 )
 
 func TestNormalizeTx1(t *testing.T) {
+	now := time.Now().Unix()
 	tests := []struct {
 		name  string
 		srcTx string
@@ -96,6 +98,10 @@ func TestNormalizeTx1(t *testing.T) {
 				return
 			}
 			got := NormalizeTx(&srcTx)
+			// special handling for current date, if around now, replace with special value
+			if math.Abs(float64(got.Date - now)) < 30 {
+				got.Date = 666666
+			}
 			assert.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION
DecimalToSatoshis has a bug: for input "0", it trims the single 0 to "", and returns as a valid response.  Results in unparseable normalized TX in case of Solana, KIN, Cosmos.  See #1106 . 

Also solve a minor sporadic unit test, #1111 .