### PR TITLE
Initial dig at tokens cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,20 @@ New Subscriptions --(Rabbit MQ)--> Subscriber --> DB
 
 The whole flow is not available at Atlas repo. We will have integration tests with it. Also there will be examples of all instances soon.
 
+### Tokens Cache
+
+A quite common, expensive operation is looking up the set of owned tokens for an address.
+(Referring to tokens as user-defined such as ERC-20).
+
+We remember the list of tokens for an address in the "tokens cache" tables.
+The API fills the cache lazily, whenever a request for the tokens list comes in.
+On top of that, a background routine updates the cache incrementally for existing addresses,
+by observing new token transactions.
+
+As of now, there is no garbage collection logic for the tokens cache, so it grows without bounds.
+The cache can be safely reset using SQL truncate: `TRUNCATE address_tokens, address_token_trackers;`.
+Just be sure to clean both tables at once, otherwise inconsistency arises.
+
 ## Setup
 
 ### Prerequisite

--- a/db/address_tokens.go
+++ b/db/address_tokens.go
@@ -1,0 +1,107 @@
+package db
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/jinzhu/gorm"
+	"github.com/trustwallet/blockatlas/db/models"
+)
+
+// GetAddressTokens returns the set of known tokens for an address.
+// If the set is unknown, "ok" is set to false.
+func (i *Instance) GetAddressTokens(coin uint, address string) (tokens []string, ok bool, err error) {
+	// Check if the address is tracked (i.e. was MarkAddressTokensTracked() called?).
+	ok, err = i.AddressTokensTracked(coin, address)
+	if err != nil || !ok {
+		return
+	}
+	// The address is tracked. Read the list of tokens.
+	if err := i.Gorm.Table("address_tokens").
+		Where("coin = ? AND address = ?", coin, address).
+		Pluck("token", &tokens).
+		Error; err != nil {
+		return nil, false, err
+	}
+	return
+}
+
+// UpsertAddressTokens adds in a new set of tokens for an address.
+// Future calls to GetTokens() will return the set union of the previous set and the new set,
+// if MarkAddressTokensTracked() was called at a previous time.
+// This func is idempotent.
+func (i *Instance) UpsertAddressTokens(coin uint, address string, tokens []string) error {
+	if len(tokens) == 0 {
+		return nil
+	}
+	// Insert token mapping
+	stmt, values := upsertTokensStmt(coin, address, tokens)
+	return i.Gorm.Exec(stmt, values...).Error
+}
+
+// UpsertAddressTokensMulti is like UpsertAddressTokens() but for multiple mappings at once.
+// This func is idempotent.
+func (i *Instance) UpsertAddressTokensMulti(mappings []models.AddressToken) error {
+	if len(mappings) == 0 {
+		return nil
+	}
+	// Insert token mapping
+	stmt, values := upsertTokensMultiStmt(mappings)
+	return i.Gorm.Exec(stmt, values...).Error
+}
+
+// AddressTokensTracked returns whether the set of tokens for a single address are marked "tracked".
+// In other words, was MarkAddressTokensTracked() called previously?
+func (i *Instance) AddressTokensTracked(coin uint, address string) (bool, error) {
+	trackedEntry := &models.AddressTokenTracker{Coin: coin, Address: address}
+	if err := i.Gorm.Take(trackedEntry).Error; errors.Is(err, gorm.ErrRecordNotFound) {
+		return false, nil // The address is not fully tracked for tokens.
+	} else if err != nil {
+		return false, err // Error during lookup
+	}
+	return true, nil
+}
+
+// AddressTokensTrackedMulti checks AddressTokensTracked() for multiple addresses at once.
+// It returns the list of address for which AddressTokensTracked() resolves to (true, nil).
+func (i *Instance) AddressTokensTrackedMulti(coin uint, addresses []string) (matched []string, err error) {
+	err = i.Gorm.Where("coin = ? AND address IN (?)", coin, addresses).
+		Pluck("address", &matched).
+		Error
+	return
+}
+
+// MarkAddressTokensTracked marks the set of tokens as "tracked" for a single address.
+// This will activate GetAddressTokens().
+// This func is idempotent.
+func (i *Instance) MarkAddressTokensTracked(coin uint, address string) error {
+	trackedEntry := &models.AddressTokenTracker{Coin: coin, Address: address}
+	return i.Gorm.FirstOrCreate(trackedEntry).Error
+}
+
+func upsertTokensStmt(coin uint, address string, tokens []string) (stmt string, values []interface{}) {
+	mappings := make([]models.AddressToken, len(tokens))
+	for i, token := range tokens {
+		mappings[i] = models.AddressToken{
+			Coin:    coin,
+			Address: address,
+			Token:   token,
+		}
+	}
+	return upsertTokensMultiStmt(mappings)
+}
+
+func upsertTokensMultiStmt(mappings []models.AddressToken) (stmt string, values []interface{}) {
+	var batch strings.Builder
+	batch.WriteString("INSERT INTO address_tokens (coin, address, token) VALUES\n")
+	for i, mapping := range mappings {
+		if i > 0 {
+			batch.WriteString(",\n")
+		}
+		batch.WriteString("  (?, ?, ?)")
+		values = append(values, mapping.Coin, mapping.Address, mapping.Token)
+	}
+	batch.WriteString("\nON CONFLICT DO NOTHING;")
+	stmt = batch.String()
+	return
+}

--- a/db/address_tokens_test.go
+++ b/db/address_tokens_test.go
@@ -1,0 +1,34 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/trustwallet/blockatlas/db/models"
+)
+
+func TestUpsertTokensMultiStmt(t *testing.T) {
+	stmt, values := upsertTokensMultiStmt([]models.AddressToken{
+		{Coin: 1, Address: "A", Token: "A"},
+		{Coin: 1, Address: "A", Token: "B"},
+		{Coin: 1, Address: "A", Token: "A"},
+		{Coin: 1, Address: "B", Token: "A"},
+		{Coin: 2, Address: "A", Token: "A"},
+	})
+	expectedStmt := `INSERT INTO address_tokens (coin, address, token) VALUES
+  (?, ?, ?),
+  (?, ?, ?),
+  (?, ?, ?),
+  (?, ?, ?),
+  (?, ?, ?)
+ON CONFLICT DO NOTHING;`
+	expectedValues := []interface{}{
+		uint(1), "A", "A",
+		uint(1), "A", "B",
+		uint(1), "A", "A",
+		uint(1), "B", "A",
+		uint(2), "A", "A",
+	}
+	assert.Equal(t, expectedStmt, stmt)
+	assert.Equal(t, expectedValues, values)
+}

--- a/db/db.go
+++ b/db/db.go
@@ -29,6 +29,8 @@ func New(uri, env string) (*Instance, error) {
 	}
 
 	g.AutoMigrate(
+		&models.AddressTokenTracker{},
+		&models.AddressToken{},
 		&models.Subscription{},
 		&models.Tracker{},
 	)

--- a/db/models/address_tokens.go
+++ b/db/models/address_tokens.go
@@ -1,0 +1,14 @@
+package models
+
+// An AddressTokenTracker marks existence of address <=> token mappings in the database.
+type AddressTokenTracker struct {
+	Coin    uint   `gorm:"primary_key;auto_increment:false"`
+	Address string `gorm:"primary_key"`
+}
+
+// AddressToken is a single mapping between an address and a token.
+type AddressToken struct {
+	Coin    uint   `gorm:"primary_key;auto_increment:false"`
+	Address string `gorm:"primary_key"`
+	Token   string `gorm:"primary_key"`
+}

--- a/services/observer/tokens/tokens.go
+++ b/services/observer/tokens/tokens.go
@@ -1,0 +1,91 @@
+// Package tokens populates the address <=> token mappings cache.
+//
+// TODO Is this package in the right spot?
+//
+// It implements a lazy, incremental cache. The cache key is the (coin, address) tuple,
+// and the cache entry is the set of tokens the address has interacted with.
+//
+// The cache entry is created when the tokens set is queried from an authoritative source (hence "lazy").
+// This happens in the FullTokensUpdate() method. From this point on, the addresses' tokens are marked as **tracked**.
+//
+// A background routine will eavesdrop all token transactions happening on the network.
+// It populates the cache incrementally, i.e. adds tokens to the cache entry without re-doing the tokens list every time.
+// It does this using the IncrementalTokensUpdate() function.
+package tokens
+
+import (
+	"fmt"
+
+	"github.com/trustwallet/blockatlas/db"
+	"github.com/trustwallet/blockatlas/db/models"
+	"github.com/trustwallet/blockatlas/pkg/blockatlas"
+)
+
+type Service struct {
+	DB   *db.Instance
+	Coin uint
+}
+
+// FullTokensUpdate updates the cache forcefully for a single address.
+// It also marks the address as tracked from now on.
+// This would be called after fetching the set of tokens from an expensive query.
+func (s *Service) FullTokensUpdate(address string, tokens []string) error {
+	if err := s.DB.UpsertAddressTokens(s.Coin, address, tokens); err != nil {
+		return fmt.Errorf("failed to insert initial address <=> tokens mappings: %w", err)
+	}
+	if err := s.DB.MarkAddressTokensTracked(s.Coin, address); err != nil {
+		return fmt.Errorf("failed to mark address <=> tokens as tracked: %w", err)
+	}
+	return nil
+}
+
+// IncrementalTokensUpdate updates the cache incrementally from new transactions.
+// It ignores addresses that are not marked as tracked.
+// This would be called in the background when new txs come in.
+func (s *Service) IncrementalTokensUpdate(txs blockatlas.Txs) error {
+	// Collect list of addresses with token txs.
+	activeAddrsMap := make(map[string]bool)
+	for _, tx := range txs {
+		if tx.Type != blockatlas.TxTokenTransfer {
+			// TODO Also respect NativeTokenTransfers?
+			continue
+		}
+		activeAddrsMap[tx.From] = true
+		activeAddrsMap[tx.To] = true
+	}
+	activeAddrs := make([]string, 0, len(activeAddrsMap))
+	for addr := range activeAddrsMap {
+		activeAddrs = append(activeAddrs, addr)
+	}
+	// Filter by tracked addresses.
+	matched, err := s.DB.AddressTokensTrackedMulti(s.Coin, activeAddrs)
+	if err != nil {
+		return fmt.Errorf("failed to get tracked addrs: %w", err)
+	}
+	matchedMap := make(map[string]bool)
+	for _, match := range matched {
+		matchedMap[match] = true
+	}
+	// Send out updates.
+	var mappings []models.AddressToken
+	for _, tx := range txs {
+		if tx.Type != blockatlas.TxTokenTransfer {
+			// TODO Also respect NativeTokenTransfers?
+			continue
+		}
+		if matchedMap[tx.From] {
+			mappings = append(mappings, models.AddressToken{
+				Coin: s.Coin, Address: tx.From, Token: "", // FIXME how to get token?
+			})
+		}
+		if matchedMap[tx.To] {
+			mappings = append(mappings, models.AddressToken{
+				Coin: s.Coin, Address: tx.To, Token: "", // FIXME how to get token?
+			})
+		}
+	}
+	if err := s.DB.UpsertAddressTokensMulti(mappings); err != nil {
+		return fmt.Errorf("failed to upsert address <=> token mappings: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
This implements a cache mechanism for address <=> token mappings.
As discussed on Telegram, see README.md and services/observer/tokens GoDoc.

* db/models: add address_token and address_token_tracker tables
* db: add token cache operations
* services/observer/tokens: add high level interface to token cache