### PR TITLE
Fix Cosmos Validator status

### DIFF
--- a/platform/cosmos/mocks/validator.json
+++ b/platform/cosmos/mocks/validator.json
@@ -1,25 +1,26 @@
 {
   "operator_address": "cosmosvaloper1lktjhnzkpkz3ehrg8psvmwhafg56kfss3q3t8m",
-  "consensus_pubkey": "cosmosvalconspub1zcjduepqelcwpat987h9yq0ck6g9fsc8t0mththk547gwvk0w4wnkpl0stnspr3hdc",
-  "jailed": false,
-  "status": 2,
-  "tokens": "1557750969185",
-  "delegator_shares": "1557750969185.000000000000000000",
+  "consensus_pubkey": {
+    "type": "tendermint/PubKeyEd25519",
+    "value": "z/Dg9WU/rlIB+LaQVMMHW/a7rvalfIcyz3VdOwfvguc="
+  },
+  "status": 3,
+  "tokens": "597103578752",
+  "delegator_shares": "597103578752.000000000000000000",
   "description": {
     "moniker": "Umbrella ☔",
     "identity": "A530AC4D75991FE2",
     "website": "https://umbrellavalidator.com",
     "details": "One of the winners of Cosmos Game of Stakes, and HackAtom3."
   },
-  "unbonding_height": "0",
   "unbonding_time": "1970-01-01T00:00:00Z",
   "commission": {
     "commission_rates": {
       "rate": "0.070400000000000000",
       "max_rate": "1.000000000000000000",
-      "max_change_rate": "0.100000000000000000",
-      "update_time": "2019-08-05T07:10:23.689753607Z"
-    }
+      "max_change_rate": "0.100000000000000000"
+    },
+    "update_time": "2020-09-01T18:40:38.071399488Z"
   },
   "min_self_delegation": "1"
 }

--- a/platform/cosmos/stake.go
+++ b/platform/cosmos/stake.go
@@ -154,7 +154,7 @@ func NormalizeUnbondingDelegations(delegations []UnbondingDelegation, validators
 func normalizeValidator(v Validator, p Pool, inflation float64) (validator blockatlas.Validator) {
 	reward := CalculateAnnualReward(p, inflation, v)
 	return blockatlas.Validator{
-		Status: v.Status == 2,
+		Status: v.Status == 3,
 		ID:     v.Address,
 		Details: blockatlas.StakingDetails{
 			Reward:        blockatlas.StakingReward{Annual: reward},


### PR DESCRIPTION
Fixes #1437
What changed:
- Cosmos Bonded status now is 3
Doc reference:
https://docs.cosmos.network/v0.41/core/proto-docs.html#bondstatus