### PR TITLE
[Ripple/Near] new transaction API

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -6,14 +6,15 @@ import (
 	ginSwagger "github.com/swaggo/gin-swagger"
 	"github.com/swaggo/gin-swagger/swaggerFiles"
 	"github.com/trustwallet/blockatlas/config"
+	"github.com/trustwallet/blockatlas/db"
 	_ "github.com/trustwallet/blockatlas/docs"
 	"github.com/trustwallet/blockatlas/platform"
 	"github.com/trustwallet/blockatlas/services/tokenindexer"
 )
 
-func SetupPlatformAPI(router gin.IRouter) {
+func SetupPlatformAPI(router gin.IRouter, database *db.Instance) {
 	for _, api := range platform.Platforms {
-		RegisterTransactionsAPI(router, api)
+		RegisterTransactionsAPI(router, api, database)
 		RegisterTokensAPI(router, api)
 		RegisterStakeAPI(router, api)
 		RegisterBlockAPI(router, api)

--- a/api/endpoint/transaction.go
+++ b/api/endpoint/transaction.go
@@ -86,7 +86,7 @@ func GetTransactionsHistory(c *gin.Context, txAPI blockatlas.TxAPI, tokenTxAPI b
 		filteredTxs = filteredTxs[0:types.TxPerPage]
 	}
 
-	// modify in loop
+	// set direction by address
 	result := make(types.Txs, len(filteredTxs))
 	for i, t := range filteredTxs {
 		result[i] = t
@@ -113,16 +113,15 @@ func GetTransactionsByAccount(c *gin.Context, txsAPI blockatlas.TransactionsAPI,
 		return
 	}
 
-	page := make(types.TxPage, 0)
+	txs = txs.FilterTransactionsByMemo()
 
-	for _, tx := range txs {
-		tx.Direction = tx.GetTransactionDirection(account)
-		page = append(page, tx)
+	// set direction
+	result := make(types.Txs, len(txs))
+	for i, t := range txs {
+		result[i] = t
+		result[i].Direction = t.GetTransactionDirection(account)
 	}
-
-	page = page.FilterTransactionsByMemo()
-
-	c.JSON(http.StatusOK, &page)
+	c.JSON(http.StatusOK, types.NewTxPage(result))
 }
 
 // @Summary Get Transactions by XPUB

--- a/api/registry.go
+++ b/api/registry.go
@@ -1,17 +1,19 @@
 package api
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/trustwallet/blockatlas/api/endpoint"
+	"github.com/trustwallet/blockatlas/db"
 	"github.com/trustwallet/blockatlas/pkg/blockatlas"
 	"github.com/trustwallet/blockatlas/platform"
 	"github.com/trustwallet/blockatlas/services/tokenindexer"
 	"github.com/trustwallet/golibs/network/middleware"
 )
 
-func RegisterTransactionsAPI(router gin.IRouter, api blockatlas.Platform) {
+func RegisterTransactionsAPI(router gin.IRouter, api blockatlas.Platform, database *db.Instance) {
 	handle := api.Coin().Handle
 	txUtxoAPI, ok := api.(blockatlas.TxUtxoAPI)
 	if ok {
@@ -34,6 +36,13 @@ func RegisterTransactionsAPI(router gin.IRouter, api blockatlas.Platform) {
 		})
 		router.GET("/v2/"+handle+"/transactions/:address", func(c *gin.Context) {
 			endpoint.GetTransactionsHistory(c, txAPI, tokenTxAPI)
+		})
+	}
+
+	txsAPI, ok := api.(blockatlas.TransactionsAPI)
+	if ok {
+		router.GET(fmt.Sprintf("%s/v1/transactions/:account", handle), func(c *gin.Context) {
+			endpoint.GetTransactionsByAccount(c, txsAPI, database)
 		})
 	}
 }

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -61,7 +61,7 @@ func init() {
 func main() {
 	api.SetupTokensIndexAPI(engine, tokenIndexer)
 	api.SetupSwaggerAPI(engine)
-	api.SetupPlatformAPI(engine)
+	api.SetupPlatformAPI(engine, database)
 	api.SetupMetrics(engine)
 
 	golibsGin.SetupGracefulShutdown(ctx, port, engine)

--- a/config.yml
+++ b/config.yml
@@ -205,7 +205,7 @@ solana:
   api: https://api.mainnet-beta.solana.com
 
 near:
-  api: https://staging-rpc.nearprotocol.com
+  api: https://rpc.mainnet.near.org
 
 elrond:
   api: https://gateway.elrond.com

--- a/db/db.go
+++ b/db/db.go
@@ -43,6 +43,7 @@ func Setup(db *gorm.DB) error {
 		&models.Asset{},
 		&models.Subscription{},
 		&models.SubscriptionsAssetAssociation{},
+		&models.Transaction{},
 	)
 }
 

--- a/db/models/asset.go
+++ b/db/models/asset.go
@@ -48,7 +48,7 @@ func AssetsFrom(t types.Tx) (assets []Asset) {
 	}
 
 	for _, transfer := range t.TokenTransfers {
-		//Improve this later. Making cure we only include assets associated with current addresses
+		//Improve this later. Making sure we only include assets associated with current addresses
 		for _, address := range t.GetAddresses() {
 			if address == transfer.To || address == transfer.From {
 				if asset, ok := AssetFromTokenTransfer(&t, transfer); ok {

--- a/db/models/tracker.go
+++ b/db/models/tracker.go
@@ -3,11 +3,10 @@ package models
 import "time"
 
 type Tracker struct {
-	UpdatedAt      time.Time
-	Coin           string `gorm:"primary_key:true; type:varchar(64)"`
-	Priority       string `gorm:"default:normal"`
-	Height         int64  `gorm:"default:0"`
-	Enabled        bool   `gorm:"default:true" sql:"index"`
-	IndexedHeight  int64  `gorm:"default:0"`
-	IndexerEnabled bool   `gorm:"default:false"`
+	UpdatedAt     time.Time
+	Coin          string `gorm:"primary_key:true; type:varchar(64)"`
+	Priority      string `gorm:"default:normal"`
+	Height        int64  `gorm:"default:0"`
+	Enabled       bool   `gorm:"default:true" sql:"index"`
+	IndexedHeight int64  `gorm:"default:0"`
 }

--- a/db/models/tracker.go
+++ b/db/models/tracker.go
@@ -3,10 +3,10 @@ package models
 import "time"
 
 type Tracker struct {
-	UpdatedAt     time.Time
-	Coin          string `gorm:"primary_key:true; type:varchar(64)"`
-	Priority      string `gorm:"default:normal"`
-	Height        int64  `gorm:"default:0"`
-	Enabled       bool   `gorm:"default:true" sql:"index"`
-	IndexedHeight int64  `gorm:"default:0"`
+	UpdatedAt              time.Time
+	Coin                   string `gorm:"primary_key:true; type:varchar(64)"`
+	Priority               string `gorm:"default:normal"`
+	Height                 int64  `gorm:"default:0"`
+	Enabled                bool   `gorm:"default:true" sql:"index"`
+	TransactionIndexHeight int64  `gorm:"default:0"`
 }

--- a/db/models/tracker.go
+++ b/db/models/tracker.go
@@ -3,9 +3,11 @@ package models
 import "time"
 
 type Tracker struct {
-	UpdatedAt time.Time
-	Coin      string `gorm:"primary_key:true; type:varchar(64)"`
-	Priority  string `gorm:"default:normal"`
-	Height    int64
-	Enabled   bool `gorm:"default:true" sql:"index"`
+	UpdatedAt      time.Time
+	Coin           string `gorm:"primary_key:true; type:varchar(64)"`
+	Priority       string `gorm:"default:normal"`
+	Height         int64  `gorm:"default:0"`
+	Enabled        bool   `gorm:"default:true" sql:"index"`
+	IndexedHeight  int64  `gorm:"default:0"`
+	IndexerEnabled bool   `gorm:"default:false"`
 }

--- a/db/models/transaction.go
+++ b/db/models/transaction.go
@@ -1,9 +1,13 @@
 package models
 
 import (
+	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/jinzhu/gorm/dialects/postgres"
+	"github.com/trustwallet/golibs/asset"
+	"github.com/trustwallet/golibs/types"
 )
 
 type Transaction struct {
@@ -21,4 +25,63 @@ type Transaction struct {
 	Memo       string
 	Type       string
 	Metadata   postgres.Jsonb
+}
+
+func (tx Transaction) ToTx() (result types.Tx, err error) {
+	coinId, _, err := asset.ParseID(tx.AssetID)
+	if err != nil {
+		return
+	}
+
+	bytes, err := tx.Metadata.MarshalJSON()
+	if err != nil {
+		return
+	}
+
+	result = types.Tx{
+		ID:     tx.ID,
+		Coin:   coinId,
+		Date:   tx.Date.Unix(),
+		From:   tx.From,
+		To:     tx.To,
+		Fee:    types.Amount(tx.Fee),
+		Block:  tx.Block,
+		Status: types.Status(tx.Status),
+		Memo:   tx.Memo,
+		Type:   types.TransactionType(tx.Type),
+	}
+
+	switch result.Type {
+	case types.TxTransfer:
+		var transfer types.Transfer
+		err = json.Unmarshal(bytes, &transfer)
+		result.Meta = transfer
+	case types.TxTokenTransfer, types.TxNativeTokenTransfer:
+		var transfer types.TokenTransfer
+		err = json.Unmarshal(bytes, &transfer)
+		result.Meta = transfer
+	case types.TxContractCall:
+		var call types.ContractCall
+		err = json.Unmarshal(bytes, &call)
+		result.Meta = call
+	case types.TxAnyAction:
+		var action types.AnyAction
+		err = json.Unmarshal(bytes, &action)
+		result.Meta = action
+	default:
+		err = fmt.Errorf("not supported metadata type: %s", tx.Type)
+	}
+	return
+}
+
+func ToTxPage(txs []Transaction) (types.TxPage, error) {
+	page := make(types.TxPage, 0)
+	for _, tx := range txs {
+		t, err := tx.ToTx()
+		if err != nil {
+			return types.TxPage{}, err
+		}
+		page = append(page, t)
+	}
+	return page, nil
 }

--- a/db/models/transaction.go
+++ b/db/models/transaction.go
@@ -74,16 +74,16 @@ func (tx Transaction) ToTx() (result types.Tx, err error) {
 	return
 }
 
-func ToTxPage(txs []Transaction) (types.TxPage, error) {
-	page := make(types.TxPage, 0)
+func ToTxs(txs []Transaction) (types.Txs, error) {
+	result := make(types.Txs, 0)
 	for _, tx := range txs {
 		t, err := tx.ToTx()
 		if err != nil {
-			return types.TxPage{}, err
+			return types.Txs{}, err
 		}
-		page = append(page, t)
+		result = append(result, t)
 	}
-	return page, nil
+	return result, nil
 }
 
 func NormalizeTransactions(txs []types.Tx) ([]Transaction, error) {

--- a/db/models/transaction.go
+++ b/db/models/transaction.go
@@ -1,0 +1,24 @@
+package models
+
+import (
+	"time"
+
+	"github.com/jinzhu/gorm/dialects/postgres"
+)
+
+type Transaction struct {
+	ID         string `gorm:"primary_key; autoIncrement:false; index"`
+	Coin       uint   `gorm:"primary_key; autoIncrement:false; index"`
+	AssetID    string
+	From       string
+	To         string
+	FeeAssetID string
+	Fee        string
+	Date       time.Time
+	Block      uint64
+	Sequence   uint64
+	Status     string
+	Memo       string
+	Type       string
+	Metadata   postgres.Jsonb
+}

--- a/db/transaction.go
+++ b/db/transaction.go
@@ -9,10 +9,11 @@ func (i *Instance) CreateTransactions(txs []models.Transaction) error {
 	return i.Gorm.Clauses(clause.OnConflict{DoNothing: true}).Create(&txs).Error
 }
 
-func (i *Instance) GetTransactionsByAccount(account string, coin uint) (txs []models.Transaction, err error) {
-	err = i.Gorm.Where("coin = ? AND (\"from\" = ? OR \"to\" = ?)", coin, account, account).
+func (i *Instance) GetTransactionsByAccount(account string, coin uint, limit int) (txs []models.Transaction, err error) {
+	err = i.Gorm.Where("coin = ? AND \"from\" = ?", coin, account).
+		Or("coin = ? AND \"to\" = ?", coin, account).
 		Order("date DESC").
-		Limit(25).
+		Limit(limit).
 		Find(&txs).Error
 	return
 }

--- a/db/transaction.go
+++ b/db/transaction.go
@@ -1,0 +1,10 @@
+package db
+
+import (
+	"github.com/trustwallet/blockatlas/db/models"
+	"gorm.io/gorm/clause"
+)
+
+func (i *Instance) CreateTransactions(txs []models.Transaction) error {
+	return i.Gorm.Clauses(clause.OnConflict{DoNothing: true}).Create(&txs).Error
+}

--- a/db/transaction.go
+++ b/db/transaction.go
@@ -8,3 +8,11 @@ import (
 func (i *Instance) CreateTransactions(txs []models.Transaction) error {
 	return i.Gorm.Clauses(clause.OnConflict{DoNothing: true}).Create(&txs).Error
 }
+
+func (i *Instance) GetTransactionsByAccount(account string, coin uint) (txs []models.Transaction, err error) {
+	err = i.Gorm.Where("coin = ? AND (\"from\" = ? OR \"to\" = ?)", coin, account, account).
+		Order("date DESC").
+		Limit(25).
+		Find(&txs).Error
+	return
+}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/gin-contrib/cors v1.3.1
 	github.com/gin-gonic/gin v1.6.3
 	github.com/itchyny/timefmt-go v0.1.2
+	github.com/jinzhu/gorm v1.9.16
 	github.com/magefile/mage v1.11.0 // indirect
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/mr-tron/base58 v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,7 @@ github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugX
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/PuerkitoBio/goquery v1.5.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
 github.com/PuerkitoBio/purell v1.1.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
@@ -34,6 +35,7 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuy
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
@@ -78,6 +80,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/deckarep/golang-set v1.7.1 h1:SCQV0S6gTtp6itiFrTqI+pfmJ4LN85S1YzhDf9rTHJQ=
 github.com/deckarep/golang-set v1.7.1/go.mod h1:93vsz/8Wt4joVM7c2AVqh+YRMiUSc14yDtF28KmMOgQ=
+github.com/denisenkom/go-mssqldb v0.0.0-20191124224453-732737034ffd/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
@@ -85,6 +88,7 @@ github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5Xh
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5/go.mod h1:a2zkGnVExMxdzMo3M0Hi/3sEU+cWnZpSni0O6/Yb/P0=
 github.com/evalphobia/logrus_sentry v0.8.2 h1:dotxHq+YLZsT1Bb45bB5UQbfCh3gM/nFFetyN46VoDQ=
 github.com/evalphobia/logrus_sentry v0.8.2/go.mod h1:pKcp+vriitUqu9KiWj/VRFbRfFNUwz95/UkgG8a6MNc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
@@ -134,11 +138,13 @@ github.com/go-playground/universal-translator v0.17.0 h1:icxd5fm+REJzpZx7ZfpaD87
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
 github.com/go-playground/validator/v10 v10.2.0 h1:KgJ0snyC2R9VXYN2rneOtQcw5aHQB1Vv0sFl1UcHBOY=
 github.com/go-playground/validator/v10 v10.2.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GOhaH6EGOAJShg8Id5JGkI=
+github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gofrs/uuid v3.2.0+incompatible h1:y12jRkkFxsd7GpqdSZ+/KCs/fJbqpEXSGd4+jfEaewE=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
+github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
@@ -250,8 +256,11 @@ github.com/jackc/puddle v1.1.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dv
 github.com/jackc/puddle v1.1.1/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/jinzhu/gorm v1.9.16 h1:+IyIjPEABKRpsu/F8OvDPy9fyQlgsg2luMV2ZIH5i5o=
+github.com/jinzhu/gorm v1.9.16/go.mod h1:G3LB3wezTOWM2ITLzPxEXgSkOXAntiLHS7UdBefADcs=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
+github.com/jinzhu/now v1.0.1/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/jinzhu/now v1.1.1 h1:g39TucaRWyV3dwDO++eEc6qf8TVIQ/Da48WmqjZ3i7E=
 github.com/jinzhu/now v1.1.1/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
@@ -283,6 +292,7 @@ github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.1.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
+github.com/lib/pq v1.1.1/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.3.0 h1:/qkRGz8zljWiDcFvgpwUpwIAPu3r07TDvs3Rws+o/pU=
 github.com/lib/pq v1.3.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
@@ -310,6 +320,7 @@ github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2yME+cCiQ=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/mattn/go-sqlite3 v1.14.0/go.mod h1:JIl7NbARA7phWnGvh0LKTyg7S9BA+6gx71ShQilpsus=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
@@ -474,12 +485,14 @@ golang.org/x/crypto v0.0.0-20170930174604-9419663f5a44/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190411191339-88737f569e3a/go.mod h1:WFFai1msRO1wXaEeE5yQxYXgSfI8pQAWXbQop6sCtWE=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20191205180655-e7c4368fe9dd/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200115085410-6d4e4cb37c7d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -506,6 +519,7 @@ golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKG
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/mod v0.3.0 h1:RM4zey1++hCTbCVQfnWeKs9/IEsaBLA8vTkd0WVtmH4=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -525,6 +539,8 @@ golang.org/x/net v0.0.0-20190611141213-3f473d35a33a/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201216054612-986b41b23924/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
@@ -564,6 +580,7 @@ golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/go.sum
+++ b/go.sum
@@ -200,8 +200,7 @@ github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2p
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/itchyny/timefmt-go v0.1.1 h1:rLpnm9xxb39PEEVzO0n4IRp0q6/RmBc7Dy/rE4HrA0U=
-github.com/itchyny/timefmt-go v0.1.1/go.mod h1:0osSSCQSASBJMsIZnhAaF1C2fCBTJZXrnj37mG8/c+A=
+github.com/itchyny/timefmt-go v0.1.2 h1:q0Xa4P5it6K6D7ISsbLAMwx1PnWlixDcJL6/sFs93Hs=
 github.com/itchyny/timefmt-go v0.1.2/go.mod h1:0osSSCQSASBJMsIZnhAaF1C2fCBTJZXrnj37mG8/c+A=
 github.com/jackc/chunkreader v1.0.0 h1:4s39bBR8ByfqH+DKm8rQA3E1LHZWB9XWcrz8fqaZbe0=
 github.com/jackc/chunkreader v1.0.0/go.mod h1:RT6O25fNZIuasFJRyZ4R/Y2BbhasbmZXF9QQ7T3kePo=

--- a/pkg/blockatlas/platform.go
+++ b/pkg/blockatlas/platform.go
@@ -22,7 +22,7 @@ type (
 	// TransactionAPI provides indexed transactions from database
 	TransactionsAPI interface {
 		Platform
-		GetTransactionsByAccount(account, token string, database *db.Instance) (types.TxPage, error)
+		GetTransactionsByAccount(account, token string, limit int, database *db.Instance) (types.TxPage, error)
 	}
 
 	// TxAPI provides transaction lookups based on address

--- a/pkg/blockatlas/platform.go
+++ b/pkg/blockatlas/platform.go
@@ -1,6 +1,7 @@
 package blockatlas
 
 import (
+	"github.com/trustwallet/blockatlas/db"
 	"github.com/trustwallet/golibs/coin"
 	"github.com/trustwallet/golibs/types"
 )
@@ -16,6 +17,12 @@ type (
 		Platform
 		CurrentBlockNumber() (int64, error)
 		GetBlockByNumber(num int64) (*types.Block, error)
+	}
+
+	// TransactionAPI provides indexed transactions from database
+	TransactionsAPI interface {
+		Platform
+		GetTransactionsByAccount(account, token string, database *db.Instance) (types.TxPage, error)
 	}
 
 	// TxAPI provides transaction lookups based on address

--- a/pkg/blockatlas/platform.go
+++ b/pkg/blockatlas/platform.go
@@ -22,7 +22,7 @@ type (
 	// TransactionAPI provides indexed transactions from database
 	TransactionsAPI interface {
 		Platform
-		GetTransactionsByAccount(account, token string, limit int, database *db.Instance) (types.TxPage, error)
+		GetTransactionsByAccount(account, token string, limit int, database *db.Instance) (types.Txs, error)
 	}
 
 	// TxAPI provides transaction lookups based on address

--- a/platform/near/base.go
+++ b/platform/near/base.go
@@ -11,9 +11,7 @@ type Platform struct {
 }
 
 func Init(api string) *Platform {
-	p := &Platform{
-		client: Client{client.InitClient(api, middleware.SentryErrorHandler)},
-	}
+	p := &Platform{client: Client{client.InitJSONClient(api, middleware.SentryErrorHandler)}}
 	return p
 }
 

--- a/platform/near/block.go
+++ b/platform/near/block.go
@@ -1,6 +1,13 @@
 package near
 
-import "github.com/trustwallet/golibs/types"
+import (
+	"github.com/trustwallet/golibs/client"
+	"github.com/trustwallet/golibs/types"
+)
+
+const (
+	errorMissingBlock = -32000
+)
 
 func (p *Platform) CurrentBlockNumber() (int64, error) {
 	return p.client.GetLasteBlock()
@@ -9,6 +16,11 @@ func (p *Platform) CurrentBlockNumber() (int64, error) {
 func (p *Platform) GetBlockByNumber(num int64) (*types.Block, error) {
 	chunk, err := p.client.GetTxsInBlock(num)
 	if err != nil {
+		// near won't return old blocks
+		rpcError, ok := err.(*client.RpcError)
+		if ok && rpcError.Code == errorMissingBlock {
+			return &types.Block{Number: num, Txs: []types.Tx{}}, nil
+		}
 		return nil, err
 	}
 	normalized := NormalizeChunk(chunk)

--- a/platform/near/block.go
+++ b/platform/near/block.go
@@ -1,16 +1,16 @@
-package ripple
+package near
 
 import "github.com/trustwallet/golibs/types"
 
 func (p *Platform) CurrentBlockNumber() (int64, error) {
-	return p.client.GetCurrentBlock()
+	return p.client.GetLasteBlock()
 }
 
 func (p *Platform) GetBlockByNumber(num int64) (*types.Block, error) {
-	srcBlock, err := p.client.GetBlockByNumber(num)
+	chunk, err := p.client.GetTxsInBlock(num)
 	if err != nil {
 		return nil, err
 	}
-	txs := NormalizeTxs(srcBlock)
-	return &types.Block{Number: num, Txs: txs}, nil
+	normalized := NormalizeChunk(chunk)
+	return &types.Block{Number: num, Txs: normalized}, nil
 }

--- a/platform/near/client.go
+++ b/platform/near/client.go
@@ -5,3 +5,28 @@ import "github.com/trustwallet/golibs/client"
 type Client struct {
 	client.Request
 }
+
+func (c *Client) GetLasteBlock() (int64, error) {
+	var block Block
+	err := c.RpcCall(&block, "block", map[string]string{"finality": "final"})
+	if err != nil {
+		return 0, err
+	}
+	return int64(block.Header.Height), nil
+}
+
+func (c *Client) GetTxsInBlock(num int64) (result ChunkDetail, err error) {
+	var block Block
+	err = c.RpcCall(&block, "block", map[string]int64{"block_id": num})
+	if err != nil || len(block.Chunks) == 0 {
+		return
+	}
+
+	var chunk ChunkDetail
+	err = c.RpcCall(&chunk, "chunk", []string{block.Chunks[0].Hash})
+	if err != nil {
+		return
+	}
+	chunk.Header.Timestamp = block.Header.Timestamp
+	return chunk, nil
+}

--- a/platform/near/mocks/chunk_call.json
+++ b/platform/near/mocks/chunk_call.json
@@ -1,0 +1,44 @@
+{
+  "author": "dokiacapital.poolv1.near",
+  "header": {
+    "chunk_hash": "EBPzsMhnv7aiup59ixWJe55FDVhPV8qfTmJJYUrtLxDa",
+    "prev_block_hash": "FSDWQfYySuRbW7tRX1QKtphj3jZ6q8wGPyLCNzb6xiDd",
+    "outcome_root": "11111111111111111111111111111111",
+    "prev_state_root": "HNDta5RswH82MR6bvmNPqsnwyam86acfHFGrcuUd8EBt",
+    "encoded_merkle_root": "5JpgyZ7LzUDT587zKQmy38hUN7oAtebCate9zBvDqHK6",
+    "encoded_length": 250,
+    "height_created": 29444831,
+    "height_included": 29444831,
+    "shard_id": 0,
+    "gas_used": 0,
+    "gas_limit": 1000000000000000,
+    "rent_paid": "0",
+    "validator_reward": "0",
+    "balance_burnt": "0",
+    "outgoing_receipts_root": "H4Rd6SGeEBTbxkitsCdzfu9xL9HtZ2eHoPCQXUeZ6bW4",
+    "tx_root": "7fCahUJFbLB3oZECFBdL39KUmZak7WGf2ruwSGCCFMMG",
+    "validator_proposals": [],
+    "signature": "ed25519:E4EFQW7tMQAtVRLywh4jtJhu7Lcz8QzK8BNXydFnubzPiN8SDLbrjLYoy3jfceH6qjHvWebXgarLf2os79z6krE"
+  },
+  "transactions": [
+    {
+      "signer_id": "nfendowment07.near",
+      "public_key": "ed25519:CpwMLog6WH4Mb6JpPfA1HCQzUT2Zn4g3i1MNxtuuDuMz",
+      "nonce": 5,
+      "receiver_id": "nfendowment07.near",
+      "actions": [
+        {
+          "FunctionCall": {
+            "method_name": "confirm",
+            "args": "eyJyZXF1ZXN0X2lkIjoxfQ==",
+            "gas": 300000000000000,
+            "deposit": "0"
+          }
+        }
+      ],
+      "signature": "ed25519:2rXvVZgprAaTGcbqWzZVjirjMdqZQGtMbG4a2A3b4vtHf1NLkCSqPBbnqnkMosGuabCkPEEs8qPdKq5SBuzxS6dp",
+      "hash": "6Si15TYqgzp8f8ZVDTeM1KwxieaSNtcKk3h48AeCfP3G"
+    }
+  ],
+  "receipts": []
+}

--- a/platform/near/mocks/chunk_transfer.json
+++ b/platform/near/mocks/chunk_transfer.json
@@ -1,0 +1,41 @@
+{
+  "author": "astro-stakers.poolv1.near",
+  "header": {
+    "chunk_hash": "EjxdYT6gZA2JcN3GeEwPF8QDswsd6EsqZzb2goeBrmrG",
+    "prev_block_hash": "AqL3U3cm3ZFnbx7V1Mc9pUPedb71gFaRvUbZnGBDrUfp",
+    "outcome_root": "7UYmU3Hqf62fEZDae2LqYHFSYPTKUTECDJStGogZndJW",
+    "prev_state_root": "6Lzwt9WUB2uN7vF9Q2nrxKrYZ1PywZ44HQ8oPCTRVdnz",
+    "encoded_merkle_root": "4Z2dR24o4htn5pHvy4SZ3vugFWMHUYbNjEPR4YkFUsWF",
+    "encoded_length": 249,
+    "height_created": 29445373,
+    "height_included": 29445373,
+    "shard_id": 0,
+    "gas_used": 0,
+    "gas_limit": 1000000000000000,
+    "rent_paid": "0",
+    "validator_reward": "0",
+    "balance_burnt": "0",
+    "outgoing_receipts_root": "H4Rd6SGeEBTbxkitsCdzfu9xL9HtZ2eHoPCQXUeZ6bW4",
+    "tx_root": "CArPD4gKoyGffCiAGQcUa5wtdfXV3Yzt22zREqcVckrQ",
+    "validator_proposals": [],
+    "signature": "ed25519:2thkwQHAWRGxwMg3kK22Wwz5jcYkMvAoixWiUL3VFtrZVaL2mfpSWkmVaMPREuGZt2bUuEVJXSNhc3Qk6aHRSWfp"
+  },
+  "transactions": [
+    {
+      "signer_id": "a7e956ffba0f7a1905445d107de74e32e8e84b31c6171caae381e6a1613e1b50",
+      "public_key": "ed25519:CJTTF5zLoTPmybiaTFnT53ymLbBHQzx2zS4o78rXz7rw",
+      "nonce": 8,
+      "receiver_id": "hewig.near",
+      "actions": [
+        {
+          "Transfer": {
+            "deposit": "100000000000000000000000"
+          }
+        }
+      ],
+      "signature": "ed25519:67eDadqqf1mnBcgswcaCq4j2dpunm1UrEe31jQ1JfMSHAaw8oQBV8uyQb9E5tsMTpHvshAtVUDSV6ErbmZ6EQMas",
+      "hash": "HnFPnVX9xpF8AGmkDqV7iNPfMN14pifmgTRjvkLuCmoM"
+    }
+  ],
+  "receipts": []
+}

--- a/platform/near/model.go
+++ b/platform/near/model.go
@@ -1,0 +1,45 @@
+package near
+
+type Block struct {
+	Header BlockHeader `json:"header"`
+	Chunks []Chunk     `json:"chunks"`
+}
+
+type BlockHeader struct {
+	Height    uint64 `json:"height"`
+	Timestamp uint64 `json:"timestamp"`
+}
+
+type Chunk struct {
+	Hash      string `json:"chunk_hash"`
+	Height    uint64 `json:"height_created"`
+	Timestamp uint64
+}
+
+type ChunkDetail struct {
+	Header       Chunk `json:"header"`
+	Transactions []Tx  `json:"transactions,omitempty"`
+}
+
+type Tx struct {
+	SignerID   string        `json:"signer_id"`
+	Nonce      int           `json:"nonce"`
+	ReceiverID string        `json:"receiver_id"`
+	Actions    []interface{} `json:"actions"`
+	Hash       string        `json:"hash"`
+}
+
+type TransferAction struct {
+	Transfer Transfer `json:"Transfer"`
+}
+
+type Transfer struct {
+	Deposit string `json:"deposit"`
+}
+
+type FunctionCall struct {
+	MethodName string `json:"method_name"`
+	Args       string `json:"args"`
+	Gas        int64  `json:"gas"`
+	Deposit    string `json:"deposit"`
+}

--- a/platform/near/transaction.go
+++ b/platform/near/transaction.go
@@ -41,7 +41,7 @@ func NormalizeChunk(chunk ChunkDetail) types.Txs {
 			From:     tx.SignerID,
 			To:       tx.ReceiverID,
 			Fee:      "0",
-			Date:     int64(chunk.Header.Timestamp),
+			Date:     int64(chunk.Header.Timestamp / 1000),
 			Block:    chunk.Header.Height,
 			Status:   types.StatusCompleted,
 			Sequence: uint64(tx.Nonce),

--- a/platform/near/transaction.go
+++ b/platform/near/transaction.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 
+	"github.com/trustwallet/blockatlas/db"
+	"github.com/trustwallet/blockatlas/db/models"
 	"github.com/trustwallet/golibs/coin"
 	"github.com/trustwallet/golibs/types"
 )
@@ -11,6 +13,14 @@ import (
 func (p *Platform) GetTxsByAddress(address string) (types.Txs, error) {
 	normalized := make(types.Txs, 0)
 	return normalized, nil
+}
+
+func (p *Platform) GetTransactionsByAccount(account, token string, limit int, database *db.Instance) (page types.Txs, err error) {
+	txs, err := database.GetTransactionsByAccount(account, p.Coin().ID, limit)
+	if err != nil {
+		return
+	}
+	return models.ToTxs(txs)
 }
 
 func NormalizeChunk(chunk ChunkDetail) types.Txs {

--- a/platform/near/transaction.go
+++ b/platform/near/transaction.go
@@ -1,8 +1,64 @@
 package near
 
-import "github.com/trustwallet/golibs/types"
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/trustwallet/golibs/coin"
+	"github.com/trustwallet/golibs/types"
+)
 
 func (p *Platform) GetTxsByAddress(address string) (types.Txs, error) {
 	normalized := make(types.Txs, 0)
 	return normalized, nil
+}
+
+func NormalizeChunk(chunk ChunkDetail) types.Txs {
+	normalized := make(types.Txs, 0)
+	for _, tx := range chunk.Transactions {
+		if len(tx.Actions) != 1 {
+			continue
+		}
+
+		transfer, err := mapTransfer(tx.Actions[0])
+		if err != nil {
+			continue
+		}
+
+		normalized = append(normalized, types.Tx{
+			ID:       tx.Hash,
+			Coin:     coin.NEAR,
+			From:     tx.SignerID,
+			To:       tx.ReceiverID,
+			Fee:      "0",
+			Date:     int64(chunk.Header.Timestamp),
+			Block:    chunk.Header.Height,
+			Status:   types.StatusCompleted,
+			Sequence: uint64(tx.Nonce),
+			Type:     types.TxTransfer,
+			Meta: types.Transfer{
+				Value:    types.Amount(transfer.Transfer.Deposit),
+				Symbol:   coin.Near().Name,
+				Decimals: coin.Near().Decimals,
+			},
+		})
+	}
+
+	return normalized
+}
+
+func mapTransfer(i interface{}) (action TransferAction, err error) {
+	bytes, err := json.Marshal(i)
+	if err != nil {
+		return
+	}
+	err = json.Unmarshal(bytes, &action)
+	if err != nil {
+		return
+	}
+
+	if action.Transfer.Deposit == "" {
+		err = errors.New("unable marshalling to transfer actoin struct")
+	}
+	return
 }

--- a/platform/near/transaction_test.go
+++ b/platform/near/transaction_test.go
@@ -1,0 +1,58 @@
+package near
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/trustwallet/golibs/coin"
+	"github.com/trustwallet/golibs/mock"
+	"github.com/trustwallet/golibs/types"
+)
+
+func TestNormalizeChunk(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		want     types.Txs
+	}{
+		{
+			name:     "Test normalize transfer",
+			filename: "mocks/chunk_transfer.json",
+			want: types.Txs{
+				types.Tx{
+					ID:       "HnFPnVX9xpF8AGmkDqV7iNPfMN14pifmgTRjvkLuCmoM",
+					Coin:     coin.NEAR,
+					From:     "a7e956ffba0f7a1905445d107de74e32e8e84b31c6171caae381e6a1613e1b50",
+					To:       "hewig.near",
+					Fee:      "0",
+					Date:     0,
+					Block:    29445373,
+					Status:   types.StatusCompleted,
+					Sequence: 8,
+					Type:     types.TxTransfer,
+					Meta: types.Transfer{
+						Value:    "100000000000000000000000",
+						Symbol:   coin.Near().Name,
+						Decimals: coin.Near().Decimals,
+					},
+				}},
+		},
+		{
+			name:     "Test normalize funcation call",
+			filename: "mocks/chunk_call.json",
+			want:     types.Txs{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var chunk ChunkDetail
+			err := mock.JsonModelFromFilePath(tt.filename, &chunk)
+			assert.NoError(t, err)
+			if got := NormalizeChunk(chunk); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NormalizeChunk() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/platform/ripple/transaction_v2.go
+++ b/platform/ripple/transaction_v2.go
@@ -6,10 +6,10 @@ import (
 	"github.com/trustwallet/golibs/types"
 )
 
-func (p *Platform) GetTransactionsByAccount(account, token string, limit int, database *db.Instance) (page types.TxPage, err error) {
+func (p *Platform) GetTransactionsByAccount(account, token string, limit int, database *db.Instance) (page types.Txs, err error) {
 	txs, err := database.GetTransactionsByAccount(account, p.Coin().ID, limit)
 	if err != nil {
 		return
 	}
-	return models.ToTxPage(txs)
+	return models.ToTxs(txs)
 }

--- a/platform/ripple/transaction_v2.go
+++ b/platform/ripple/transaction_v2.go
@@ -6,8 +6,8 @@ import (
 	"github.com/trustwallet/golibs/types"
 )
 
-func (p *Platform) GetTransactionsByAccount(account, token string, database *db.Instance) (page types.TxPage, err error) {
-	txs, err := database.GetTransactionsByAccount(account, p.Coin().ID)
+func (p *Platform) GetTransactionsByAccount(account, token string, limit int, database *db.Instance) (page types.TxPage, err error) {
+	txs, err := database.GetTransactionsByAccount(account, p.Coin().ID, limit)
 	if err != nil {
 		return
 	}

--- a/platform/ripple/transaction_v2.go
+++ b/platform/ripple/transaction_v2.go
@@ -1,0 +1,15 @@
+package ripple
+
+import (
+	"github.com/trustwallet/blockatlas/db"
+	"github.com/trustwallet/blockatlas/db/models"
+	"github.com/trustwallet/golibs/types"
+)
+
+func (p *Platform) GetTransactionsByAccount(account, token string, database *db.Instance) (page types.TxPage, err error) {
+	txs, err := database.GetTransactionsByAccount(account, p.Coin().ID)
+	if err != nil {
+		return
+	}
+	return models.ToTxPage(txs)
+}

--- a/services/tokenindexer/indexer.go
+++ b/services/tokenindexer/indexer.go
@@ -1,17 +1,13 @@
 package tokenindexer
 
 import (
-	"encoding/json"
 	"strconv"
-	"time"
 
-	"github.com/jinzhu/gorm/dialects/postgres"
 	log "github.com/sirupsen/logrus"
 	"github.com/streadway/amqp"
 	"github.com/trustwallet/blockatlas/db"
 	"github.com/trustwallet/blockatlas/db/models"
 	"github.com/trustwallet/blockatlas/services/notifier"
-	"github.com/trustwallet/golibs/asset"
 	"github.com/trustwallet/golibs/types"
 )
 
@@ -54,7 +50,10 @@ func RunTokenIndexer(database *db.Instance, delivery amqp.Delivery) error {
 		return err
 	}
 
-	txs := transactionsFrom(transactions)
+	txs, err := models.NormalizeTransactions(transactions)
+	if err != nil {
+		return err
+	}
 	// Add txs to db
 	return CreateTransactions(database, txs)
 }
@@ -156,34 +155,4 @@ func CreateTransactions(database *db.Instance, txs []models.Transaction) error {
 		return nil
 	}
 	return database.CreateTransactions(txs)
-}
-
-func transactionsFrom(txs []types.Tx) []models.Transaction {
-	results := make([]models.Transaction, 0)
-	for _, tx := range txs {
-		metadata, err := json.Marshal(tx.Meta)
-		if err != nil {
-			// log this error
-			continue
-		}
-		assetId := asset.BuildID(tx.Coin, "")
-		model := models.Transaction{
-			ID:         tx.ID,
-			Coin:       tx.Coin,
-			From:       tx.From,
-			To:         tx.To,
-			AssetID:    assetId,
-			Fee:        string(tx.Fee),
-			FeeAssetID: assetId,
-			Block:      tx.Block,
-			Sequence:   tx.Sequence,
-			Status:     string(tx.Status),
-			Memo:       tx.Memo,
-			Metadata:   postgres.Jsonb{RawMessage: metadata},
-			Date:       time.Unix(tx.Date, 0),
-			Type:       string(tx.Type),
-		}
-		results = append(results, model)
-	}
-	return results
 }


### PR DESCRIPTION
Fixes #1402 and fixes #1409

Changes: 

1. Save v2 compatible transfer, token transfer txs to db
2. Add new endpoint to fetch txs by account
3. Near block parsing