### PR TITLE
[Cosmos] Improve transaction fetching

### DIFF
--- a/platform/cosmos/transaction.go
+++ b/platform/cosmos/transaction.go
@@ -25,7 +25,7 @@ func (p *Platform) GetTxsByAddress(address string) (blockatlas.TxPage, error) {
 				return
 			}
 			// Condition when no more pages to paginate
-			if txs.PageTotal == "1" {
+			if txs.PageTotal == "1" || txs.PageTotal == "0" {
 				out <- txs.Txs
 				return
 			}

--- a/platform/kava/transaction.go
+++ b/platform/kava/transaction.go
@@ -32,7 +32,7 @@ func (p *Platform) GetTokenTxsByAddress(address, token string) (blockatlas.TxPag
 				return
 			}
 			// Condition when no more pages to paginate
-			if txs.PageTotal == "1" {
+			if txs.PageTotal == "1" || txs.PageTotal == "0" {
 				out <- txs.Txs
 				return
 			}


### PR DESCRIPTION
If number of available pages is 0, client will try to request: txs?limit=25&message.recipient=cosmos1s9....q&page=0 - which will always return 400 errors

This is a simple change, cosmos and kava platforms require refactor and consolidation into one platform.